### PR TITLE
fixing bug in reading input mode

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -26,6 +26,7 @@ class SchemaPack {
     this.validationResult = null;
     this.valid = null;
     this.wsdlObject = {};
+
   }
 
   /**
@@ -33,7 +34,9 @@ class SchemaPack {
    * @returns {object} A validation object with format {result: <boolean>, reason: <string>}
    */
   validate() {
-    this.validationResult = new Validator().validate(this.input);
+    let result = new Validator().validate(this.input);
+    this.validationResult = result.valResult;
+    this.input.data = result.xml;
     return this.validationResult;
   }
 
@@ -43,6 +46,8 @@ class SchemaPack {
    * @returns {function} A callback execution
    */
   convert(callback) {
+    this.validate();
+
     const parser = new ParserFactory().getParser(this.input.data);
     let postmanCollection,
       mapper,

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -10,14 +10,18 @@ const WSDL_11_VALIDATOR = 'definitions>',
 class Validator {
   /**
    * generates a valid result object.
+   * @param {string} xml xml content in string representation
    * @param {boolean} result true when input is valid and viceversa
    * @param {string} reason Return the reason of the result
    * @returns {object} A valid Result object with format {result: <boolean>, reason: <string>}
    */
-  result(result, reason = null) {
+  result(xml, result, reason = null) {
     return {
-      result,
-      reason
+      xml,
+      valResult: {
+        result,
+        reason
+      }
     };
   }
 
@@ -31,21 +35,21 @@ class Validator {
   validate(input) {
     let xml;
     if (this.inputNotProvided(input.data)) {
-      return this.result(false, 'Input not provided');
+      return this.result(undefined, false, 'Input not provided');
     }
 
     try {
       xml = readInput(input);
     }
     catch (inputError) {
-      return this.result(false, inputError.message);
+      return this.result(undefined, false, inputError.message);
     }
 
     if (this.notContainsWsdlSpec(xml)) {
-      return this.result(false, 'Not WSDL Specification found in your document');
+      return this.result(undefined, false, 'Not WSDL Specification found in your document');
     }
 
-    return this.result(true, 'Success');
+    return this.result(xml, true, 'Success');
   }
 
   /**

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -27,6 +27,24 @@ describe('SchemaPack convert unit test WSDL 1.1', function() {
       });
     });
   });
+
+  it('Should get an object representing PM Collection from a file sending the path', function() {
+    const
+      VALID_WSDL_PATH = validWSDLs + '/calculator-soap11and12.wsdl',
+      schemaPack = new SchemaPack({
+        type: 'file',
+        data: VALID_WSDL_PATH
+      }, {});
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output).to.be.an('array');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].type).to.equal('collection');
+      expect(result.output[0].data).to.be.an('object');
+    });
+  });
 });
 
 describe('SchemaPack convert unit test WSDL 1.1 with options', function() {

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -7,7 +7,7 @@ describe('Validator result', function() {
   it('Should return a validatorResult format', function() {
     const validatorResult = new Validator().result(true, 'Some reason');
     expect(validatorResult).to.be.an('object')
-      .that.have.all.keys('result', 'reason');
+      .that.have.all.keys('xml', 'valResult');
   });
 });
 
@@ -19,13 +19,13 @@ describe('Validator inputNotProvided', function() {
     expect(validator.inputNotProvided(nullInput)).to.be.true;
   });
 
-  it('Should return true if input is undefined', function () {
+  it('Should return true if input is undefined', function() {
     const undefinedInput = undefined,
       validator = new Validator();
     expect(validator.inputNotProvided(undefinedInput)).to.be.true;
   });
 
-  it('Should return true if input is empty', function () {
+  it('Should return true if input is empty', function() {
     const emptyInput = '',
       validator = new Validator();
     expect(validator.inputNotProvided(emptyInput)).to.be.true;
@@ -65,7 +65,7 @@ describe('Validator validate', function() {
   it('Should return a failed validationResult when input.data is null', function() {
     const nullInput = mockInput(null),
       validator = new Validator();
-    expect(validator.validate(nullInput)).to.be.an('object')
+    expect(validator.validate(nullInput).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Input not provided'
@@ -75,7 +75,7 @@ describe('Validator validate', function() {
   it('Should return a failed validationResult when input.data is undefined', function() {
     const undefinedInput = mockInput(undefined),
       validator = new Validator();
-    expect(validator.validate(undefinedInput)).to.be.an('object')
+    expect(validator.validate(undefinedInput).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Input not provided'
@@ -85,7 +85,7 @@ describe('Validator validate', function() {
   it('Should return a failed validationResult when input.data is empty', function() {
     const emptyInput = mockInput(''),
       validator = new Validator();
-    expect(validator.validate(emptyInput)).to.be.an('object')
+    expect(validator.validate(emptyInput).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Input not provided'
@@ -96,7 +96,7 @@ describe('Validator validate', function() {
 string`, function() {
     const input = mockInput('Does not contains WSDL validation', 'string'),
       validator = new Validator();
-    expect(validator.validate(input)).to.be.an('object')
+    expect(validator.validate(input).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Not WSDL Specification found in your document'
@@ -106,7 +106,7 @@ string`, function() {
   it('Should return a failed validationResult if input type is not supported', function() {
     const input = mockInput('Any type data', 'NotSupportedType'),
       validator = new Validator();
-    expect(validator.validate(input)).to.be.an('object')
+    expect(validator.validate(input).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: `Invalid input type (${input.type}). Type must be file/string.`
@@ -117,7 +117,7 @@ string`, function() {
     function() {
       const definitionsInput = mockInput('<definitions ...> ... </ definitions>', 'string'),
         validator = new Validator();
-      expect(validator.validate(definitionsInput)).to.be.an('object')
+      expect(validator.validate(definitionsInput).valResult).to.be.an('object')
         .and.to.include({
           result: true,
           reason: 'Success'
@@ -128,7 +128,7 @@ string`, function() {
     function() {
       const descriptionInput = mockInput('<description ...> ... </ description>', 'string'),
         validator = new Validator();
-      expect(validator.validate(descriptionInput)).to.be.an('object')
+      expect(validator.validate(descriptionInput).valResult).to.be.an('object')
         .and.to.include({
           result: true,
           reason: 'Success'


### PR DESCRIPTION
Bug fixing.

There is a bug when the path to a file is sent instead of the content.

Cause:

the input was not read when call directly convert, assumes that the validation does the reading

Solution:

Added the xml content to the validation method result
call the validation method from the convert method

Added unit test to fulfill this escenario