### PR TITLE
Adding validateContentType option to options, integrating validateCon…

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -113,7 +113,7 @@ class SchemaPack {
       wsdlObject = parser.getWsdlObject(this.input.data);
     let result;
     try {
-      result = transactionValidator.validateTransaction(transactions, wsdlObject);
+      result = transactionValidator.validateTransaction(transactions, wsdlObject, this.options);
       callback(null, result);
     }
     catch (error) {

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -33,9 +33,10 @@ class TransactionValidator {
    *
    * @param {*} items RequestList
    * @param {*} wsdlObject WSDLObject from wsdl file
+   * @param {object} options contains options to modify validation
    * @returns {object} validation results
    */
-  validateTransaction(items, wsdlObject) {
+  validateTransaction(items, wsdlObject, options = {}) {
     let result = {
       matched: true,
       requests: {}
@@ -46,7 +47,7 @@ class TransactionValidator {
     }
     this.validateStructure(items);
     this.validateRequiredFields(items);
-    result = this.validateItems(items, wsdlObject);
+    result = this.validateItems(items, wsdlObject, options);
     return result;
   }
 
@@ -56,14 +57,20 @@ class TransactionValidator {
    *
    * @param {*} items RequestList
    * @param {*} wsdlObject WSDLObject from wsdl file
+   * @param {object} options contains options to modify validation
    * @param {*} result result for shallow copy
    * @returns {object} validation results
    */
-  validateItems(items, wsdlObject) {
+  validateItems(items, wsdlObject, options) {
     let processedInfoItems = [],
       endpointMatched = true,
       requests = {},
-      validationResult = {};
+      validationResult = {},
+      {
+        validateContentType
+      } = options,
+      validateHeadersDefault = false,
+      validateHeadersOption = validateContentType ? true : validateHeadersDefault;
 
     items.forEach((requestItem) => {
       const requestBody = requestItem.request.body.raw;
@@ -84,7 +91,12 @@ class TransactionValidator {
 
       if (operationFromWSDL) {
         const { protocol, method, name } = operationFromWSDL,
-          headerMismatches = this.validateHeaders(requestItem.request.header, requestItem.id, false),
+          headerMismatches = this.validateHeaders(
+            requestItem.request.header,
+            requestItem.id,
+            validateHeadersOption,
+            false
+          ),
           requestBodyMismatches = this.validateBody(
             unwrapAndCleanBody(requestBody, protocol),
             wsdlObject,
@@ -93,7 +105,7 @@ class TransactionValidator {
           ),
           endpointMismatches = [...headerMismatches, ...requestBodyMismatches],
           { responses, responsesMatched } = this.getResponsesValidation(requestItem.response, protocol, wsdlObject,
-            operationFromWSDL);
+            operationFromWSDL, validateHeadersOption);
 
         endpoints = [
           this.getEndpointResult(endpointMismatches, `${method} ${protocol} ${name}`, responses)
@@ -148,17 +160,18 @@ class TransactionValidator {
    * @param {string} protocol The request protocol
    * @param {Object} wsdlObject The wsdlObject generated from wsdl document
    * @param {Object} operationFromWSDL The wsdlObject operation's
+   * @param {boolean} validateHeadersOption if validateContentType option value, False by default
    * @returns {Object} {responses, responsesMatched} responses contains the list of validated responses
    *                    responsesMatched is false if any response failed
    */
-  getResponsesValidation(responseItem, protocol, wsdlObject, operationFromWSDL) {
+  getResponsesValidation(responseItem, protocol, wsdlObject, operationFromWSDL, validateHeadersOption) {
     let responses = {},
       responsesMatched = true;
     responseItem.forEach((response) => {
       const body = unwrapAndCleanBody(response.body, protocol),
         header = response.header,
         id = response.id,
-        headerMismatches = this.validateHeaders(header, id, true),
+        headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true),
         bodyMismatches = this.validateBody(body, wsdlObject, operationFromWSDL, true),
         mismatches = [...headerMismatches, ...bodyMismatches],
         matched = !mismatches.length > 0;
@@ -344,12 +357,16 @@ class TransactionValidator {
    * @description validates request or response headers
    * @param {object} requestHeaders headers list
    * @param {string} entityId request or response id
+   * @param {boolean} validateHeadersOption if validateContentType option value, False by default
    * @param {boolean} isResponse true if the entity is response false if not
    * @returns {Array} missmatchs array
    */
-  validateHeaders(requestHeaders, entityId, isResponse) {
+  validateHeaders(requestHeaders, entityId, validateHeadersOption, isResponse) {
     let missmatches = [],
+      contentTypeMissmatch;
+    if (validateHeadersOption) {
       contentTypeMissmatch = this.validateContentTypeHeader(requestHeaders, entityId, isResponse);
+    }
     if (contentTypeMissmatch) {
       missmatches.push(contentTypeMissmatch);
     }

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -25,16 +25,27 @@ function getOptions(mode = 'document', criteria = {}) {
     mode = 'document';
   }
 
-  let optsArray = [{
-    name: 'Folder organization',
-    id: 'folderStrategy',
-    type: 'enum',
-    default: 'Port/Endpoint',
-    availableOptions: ['No folders', 'Port/Endpoint', 'Service'],
-    description: 'Select whether to create folders according to the WSDL port/endpoing service or without folders',
-    external: true,
-    usage: ['CONVERSION']
-  }];
+  let optsArray = [
+    {
+      name: 'Folder organization',
+      id: 'folderStrategy',
+      type: 'enum',
+      default: 'Port/Endpoint',
+      availableOptions: ['No folders', 'Port/Endpoint', 'Service'],
+      description: 'Select whether to create folders according to the WSDL port/endpoing service or without folders',
+      external: true,
+      usage: ['CONVERSION']
+    },
+    {
+      name: 'Header validation',
+      id: 'validateHeader',
+      type: 'boolean',
+      default: false,
+      description: 'Select true to validate your collection requests/responses headers are correctly set',
+      external: true,
+      usage: ['VALIDATION']
+    }
+  ];
 
   if (criteria && typeof criteria === 'object') {
     if (Array.isArray(criteria.usage)) {

--- a/test/e2e/validateTransactions.test.js
+++ b/test/e2e/validateTransactions.test.js
@@ -39,8 +39,15 @@ describe('Test validate Transactions method in SchemaPack', function () {
     });
   });
 
-  it('Should validate when Header Content-Type was not found in the transaction', function() {
-    schemaPack.validateTransactions(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
+  it('Should validate when validateContentType option is true ' +
+    'and Header Content-Type was not found in the transaction', function() {
+    const options = {
+        validateContentType: true
+      },
+      schemaPackWithOptions = new SchemaPack({
+        type: 'string', data: fileContent
+      }, options);
+    schemaPackWithOptions.validateTransactions(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object').and.to.deep.include({
         matched: false,
@@ -126,8 +133,15 @@ describe('Test validate Transactions method in SchemaPack', function () {
     });
   });
 
-  it('Should validate when Header is other than text/xml', function() {
-    schemaPack.validateTransactions(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
+  it('Should validate when validateContentType option is true' +
+    ' and Header is other than text/xml', function() {
+    const options = {
+        validateContentType: true
+      },
+      schemaPackWithOptions = new SchemaPack({
+        type: 'string', data: fileContent
+      }, options);
+    schemaPackWithOptions.validateTransactions(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object').and.to.deep.include({
         matched: false,
@@ -205,6 +219,158 @@ describe('Test validate Transactions method in SchemaPack', function () {
                     reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we' +
                       ' found \"text/plain; charset=utf-8\" instead'
                   }]
+                }
+              }
+            }],
+            requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+          }
+        }
+      });
+    });
+  });
+
+  it('Should not validate header when validateContentType option is not provided (false by default) ' +
+    'and Header Content-Type was not found in the transaction', function() {
+    schemaPack.validateTransactions(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object').and.to.deep.include({
+        matched: true,
+        requests: {
+          '18403328-4213-4c3e-b0e9-b21a636697c3': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap12 NumberToDollars',
+              mismatches: [],
+              responses: {
+                '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                  id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+          },
+          '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap12 NumberToWords',
+              mismatches: [],
+              responses: {
+                'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                  id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+          },
+          '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap NumberToDollars',
+              mismatches: [],
+              responses: {
+                '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                  id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+          },
+          'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap NumberToWords',
+              mismatches: [],
+              responses: {
+                'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                  id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+          }
+        }
+      });
+    });
+  });
+
+  it('Should not validate header when validateContentType option is not provided (false by default) ' +
+    ' and Header is other than text/xml', function() {
+    schemaPack.validateTransactions(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object').and.to.deep.include({
+        matched: true,
+        requests: {
+          '18403328-4213-4c3e-b0e9-b21a636697c3': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap12 NumberToDollars',
+              mismatches: [],
+              responses: {
+                '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                  id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+          },
+          '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap12 NumberToWords',
+              mismatches: [],
+              responses: {
+                'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                  id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+          },
+          '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap NumberToDollars',
+              mismatches: [],
+              responses: {
+                '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                  id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+          },
+          'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap NumberToWords',
+              mismatches: [],
+              responses: {
+                'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                  id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                  matched: true,
+                  mismatches: []
                 }
               }
             }],

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -171,13 +171,13 @@ describe('SchemaPack getOptions', function () {
   it('Should return external options when called without parameters', function () {
     const options = SchemaPack.getOptions();
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(1);
+    expect(options.length).to.eq(2);
   });
 
   it('Should return external options when called with mode = document', function () {
     const options = SchemaPack.getOptions('document');
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(1);
+    expect(options.length).to.eq(2);
   });
 
   it('Should return external options when called with mode = use', function () {
@@ -200,7 +200,7 @@ describe('SchemaPack getOptions', function () {
       usage: ['VALIDATION']
     });
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(0);
+    expect(options.length).to.eq(1);
   });
 
   it('Should return external options when called with mode use and usage conversion', function () {
@@ -223,7 +223,7 @@ describe('SchemaPack getOptions', function () {
   it('Should return external options when called with mode document and usage not an object', function () {
     const options = SchemaPack.getOptions('document', 2);
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(1);
+    expect(options.length).to.eq(2);
   });
 
 });

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -340,10 +340,14 @@ describe('Validate method and url found item in wsdl and operation wsdl in colle
 });
 
 describe('Validate Headers', function () {
-  it('Should return missing header when not content-type header is present', function () {
-    const transactionValidator = new TransactionValidator(),
+  it('Should return missing header when validateContentType option is on true' +
+    ' and not content-type header is present', function () {
+    const options = {
+        validateContentType: true
+      },
+      transactionValidator = new TransactionValidator(),
       result = transactionValidator.validateTransaction(numberToWordsCollectionItemsNoCTHeader,
-        numberToWordsWSDLObject);
+        numberToWordsWSDLObject, options);
     expect(result).to.be.an('object').and.to.deep.include({
       matched: false,
       requests: {
@@ -427,10 +431,14 @@ describe('Validate Headers', function () {
     });
   });
 
-  it('Should return bad header when not content-type header is not text/xml', function () {
-    const transactionValidator = new TransactionValidator(),
+  it('Should return bad header mismatch when validateContentType option' +
+    ' is true and content-type header is not text/xml', function () {
+    const options = {
+        validateContentType: true
+      },
+      transactionValidator = new TransactionValidator(),
       result = transactionValidator.validateTransaction(numberToWordsCollectionItemsCTHeaderNXML,
-        numberToWordsWSDLObject);
+        numberToWordsWSDLObject, options);
     expect(result).to.be.an('object').and.to.deep.include({
       matched: false,
       requests: {
@@ -507,6 +515,317 @@ describe('Validate Headers', function () {
                   reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we' +
                     ' found \"text/plain; charset=utf-8\" instead'
                 }]
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+  it('Should not return missing header when validateContentType option is not provided' +
+    ' and not content-type header is present', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsNoCTHeader,
+        numberToWordsWSDLObject);
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+  it('Should not return bad header mismatch when validateContentType option' +
+    ' is not provided and content-type header is not text/xml', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsCTHeaderNXML,
+        numberToWordsWSDLObject);
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+
+  it('Should not return missing header when validateContentType option is set explicitly on false' +
+    ' and not content-type header is present', function () {
+    const options = {
+        validateContentType: false
+      },
+      transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsNoCTHeader,
+        numberToWordsWSDLObject, options);
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+  it('Should not return bad header mismatch when validateContentType option is set explicitly on false' +
+    ' and content-type header is not text/xml', function () {
+    const options = {
+        validateContentType: false
+      },
+      transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsCTHeaderNXML,
+        numberToWordsWSDLObject, options);
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
               }
             }
           }],

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -13,7 +13,7 @@ describe('Index getOptions', function () {
   it('Should return external options when called without parameters', function () {
     const options = getOptions();
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(1);
+    expect(options.length).to.eq(2);
   });
 });
 


### PR DESCRIPTION
This pr contains:
- adding validateContentType option to options.
- implement validateContentType option in TransactionValidator. (false as default value).
- implement options in validateTransactions function from SchemaPack.
- Fix current tests and adding new test scenarios in TransactionValidator (unit).
- Fix current tests and adding new test scenarios in validateTransactions (e2e).
- Fix getOptions tests.