### PR TITLE
Removing host from operations url filter, adding logs in validationRe…

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -5,7 +5,6 @@ const Ajv = require('ajv'),
     unwrapAndCleanBody
   } = require('./utils/messageWithSchemaValidation'),
   transactionSchema = require('./constants/transactionSchema'),
-  sdk = require('postman-collection'),
   { parseFromXmlToObject, getNamespaceByURL } = require('./WsdlParserCommon'),
   HEADER_PROPERTY = 'HEADER',
   ENDPOINT_PROPERTY = 'ENDPOINT',
@@ -85,7 +84,7 @@ class TransactionValidator {
       if (requestBody) {
         const parsedXmlMessage = this.parseBodyMessage(requestBody),
           processedInfo = this.getItemRequestProcessedInfo(requestItem.request, parsedXmlMessage);
-        operationFromWSDL = this.getOperationFromWSDLObjectByUrlNameProtocol(
+        operationFromWSDL = this.getOperationFromWSDLObjectByUrlPathNameProtocol(
           processedInfo,
           wsdlObject
         );
@@ -265,7 +264,7 @@ class TransactionValidator {
    * @param {*} wsdlObject WSDLObject from wsdl file
    * @returns {object} validation results
    */
-  getOperationFromWSDLObjectByUrlNameProtocol(
+  getOperationFromWSDLObjectByUrlPathNameProtocol(
     itemRequestProcessedInfo,
     wsdlObject
   ) {
@@ -279,16 +278,18 @@ class TransactionValidator {
    * @param {object} requestUrl Request url postman object
    * @returns {string} raw url
    */
-  getRawURL(requestUrl) {
+  getUrlPath(requestUrl) {
     if (typeof requestUrl === 'object') {
-      requestUrl.variable.forEach((pathVar) => {
-        if (pathVar.value === null ||
-          (typeof pathVar.value === 'string' && pathVar.value.trim.length === 0)
-        ) {
-          pathVar.value = ':' + pathVar.key;
-        }
-      });
-      return new sdk.Url(requestUrl).toString();
+      if (requestUrl.variable) {
+        requestUrl.variable.forEach((pathVar) => {
+          if (pathVar.value === null ||
+            (typeof pathVar.value === 'string' && pathVar.value.trim.length === 0)
+          ) {
+            pathVar.value = ':' + pathVar.key;
+          }
+        });
+      }
+      return requestUrl.path ? requestUrl.path.join('/') : '';
     }
     return requestUrl;
   }
@@ -344,7 +345,7 @@ class TransactionValidator {
    * @returns {object} {url, name, protocol, method}
    */
   getItemRequestProcessedInfo(itemRequest, parsedXmlMessage) {
-    let rawURL = this.getRawURL(itemRequest.url),
+    let rawURL = this.getUrlPath(itemRequest.url),
       isSoap = true,
       protocol = '',
       envelope = '',
@@ -473,8 +474,19 @@ class TransactionValidator {
    */
   filterOperationsQuery(operation) {
     return (itemRequestProcessedInfo) => {
+      const isWsdlObjectOperation = operation.style;
+      let isIncludedOrEmpty;
+      if (isWsdlObjectOperation) {
+        isIncludedOrEmpty = itemRequestProcessedInfo.url === '' ||
+          operation.url.includes(itemRequestProcessedInfo.url);
+      }
+      else {
+        isIncludedOrEmpty = operation.url === '' ||
+          itemRequestProcessedInfo.url.includes(operation.url);
+      }
+
       return (
-        operation.url === itemRequestProcessedInfo.url &&
+        isIncludedOrEmpty &&
         operation.name === itemRequestProcessedInfo.name &&
         operation.protocol === itemRequestProcessedInfo.protocol
       );

--- a/test/convert-validation/ValidationReport.test.js
+++ b/test/convert-validation/ValidationReport.test.js
@@ -41,11 +41,13 @@ describe('SchemaPack convert and validate report missmatches WSDL 1.1', function
 
         schemaPack.validateTransactions(historyRequests, (error, result) => {
           if (error) {
+            console.error(`Test Failed ${file}`);
             fs.writeFileSync(outputDirectory + file + '-validationResult.json', JSON.stringify(error));
             fs.writeFileSync(outputDirectory + file + '-collection.json',
               JSON.stringify(collectionResult.output[0].data));
           }
           if (!error && !result.matched) {
+            console.error(`Test Failed ${file}`);
             fs.writeFileSync(outputDirectory + file + '-validationResult.json', JSON.stringify(result));
             fs.writeFileSync(outputDirectory + file + '-collection.json',
               JSON.stringify(collectionResult.output[0].data));

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -779,8 +779,24 @@ describe('Validate Headers', function () {
 describe('get Raw URL', function () {
   it('Should return the same url when it is a string', function () {
     const transactionValidator = new TransactionValidator(),
-      result = transactionValidator.getRawURL('http://url.com');
+      result = transactionValidator.getUrlPath('http://url.com');
     expect(result).to.be.equal('http://url.com');
+  });
+
+  it('Should return empty string when url does not have path', function() {
+    const transactionValidator = new TransactionValidator(),
+      url = {
+        'raw': 'https://queue.amazonaws.com',
+        'protocol': 'https',
+        'host': [
+          'queue',
+          'amazonaws',
+          'com'
+        ]
+      },
+      result = transactionValidator.getUrlPath(url);
+
+    expect(result).to.be.equal('');
   });
 });
 


### PR DESCRIPTION
- Operation filter changed to filter with path only, not host in URL.
- Adding some logs in validationReport.
- Adding a test to validate when the URL does not have a path.
- Modifies filterOperationQuery and getRawUrl (now getUrlPath).