### PR TITLE
Wsdl documentation to collection desc

### DIFF
--- a/lib/WSDLObject.js
+++ b/lib/WSDLObject.js
@@ -23,6 +23,7 @@ class WsdlObject {
     this.log = new Log();
     this.xmlParsed = '';
     this.version = '';
+    this.documentation = '';
   }
 }
 

--- a/lib/Wsdl11Parser.js
+++ b/lib/Wsdl11Parser.js
@@ -54,7 +54,8 @@ const
     THIS_NS_PREFIX,
     getBindingOperation,
     assignSecurity,
-    getDocumentationStringFromNode
+    getDocumentationStringFromNode,
+    getWSDLDocumentation
   } = require('./WsdlParserCommon'),
   {
     getQNamePrefixFilter,
@@ -91,6 +92,7 @@ class Wsdl11Parser {
     wsdlObject = this.assignNamespaces(wsdlObject, parsedXml);
     wsdlObject = this.assignOperations(wsdlObject, parsedXml);
     wsdlObject = this.assignSecurity(wsdlObject, parsedXml);
+    wsdlObject = this.assignDocumentation(wsdlObject, parsedXml);
     wsdlObject.xmlParsed = parsedXml;
     wsdlObject.version = '1.1';
     return wsdlObject;
@@ -133,6 +135,12 @@ class Wsdl11Parser {
 
   assignSecurity(wsdlObject, parsedXml) {
     return assignSecurity(wsdlObject, parsedXml, WSDL_ROOT);
+  }
+
+  assignDocumentation(wsdlObject, parsedXml) {
+    let newWsdlObject = { ...wsdlObject };
+    newWsdlObject.documentation = getWSDLDocumentation(parsedXml, WSDL_ROOT);
+    return newWsdlObject;
   }
 
   /**

--- a/lib/Wsdl20Parser.js
+++ b/lib/Wsdl20Parser.js
@@ -16,7 +16,8 @@ const
     THIS_NS_PREFIX,
     getBindingOperation,
     assignSecurity,
-    getDocumentationStringFromNode
+    getDocumentationStringFromNode,
+    getWSDLDocumentation
   } = require('./WsdlParserCommon'),
   {
     getArrayFrom
@@ -90,6 +91,7 @@ class Wsdl20Parser {
     wsdlObject = this.assignNamespaces(wsdlObject, parsedXml);
     wsdlObject = this.assignOperations(wsdlObject, parsedXml);
     wsdlObject = this.assignSecurity(wsdlObject, parsedXml);
+    wsdlObject = this.assignDocumentation(wsdlObject, parsedXml);
     wsdlObject.xmlParsed = parsedXml;
     wsdlObject.version = '2.0';
     return wsdlObject;
@@ -225,6 +227,13 @@ class Wsdl20Parser {
 
   assignSecurity(wsdlObject, parsedXml) {
     return assignSecurity(wsdlObject, parsedXml, WSDL_ROOT);
+  }
+
+
+  assignDocumentation(wsdlObject, parsedXml) {
+    let newWsdlObject = { ...wsdlObject };
+    newWsdlObject.documentation = getWSDLDocumentation(parsedXml, WSDL_ROOT);
+    return newWsdlObject;
   }
 
   /**

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -1,8 +1,6 @@
 const {
-  SecurityAssertionsHelper
-} = require('./security/SecurityAssertionsHelper');
-
-const
+    SecurityAssertionsHelper
+  } = require('./security/SecurityAssertionsHelper'),
   {
     getArrayFrom
   } = require('./utils/objectUtils'),
@@ -18,6 +16,7 @@ const
   XML_NAMESPACE_DECLARATION = 'xmlns',
   TARGET_NAMESPACE_SPEC = 'targetNamespace',
   SERVICE_TAG = 'service',
+  DOCUMENTATION_TAG = 'documentation',
   BINDING_TAG = 'binding',
   SCHEMA_TAG = 'schema',
   SCHEMA_NS_URL = 'http://www.w3.org/2001/XMLSchema',
@@ -371,6 +370,28 @@ function getDocumentationStringFromNode(node) {
   return removeLineBreak(node);
 }
 
+/**
+ * Finds all the services of the document
+ * creates a namespace array object with the found information
+ * @param {object} parsedXml the binding operation object
+ * @param {string} wsdlRoot the root tag for the document
+ * @returns {Array} the [services] object
+ */
+function getWSDLDocumentation(parsedXml, wsdlRoot) {
+  if (!parsedXml || typeof parsedXml !== 'object') {
+    throw new WsdlError('Can not get documentation from undefined or null object');
+  }
+  try {
+    const principalPrefix = getPrincipalPrefix(parsedXml, wsdlRoot),
+      definitions = getNodeByName(parsedXml, principalPrefix, wsdlRoot);
+    let documentation = getNodeByName(definitions, principalPrefix, DOCUMENTATION_TAG);
+    return documentation ? getDocumentationStringFromNode(documentation) : '';
+  }
+  catch (error) {
+    throw new WsdlError('Can not get documentation from object');
+  }
+}
+
 module.exports = {
   PARSER_ATRIBUTE_NAME_PLACE_HOLDER,
   getPrincipalPrefix,
@@ -391,5 +412,6 @@ module.exports = {
   getBindingOperation,
   assignSecurity,
   getSecurity,
-  getDocumentationStringFromNode
+  getDocumentationStringFromNode,
+  getWSDLDocumentation
 };

--- a/lib/WsdlToPostmanCollectionMapper.js
+++ b/lib/WsdlToPostmanCollectionMapper.js
@@ -94,7 +94,7 @@ class WsdlToPostmanCollectionMapper {
    * @returns {string} the collection description in string representation
    */
   getCollectionDescription(wsdlObject) {
-    return wsdlObject.log.errors;
+    return wsdlObject.documentation + '\n' + wsdlObject.log.errors;
   }
 
   /**

--- a/test/unit/wsdl11Parser.test.js
+++ b/test/unit/wsdl11Parser.test.js
@@ -344,7 +344,7 @@ describe('WSDL 1.1 parser assignNamespaces', function () {
     expect(wsdlObject).to.have.all.keys('targetNamespace',
       'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
       'SOAP12Namespace', 'schemaNamespace',
-      'tnsNamespace', 'allNameSpaces', 'fileName', 'log',
+      'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
       'operationsArray', 'securityPolicyArray',
       'securityPolicyNamespace', 'xmlParsed', 'version');
 
@@ -2656,7 +2656,7 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
       expect(wsdlObject).to.have.all.keys('targetNamespace',
         'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
         'SOAP12Namespace', 'schemaNamespace',
-        'tnsNamespace', 'allNameSpaces', 'fileName', 'log',
+        'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
         'operationsArray', 'securityPolicyArray',
         'securityPolicyNamespace', 'xmlParsed', 'version');
 

--- a/test/unit/wsdl20Parser.test.js
+++ b/test/unit/wsdl20Parser.test.js
@@ -182,7 +182,7 @@ describe('WSDL 2.0 parser assignNamespaces', function () {
     expect(wsdlObject).to.have.all.keys('targetNamespace',
       'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
       'SOAP12Namespace', 'schemaNamespace',
-      'tnsNamespace', 'allNameSpaces', 'fileName', 'log',
+      'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
       'operationsArray', 'securityPolicyArray',
       'securityPolicyNamespace', 'xmlParsed', 'version');
 
@@ -204,7 +204,7 @@ describe('WSDL 2.0 parser getWsdlObject', function () {
       expect(wsdlObject).to.have.all.keys('targetNamespace',
         'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
         'SOAP12Namespace', 'schemaNamespace',
-        'tnsNamespace', 'allNameSpaces', 'fileName', 'log',
+        'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
         'operationsArray', 'securityPolicyArray',
         'securityPolicyNamespace', 'xmlParsed', 'version');
 

--- a/test/unit/wsdlParserComon.test.js
+++ b/test/unit/wsdlParserComon.test.js
@@ -18,7 +18,8 @@ const expect = require('chai').expect,
     getPrincipalPrefix,
     getBindingOperation,
     getElementsFromWSDL,
-    getDocumentationStringFromNode
+    getDocumentationStringFromNode,
+    getWSDLDocumentation
   } = require('../../lib/WsdlParserCommon'),
   {
     WSDL_ROOT: WSDL_ROOT_2_0
@@ -142,7 +143,125 @@ whttp:methodDefault="POST" type="http://www.w3.org/ns/wsdl/http">
   binding="tns:SayHelloSoap12Binding" 
   address="http://192.168.100.75:8080/Axis2-bottom/services/SayHello.SayHelloHttpSoap12Endpoint/" />
 </wsdl2:service>
-</wsdl2:description>`;
+</wsdl2:description>`,
+  WSDL_1_1 = `<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+  xmlns:tns="http://www.dataaccess.com/webservicesserver/" name="NumberConversion"
+  targetNamespace="http://www.dataaccess.com/webservicesserver/">
+  <types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+      <xs:element name="NumberToWords">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ubiNum" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToWordsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="NumberToWordsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToDollars">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dNum" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToDollarsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="NumberToDollarsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <documentation>
+  This document describes number convertion service</documentation>
+  <message name="NumberToWordsSoapRequest">
+    <part name="parameters" element="tns:NumberToWords"/>
+  </message>
+  <message name="NumberToWordsSoapResponse">
+    <part name="parameters" element="tns:NumberToWordsResponse"/>
+  </message>
+  <message name="NumberToDollarsSoapRequest">
+    <part name="parameters" element="tns:NumberToDollars"/>
+  </message>
+  <message name="NumberToDollarsSoapResponse">
+    <part name="parameters" element="tns:NumberToDollarsResponse"/>
+  </message>
+  <portType name="NumberConversionSoapType">
+    <operation name="NumberToWords">
+      <documentation>Returns the word corresponding to the positive number passed as parameter.
+       Limited to quadrillions.</documentation>
+      <input message="tns:NumberToWordsSoapRequest"/>
+      <output message="tns:NumberToWordsSoapResponse"/>
+    </operation>
+    <operation name="NumberToDollars">
+      <documentation>Returns the non-zero dollar amount of the passed number.</documentation>
+      <input message="tns:NumberToDollarsSoapRequest"/>
+      <output message="tns:NumberToDollarsSoapResponse"/>
+    </operation>
+  </portType>
+  <binding name="NumberConversionSoapBinding" type="tns:NumberConversionSoapType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="NumberToWords">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="NumberToDollars">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <binding name="NumberConversionSoapBinding12" type="tns:NumberConversionSoapType">
+    <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="NumberToWords">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="NumberToDollars">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="NumberConversion">
+    <documentation>The Number Conversion Web Service, implemented with Visual DataFlex, provides 
+    functions that convert numbers into words or dollar amounts.</documentation>
+    <port name="NumberConversionSoap" binding="tns:NumberConversionSoapBinding">
+      <soap:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso"/>
+    </port>
+    <port name="NumberConversionSoap12" binding="tns:NumberConversionSoapBinding12">
+      <soap12:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso"/>
+    </port>
+  </service>
+</definitions>`;
 
 describe('WSDL parser common getNamespaceByKey', function () {
 
@@ -1657,3 +1776,58 @@ describe('WSDL parser common getDocumentationString', function () {
   });
 });
 
+describe('WSDL parser common getWSDLDocumentation', function () {
+  it('should get documentation text WSDL 1.1', function () {
+    const parser = new XMLParser();
+    let parsed = parser.parseToObject(WSDL_1_1),
+      documentation = getWSDLDocumentation(
+        parsed,
+        WSDL_ROOT_1_1
+      );
+    expect(documentation).to.equal('This document describes number convertion service');
+  });
+
+  it('should get an array object representing services using default WSDL_SAMPLE_AXIS WSDL 2.0', function () {
+    const parser = new XMLParser();
+    let parsed = parser.parseToObject(WSDL_SAMPLE_AXIS),
+      documentation = getWSDLDocumentation(
+        parsed,
+        WSDL_ROOT_2_0
+      );
+    expect(documentation).to.equal('Please Type your service description here');
+  });
+
+  it('should throw an error when call with null WSDL', function () {
+    try {
+      getWSDLDocumentation(
+        null
+      );
+      assert.fail('we expected an error');
+    }
+    catch (error) {
+      expect(error.message).to.equal('Can not get documentation from undefined or null object');
+    }
+  });
+
+  it('should throw an error when call with undefined', function () {
+    try {
+      getWSDLDocumentation(
+        undefined
+      );
+      assert.fail('we expected an error');
+    }
+    catch (error) {
+      expect(error.message).to.equal('Can not get documentation from undefined or null object');
+    }
+  });
+
+  it('should throw an error when call with an empty object', function () {
+    try {
+      getWSDLDocumentation({});
+      assert.fail('we expected an error');
+    }
+    catch (error) {
+      expect(error.message).to.equal('Can not get documentation from object');
+    }
+  });
+});


### PR DESCRIPTION

 small improvement I noticed. I believe documentation mentioned in spec under <documentation> is not used currently. Would it be good idea to add it under collection description? (it should be at info.description in collection)

2.1.4 DocumentationWSDL uses the optional wsdl:document element as a container for human readable documentation. The content of the element is arbitrary text and elements ("mixed" in XSD). The documentation element is allowed inside any WSDL language element.

according to spec there is a documentation node in the wsdl under the principal node (description for wsdl 2.0 and definitions for wsdl 1.1)

<description xmlns="http://www.w3.org/ns/wsdl" xmlns:tns="http://www.tmsws.com/wsdl20sample" xmlns:whttp="http://schemas.xmlsoap.org/wsdl/http/"xmlns:wsoap="http://schemas.xmlsoap.org/wsdl/soap/"targetNamespace="http://www.tmsws.com/wsdl20sample">

<documentation>This is a sample WSDL 2.0 document. </documentation>

we should read this node and place the text in the collections description field