### PR TITLE
support option Validation properties to ignore

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -109,7 +109,8 @@ class TransactionValidator {
             validationPropertiesToIgnore
           ),
 
-          soapMethodMismatches = this.validateSoapMethod(protocol, requestItem.request.method, operationFromWSDL),
+          soapMethodMismatches = this.validateSoapMethod(protocol, requestItem.request.method, operationFromWSDL,
+            validationPropertiesToIgnore),
           endpointMismatches = [
             ...headerMismatches,
             ...requestBodyMismatches,
@@ -203,9 +204,20 @@ class TransactionValidator {
     };
   }
 
-  validateSoapMethod(protocol, method, operationFromWSDL) {
+  /**
+   * Validate that the request uses POST method due that is the used for SOAP Protocol
+   * @param {Array} protocol the WSDL operation protocol
+   * @param {Object} method The Request Http Method
+   * @param {Object} operationFromWSDL The wsdlObject operation's
+   * @param {Object} validationPropertiesToIgnore option for ignoring properties in validation
+   * @returns {Array} mismatches array
+   */
+  validateSoapMethod(protocol, method, operationFromWSDL, validationPropertiesToIgnore) {
     const postProtocols = [SOAP_PROTOCOL, SOAP12_PROTOCOL];
     let mismatches = [];
+    if (validationPropertiesToIgnore?.includes(SOAP_METHOD_PROPERTY)) {
+      return mismatches;
+    }
     if (postProtocols.includes(protocol.toLowerCase()) && method.toLowerCase() !== 'post') {
       mismatches = [
         {
@@ -231,7 +243,7 @@ class TransactionValidator {
    */
   validateBody(rawXmlMessage, wsdlObject, operationFromWSDL, isResponse, validationPropertiesToIgnore) {
     let mismatches = [];
-    const mismatchProperty = isResponse ? 'RESPONSE_BODY' : 'BODY';
+    const mismatchProperty = isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY;
 
     if (validationPropertiesToIgnore?.includes(mismatchProperty)) {
       return mismatches;

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -71,7 +71,8 @@ class TransactionValidator {
       requests = {},
       validationResult = {},
       {
-        validateContentType
+        validateContentType,
+        validationPropertiesToIgnore
       } = options,
       validateHeadersDefault = false,
       validateHeadersOption = validateContentType ? true : validateHeadersDefault;
@@ -104,7 +105,8 @@ class TransactionValidator {
             unwrapAndCleanBody(requestBody, input.name),
             wsdlObject,
             operationFromWSDL,
-            false
+            false,
+            validationPropertiesToIgnore
           ),
 
           soapMethodMismatches = this.validateSoapMethod(protocol, requestItem.request.method, operationFromWSDL),
@@ -114,7 +116,7 @@ class TransactionValidator {
             ...soapMethodMismatches
           ],
           { responses, responsesMatched } = this.getResponsesValidation(requestItem.response, wsdlObject,
-            operationFromWSDL, validateHeadersOption);
+            operationFromWSDL, validateHeadersOption, validationPropertiesToIgnore);
 
         endpoints = [
           this.getEndpointResult(endpointMismatches, `${method} ${protocol} ${name}`, responses)
@@ -169,10 +171,12 @@ class TransactionValidator {
    * @param {Object} wsdlObject The wsdlObject generated from wsdl document
    * @param {Object} operationFromWSDL The wsdlObject operation's
    * @param {boolean} validateHeadersOption if validateContentType option value, False by default
+   * @param {Object} validationPropertiesToIgnore option for ignoring properties in validation
    * @returns {Object} {responses, responsesMatched} responses contains the list of validated responses
    *                    responsesMatched is false if any response failed
    */
-  getResponsesValidation(responseItem, wsdlObject, operationFromWSDL, validateHeadersOption) {
+  getResponsesValidation(responseItem, wsdlObject, operationFromWSDL, validateHeadersOption,
+    validationPropertiesToIgnore) {
     let responses = {},
       responsesMatched = true;
     responseItem.forEach((response) => {
@@ -180,7 +184,7 @@ class TransactionValidator {
         header = response.header,
         id = response.id,
         headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true),
-        bodyMismatches = this.validateBody(body, wsdlObject, operationFromWSDL, true),
+        bodyMismatches = this.validateBody(body, wsdlObject, operationFromWSDL, true, validationPropertiesToIgnore),
         mismatches = [...headerMismatches, ...bodyMismatches],
         matched = !mismatches.length > 0;
       if (!matched) {
@@ -222,10 +226,17 @@ class TransactionValidator {
    * @param {Object} wsdlObject Object generated from wsdl document
    * @param {Object} operationFromWSDL wsdlObject operation's
    * @param {Boolean} isResponse True if provided message is in a response, False if is in a request
+   * @param {Object} validationPropertiesToIgnore option for ignoring properties in validation
    * @returns {Array} List of mismatches found
    */
-  validateBody(rawXmlMessage, wsdlObject, operationFromWSDL, isResponse) {
+  validateBody(rawXmlMessage, wsdlObject, operationFromWSDL, isResponse, validationPropertiesToIgnore) {
     let mismatches = [];
+    const mismatchProperty = isResponse ? 'RESPONSE_BODY' : 'BODY';
+
+    if (validationPropertiesToIgnore?.includes(mismatchProperty)) {
+      return mismatches;
+    }
+
     if (rawXmlMessage) {
       const parsedXml = wsdlObject.xmlParsed,
         cleanSchema = getCleanSchema(parsedXml, wsdlObject.schemaNamespace, wsdlObject.version),

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -67,6 +67,21 @@ const
 class WsdlInformationService11 {
   constructor() {
     this.version = '1.1';
+    this.InputTagName = INPUT_TAG;
+    this.NameTag = NAME_TAG;
+    this.OutputTagName = OUTPUT_TAG;
+    this.FaultTagName = FAULT_TAG;
+    this.SOAPNamesapceURL = SOAP_NS_URL;
+    this.SOAP12NamesapceURL = SOAP_12_NS_URL;
+    this.SOAPNamespaceKey = SOAP_NS_KEY;
+    this.SchemaNamespaceURL = SCHEMA_NS_URL;
+    this.RootTagName = WSDL_ROOT;
+    this.WSDLNamespaceURL = WSDL_NS_URL;
+    this.SOAP12NamespaceKey = SOAP_12_NS_KEY;
+    this.HTTPNamespaceKey = HTTP_NS_KEY;
+    this.THISNamespaceKey = TNS_NS_KEY;
+    this.TargetNamespaceKey = TARGETNAMESPACE_KEY;
+    this.XMLPolicyURL = XML_POLICY;
   }
 
   /**
@@ -86,126 +101,6 @@ class WsdlInformationService11 {
   */
   getAbstractDefinitionName(binding) {
     return getAttributeByName(binding, ATTRIBUTE_TYPE).replace(THIS_NS_PREFIX, '');
-  }
-
-  getInputTagName() {
-    return INPUT_TAG;
-  }
-
-  getNameTag() {
-    return NAME_TAG;
-  }
-
-  /**
-   * gets the output tag name for WSDL 1.1 version
-   * @returns {string} the output tag name
-   */
-  getOuputTagName() {
-    return OUTPUT_TAG;
-  }
-
-  /**
-   * gets the fault tag name for WSDL 1.1 version
-   * @returns {string} the fault tag name
-   */
-  getFaultTagName() {
-    return FAULT_TAG;
-  }
-
-  /**
-   * gets WSDL object 1.1 version
-   * @returns {string} the wsdl object version
-   */
-  getWSDLObjectVersion() {
-    return this.version;
-  }
-
-  /**
-   * gets the SOAP  namespace url for 1.1 version
-   * @returns {string} the name of the tag
-   */
-  getSOAPNamespaceURL() {
-    return SOAP_NS_URL;
-  }
-
-  /**
-   * gets the SOAP 12 namespace url for 1.1 version
-   * @returns {string} the url
-   */
-  getSOAP12NamespaceURL() {
-    return SOAP_12_NS_URL;
-  }
-
-  /**
-   * gets the schema namespace url for 1.1 version
-   * @returns {string} the url
-   */
-  getSchemaNamespaceURL() {
-    return SCHEMA_NS_URL;
-  }
-
-  /**
-  * gets the root tag for 1.1 version
-  * @returns {string} the name of the tag
-  */
-  getRootTagName() {
-    return WSDL_ROOT;
-  }
-
-  /**
-  * gets the WSDL namespace url for 1.1 version
-  * @returns {string} the url
-  */
-  getWSDLNamespaceURL() {
-    return WSDL_NS_URL;
-  }
-
-  /**
-  * gets the SOAP namespace url for 1.1 version
-  * @returns {string} the key
-  */
-  getSOAPNamespaceKey() {
-    return SOAP_NS_KEY;
-  }
-
-  /**
-  * gets the SOAP 12 namespace url for 1.1 version
-  * @returns {string} the  key
-  */
-  getSOAP12NamespaceKey() {
-    return SOAP_12_NS_KEY;
-  }
-
-  /**
-   * gets the HTTP 12 namespace key for 1.1 version
-   * @returns {string} the key
-   */
-  getHTTPNamespaceKey() {
-    return HTTP_NS_KEY;
-  }
-
-  /**
-  * gets the TNS (this name space) namespace key for 1.1 version
-  * @returns {string} the name of the tag
-  */
-  getTHISNamespaceKey() {
-    return TNS_NS_KEY;
-  }
-
-  /**
-  * gets the target namespace key for 1.1 version
-  * @returns {string} the key
-  */
-  getTargetNamespaceKey() {
-    return TARGETNAMESPACE_KEY;
-  }
-
-  /**
-  * gets the xml policy namespace url for 1.1 version
-  * @returns {string} the url
-  */
-  getXMLPolicyURL() {
-    return XML_POLICY;
   }
 
   getOperationxPathInfo(bindingName, operationName, wsdlNamespaceUrl) {
@@ -547,10 +442,8 @@ class WsdlInformationService11 {
    * @returns {string} the verb
    */
   getOperationHttpMethod(bindingOperation, httpNamespace) {
-
     let readVerb = getAttributeByName(bindingOperation, httpNamespace.key + XML_NAMESPACE_SEPARATOR +
       ATTRIBUTE_METHOD);
-
     return getHttpVerb(readVerb);
   }
 }

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -64,38 +64,23 @@ const
 class WsdlInformationService20 {
   constructor() {
     this.version = '2.0';
-  }
+    this.InputTagName = INPUT_TAG;
+    this.NameTag = NAME_TAG;
+    this.OutputTagName = OUTPUT_TAG;
+    this.FaultTagName = FAULT_TAG;
+    this.SOAPNamesapceURL = SOAP_NS_URL;
+    this.SOAPNamesapceURL = SOAP_NS_URL;
+    this.SOAP12NamesapceURL = SOAP_12_NS_URL;
+    this.SOAPNamespaceKey = SOAP_NS_KEY;
+    this.SchemaNamespaceURL = SCHEMA_NS_URL;
+    this.RootTagName = WSDL_ROOT;
+    this.WSDLNamespaceURL = WSDL_NS_URL;
+    this.SOAP12NamespaceKey = SOAP_12_NS_KEY;
+    this.HTTPNamespaceKey = HTTP_NS_KEY;
+    this.THISNamespaceKey = TNS_NS_KEY;
+    this.TargetNamespaceKey = TARGETNAMESPACE_KEY;
+    this.XMLPolicyURL = XML_POLICY;
 
-  /**
-  * gets the input tag name for WSDL 2.0 version
-  * @returns {string} the input tag name
-  */
-  getInputTagName() {
-    return INPUT_TAG;
-  }
-
-  /**
-  * gets the name tag name for WSDL 2.0 version
-  * @returns {string} the name tag name
-  */
-  getNameTag() {
-    return NAME_TAG;
-  }
-
-  /**
-  * gets the output tag name for WSDL 2.0 version
-  * @returns {string} the output tag name
-  */
-  getOuputTagName() {
-    return OUTPUT_TAG;
-  }
-
-  /**
-  * gets the fault tag name for WSDL 2.0 version
-  * @returns {string} the fault tag name
-  */
-  getFaultTagName() {
-    return OUTFAULT_TAG;
   }
 
   /**
@@ -114,102 +99,6 @@ class WsdlInformationService20 {
   */
   getAbstractDefinitionName(binding) {
     return getAttributeByName(binding, INTERFACE_TAG).replace(THIS_NS_PREFIX, '');
-  }
-
-  /**
-   * gets WSDL object 2.0 version
-   * @returns {string} the wsdl object version
-   */
-  getWSDLObjectVersion() {
-    return this.version;
-  }
-
-  /**
-  * gets the root tag for 2.0 version
-  * @returns {string} the name of the tag
-  */
-  getRootTagName() {
-    return WSDL_ROOT;
-  }
-
-  /**
-  * gets the WSDL namespace url for 2.0 version
-  * @returns {string} the url
-  */
-  getWSDLNamespaceURL() {
-    return WSDL_NS_URL;
-  }
-
-  /**
-  * gets the SOAP namespace url for 2.0 version
-  * @returns {string} the url
-  */
-  getSOAPNamespaceURL() {
-    return SOAP_NS_URL;
-  }
-
-  /**
-   * gets the schema namespace url for 2.0 version
-   * @returns {string} the url
-   */
-  getSchemaNamespaceURL() {
-    return SCHEMA_NS_URL;
-  }
-
-  /**
-   * gets the SOAP 12 namespace url for 2.0 version
-   * @returns {string} the url
-   */
-  getSOAP12NamespaceURL() {
-    return SOAP_12_NS_URL;
-  }
-
-  /**
-   * gets the SOAP  namespace url for 2.0 version
-   * @returns {string} the key
-   */
-  getSOAPNamespaceKey() {
-    return SOAP_NS_KEY;
-  }
-
-  /**
-  * gets the SOAP 12 namespace key for 2.0 version
-  * @returns {string} the key
-  */
-  getSOAP12NamespaceKey() {
-    return SOAP_12_NS_KEY;
-  }
-
-  /**
-  * gets the HTTP namespace key for 2.0 version
-  * @returns {string} the key
-  */
-  getHTTPNamespaceKey() {
-    return HTTP_NS_KEY;
-  }
-
-  /**
-  * gets the TNS (this name space) namespace key for 2.0 version
-  * @returns {string} the key
-  */
-  getTHISNamespaceKey() {
-    return TNS_NS_KEY;
-  }
-
-  /**
-  * gets the target namespace key for 2.0 version
-  * @returns {string} the key
-  */
-  getTargetNamespaceKey() {
-    return TARGETNAMESPACE_KEY;
-  }
-
-  /**
-  * gets the xml policy namespace url for 2.0 version
-  * @returns {string} the url
-  */
-  getXMLPolicyURL() {
-    return XML_POLICY;
   }
 
   /**

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -42,7 +42,7 @@ class WsdlParser {
     wsdlObject = this.assignSecurity(wsdlObject, parsedXml);
     wsdlObject = this.assignDocumentation(wsdlObject, parsedXml);
     wsdlObject.xmlParsed = parsedXml;
-    wsdlObject.version = this.informationService.getWSDLObjectVersion();
+    wsdlObject.version = this.informationService.version;
     return wsdlObject;
   }
 
@@ -58,22 +58,22 @@ class WsdlParser {
     let newWsdlObject = {
       ...wsdlObject
     };
-    const allNameSpaces = getAllNamespaces(parsedXml, this.informationService.getRootTagName()),
-      wsdlNamespace = getNamespaceByURL(parsedXml, this.informationService.getWSDLNamespaceURL(),
-        this.informationService.getRootTagName()),
-      soapNamespace = getNamespaceByKey(parsedXml, this.informationService.getSOAPNamespaceKey(),
-        this.informationService.getRootTagName()),
-      soap12Namespace = getNamespaceByKey(parsedXml, this.informationService.getSOAP12NamespaceKey(),
-        this.informationService.getRootTagName()),
-      schemaNamespace = getSchemaNamespace(parsedXml, this.informationService.getRootTagName()),
-      HTTPNamespace = getNamespaceByKey(parsedXml, this.informationService.getHTTPNamespaceKey(),
-        this.informationService.getRootTagName()),
-      tnsNamespace = getNamespaceByKey(parsedXml, this.informationService.getTHISNamespaceKey(),
-        this.informationService.getRootTagName()),
-      targetNamespace = getNamespaceByKey(parsedXml, this.informationService.getTargetNamespaceKey(),
-        this.informationService.getRootTagName()),
-      securityPolicyNamespace = getNamespaceByURL(parsedXml, this.informationService.getXMLPolicyURL(),
-        this.informationService.getRootTagName());
+    const allNameSpaces = getAllNamespaces(parsedXml, this.informationService.RootTagName),
+      wsdlNamespace = getNamespaceByURL(parsedXml, this.informationService.WSDLNamespaceURL,
+        this.informationService.RootTagName),
+      soapNamespace = getNamespaceByKey(parsedXml, this.informationService.SOAPNamespaceKey,
+        this.informationService.RootTagName),
+      soap12Namespace = getNamespaceByKey(parsedXml, this.informationService.SOAP12NamespaceKey,
+        this.informationService.RootTagName),
+      schemaNamespace = getSchemaNamespace(parsedXml, this.informationService.RootTagName),
+      HTTPNamespace = getNamespaceByKey(parsedXml, this.informationService.HTTPNamespaceKey,
+        this.informationService.RootTagName),
+      tnsNamespace = getNamespaceByKey(parsedXml, this.informationService.THISNamespaceKey,
+        this.informationService.RootTagName),
+      targetNamespace = getNamespaceByKey(parsedXml, this.informationService.TargetNamespaceKey,
+        this.informationService.RootTagName),
+      securityPolicyNamespace = getNamespaceByURL(parsedXml, this.informationService.XMLPolicyURL,
+        this.informationService.RootTagName);
 
     newWsdlObject.targetNamespace = targetNamespace;
     newWsdlObject.wsdlNamespace = wsdlNamespace;
@@ -96,7 +96,7 @@ class WsdlParser {
   * @returns {object} the WSDLObject
   */
   assignSecurity(wsdlObject, parsedXml) {
-    return assignSecurity(wsdlObject, parsedXml, this.informationService.getRootTagName());
+    return assignSecurity(wsdlObject, parsedXml, this.informationService.RootTagName);
   }
 
   /**
@@ -107,7 +107,7 @@ class WsdlParser {
    */
   assignDocumentation(wsdlObject, parsedXml) {
     let newWsdlObject = { ...wsdlObject };
-    newWsdlObject.documentation = getWSDLDocumentation(parsedXml, this.informationService.getRootTagName());
+    newWsdlObject.documentation = getWSDLDocumentation(parsedXml, this.informationService.RootTagName);
     return newWsdlObject;
   }
 
@@ -124,10 +124,10 @@ class WsdlParser {
   assignOperations(wsdlObject, parsedXml) {
     let newWsdlObject = { ...wsdlObject },
       wsdlOperations = [];
-    const principalPrefix = getPrincipalPrefix(parsedXml, this.informationService.getRootTagName()),
-      services = getServices(parsedXml, this.informationService.getRootTagName()),
-      bindings = getBindings(parsedXml, this.informationService.getRootTagName(), wsdlObject),
-      elements = getElementsFromWSDL(parsedXml, principalPrefix, this.informationService.getRootTagName(),
+    const principalPrefix = getPrincipalPrefix(parsedXml, this.informationService.RootTagName),
+      services = getServices(parsedXml, this.informationService.RootTagName),
+      bindings = getBindings(parsedXml, this.informationService.RootTagName, wsdlObject),
+      elements = getElementsFromWSDL(parsedXml, principalPrefix, this.informationService.RootTagName,
         wsdlObject.schemaNamespace, wsdlObject.tnsNamespace);
 
     bindings.forEach((binding) => {
@@ -151,7 +151,7 @@ class WsdlParser {
             this.informationService.getBindingOperationName(bindingOperation);
 
         serviceAndPort = this.informationService.getServiceAndExpossedInfoByBindingName(
-          getAttributeByName(binding, this.informationService.getNameTag()),
+          getAttributeByName(binding, this.informationService.NameTag),
           services, principalPrefix, newWsdlObject
         );
         service = serviceAndPort ? serviceAndPort.service : undefined;
@@ -186,7 +186,7 @@ class WsdlParser {
           portTypeInterfaceOperation,
           elements,
           principalPrefix,
-          this.informationService.getInputTagName(),
+          this.informationService.InputTagName,
           portTypeInterfaceName
         );
         wsdlOperation.output = this.informationService.getElementFromPortTypeInterfaceOperation(
@@ -194,7 +194,7 @@ class WsdlParser {
           portTypeInterfaceOperation,
           elements,
           principalPrefix,
-          this.informationService.getOuputTagName(),
+          this.informationService.OutputTagName,
           portTypeInterfaceName
         );
         wsdlOperation.fault = this.informationService.getElementFromPortTypeInterfaceOperation(
@@ -202,7 +202,7 @@ class WsdlParser {
           portTypeInterfaceOperation,
           elements,
           principalPrefix,
-          this.informationService.getFaultTagName(),
+          this.informationService.FaultTagName,
           portTypeInterfaceName
         );
         wsdlOperation.xpathInfo = this.informationService.getOperationxPathInfo(

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -44,6 +44,18 @@ function getOptions(mode = 'document', criteria = {}) {
       description: 'Select true to validate your collection requests/responses headers are correctly set',
       external: true,
       usage: ['VALIDATION']
+    },
+    {
+      name: 'Properties to ignore during validation',
+      id: 'validationPropertiesToIgnore',
+      type: 'array',
+      default: [],
+      description:
+        'Specific properties (parts of a request/response pair) to ignore during validation.' +
+        ' Must be sent as an array of strings. Valid inputs in the array: PATHVARIABLE, QUERYPARAM,' +
+        ' HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY',
+      external: true,
+      usage: ['VALIDATION']
     }
   ];
 

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -52,8 +52,8 @@ function getOptions(mode = 'document', criteria = {}) {
       default: [],
       description:
         'Specific properties (parts of a request/response pair) to ignore during validation.' +
-        ' Must be sent as an array of strings. Valid inputs in the array: PATHVARIABLE, QUERYPARAM,' +
-        ' HEADER, BODY, RESPONSE_HEADER, RESPONSE_BODY',
+        ' Must be sent as an array of strings. Valid inputs in the array: ' +
+        ' BODY, RESPONSE_BODY, SOAP_METHOD',
       external: true,
       usage: ['VALIDATION']
     }

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -6,7 +6,12 @@ const expect = require('chai').expect,
   validWSDLs20 = 'test/data/validWSDLs20',
   fs = require('fs'),
   getAllTransactions = require('../../lib/utils/getAllTransactions').getAllTransactions,
-  async = require('async');
+  async = require('async'),
+  optionIds = [
+    'folderStrategy',
+    'validateHeader',
+    'validationPropertiesToIgnore'
+  ];
 
 describe('SchemaPack convert unit test WSDL 1.1', function () {
   var validWSDLsFolder = fs.readdirSync(validWSDLs);
@@ -168,16 +173,27 @@ describe('SchemaPack convert unit test WSDL 2.0', function () {
 
 describe('SchemaPack getOptions', function () {
 
-  it('Should return external options when called without parameters', function () {
+  it('must have a valid structure', function () {
     const options = SchemaPack.getOptions();
-    expect(options).to.be.an('array');
-    expect(options.length).to.eq(2);
+    options.forEach((option) => {
+      expect(option).to.have.property('name');
+      expect(option).to.have.property('id');
+      expect(option).to.have.property('type');
+      expect(option).to.have.property('default');
+      expect(option).to.have.property('description');
+    });
+  });
+
+  it('Should return external options when called without parameters', function () {
+    SchemaPack.getOptions().forEach((option) => {
+      expect(option.id).to.be.oneOf(optionIds);
+    });
   });
 
   it('Should return external options when called with mode = document', function () {
     const options = SchemaPack.getOptions('document');
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(2);
+    expect(options.length).to.eq(3);
   });
 
   it('Should return external options when called with mode = use', function () {
@@ -188,19 +204,21 @@ describe('SchemaPack getOptions', function () {
   });
 
   it('Should return external options when called with criteria usage conversion', function () {
-    const options = SchemaPack.getOptions({
+    SchemaPack.getOptions({
       usage: ['CONVERSION']
+    }).forEach((option) => {
+      expect(option.id).to.be.oneOf(optionIds);
+      expect(option.usage).to.include('CONVERSION');
     });
-    expect(options).to.be.an('array');
-    expect(options.length).to.eq(1);
   });
 
   it('Should return external options when called with criteria usage validation', function () {
-    const options = SchemaPack.getOptions({
+    SchemaPack.getOptions({
       usage: ['VALIDATION']
+    }).forEach((option) => {
+      expect(option.id).to.be.oneOf(optionIds);
+      expect(option.usage).to.include('VALIDATION');
     });
-    expect(options).to.be.an('array');
-    expect(options.length).to.eq(1);
   });
 
   it('Should return external options when called with mode use and usage conversion', function () {
@@ -223,7 +241,16 @@ describe('SchemaPack getOptions', function () {
   it('Should return external options when called with mode document and usage not an object', function () {
     const options = SchemaPack.getOptions('document', 2);
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(2);
+    expect(options.length).to.eq(3);
+  });
+
+  it('Should return default empty array in validationPropertiesToIgnore', function () {
+    const options = SchemaPack.getOptions('use', {
+      usage: ['VALIDATION']
+    });
+    expect(options).to.be.an('object');
+    expect(options).to.haveOwnProperty('validationPropertiesToIgnore');
+    expect(options.validationPropertiesToIgnore).to.be.empty;
   });
 
 });

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -700,7 +700,7 @@ describe('Validate Headers', function () {
   });
 
   it('Should not return bad header mismatch when validateContentType option is set explicitly on false' +
-  ' and content-type header is not text/xml', function () {
+    ' and content-type header is not text/xml', function () {
     const options = {
         validateContentType: false
       },
@@ -819,7 +819,7 @@ describe('validateBody method', function () {
       return newMismatch;
     },
     getExpectedWithMismatchInEndpoint = (expectedBase, itemId, mismatch, type = 'request') => {
-      let newExpected = Object.assign({}, expectedBase);
+      let newExpected = JSON.parse(JSON.stringify(expectedBase));
       if (type === 'request') {
         newExpected.matched = false;
         newExpected.requests[itemId].endpoints[0].mismatches = [mismatch];
@@ -907,6 +907,7 @@ describe('validateBody method', function () {
         new XMLParser());
     expect(result).to.be.an('object').and.to.deep.include(expectedBase);
   });
+
   it('Should have a mismatch when a request endpoint has a type error in body', function () {
     const transactionValidator = new TransactionValidator(),
       result = transactionValidator.validateTransaction(
@@ -1279,7 +1280,7 @@ describe('validateBody method', function () {
     });
   });
 
-  it('Should have a mismatch sdfdsfdfdf', function () {
+  it('Should have a mismatch when called with empty tag with spaces between', function () {
     const transactionValidator = new TransactionValidator(),
       result = transactionValidator.validateTransaction(
         getMatchDetailsCollectionItems,
@@ -1312,6 +1313,75 @@ describe('validateBody method', function () {
                         ' because the content type is empty.\n'
                     }
                   ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      missingEndpoints: [
+      ]
+    });
+  });
+
+  it('Shouldn\'t have a mismatch when is a type error in body and option validationPropertiesToIgnore has "BODY"',
+    function () {
+      const transactionValidator = new TransactionValidator(),
+        result = transactionValidator.validateTransaction(
+          numberToWordsCollectionItemsBodyWrongType,
+          numberToWordsWSDLObject, new XMLParser(),
+          { validationPropertiesToIgnore: ['BODY'] }
+        );
+      expect(result).to.be.an('object').and.to.deep.include(expectedBase);
+    });
+
+  it('Shouldn\'t have a mismatch when a request endpoint body has not complete all required fields' +
+    ' and option validationPropertiesToIgnore has "BODY"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(
+        numberToWordsCollectionItemsBodyIncomplete,
+        numberToWordsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['BODY'] }
+      );
+    expect(result).to.be.an('object').and.to.deep.include(expectedBase);
+  });
+
+  it('Shouldn\'t have a mismatch when a request endpoint body has more fields than expected' +
+    ' and option validationPropertiesToIgnore has "BODY"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(
+        numberToWordsCollectionItemsBodyMoreFields,
+        numberToWordsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['BODY'] }
+      );
+    expect(result).to.be.an('object').and.to.deep.include(expectedBase);
+  });
+
+  it('Shouldn\'t have a mismatch when called with empty tag with spaces between' +
+  ' and option validationPropertiesToIgnore has "BODY"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(
+        getMatchDetailsCollectionItems,
+        getMatchDetailsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['RESPONSE_BODY'] }
+      );
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '1a8221fe-3d87-4a7f-8667-483b75b809e0': {
+          requestId: '1a8221fe-3d87-4a7f-8667-483b75b809e0',
+          endpoints: [
+            {
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap getMatchDetails',
+              mismatches: [
+              ],
+              responses: {
+                '5bd6970c-5011-4fb6-941e-fc534057be74': {
+                  id: '5bd6970c-5011-4fb6-941e-fc534057be74',
+                  matched: true,
+                  mismatches: []
                 }
               }
             }

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -1194,7 +1194,7 @@ describe('validateBody method', function () {
     });
   });
 
-  it('Should have a mismatch when a response endpoint has empty body', function () {
+  it('Should have a mismatch when an endpoint response\'s  has empty body', function () {
     const transactionValidator = new TransactionValidator(),
       result = transactionValidator.validateTransaction(
         numberToWordsCollectionItemsResponseBodyLess,
@@ -1358,7 +1358,7 @@ describe('validateBody method', function () {
   });
 
   it('Shouldn\'t have a mismatch when called with empty tag with spaces between' +
-  ' and option validationPropertiesToIgnore has "BODY"', function () {
+  ' and option validationPropertiesToIgnore has "RESPONSE_BODY"', function () {
     const transactionValidator = new TransactionValidator(),
       result = transactionValidator.validateTransaction(
         getMatchDetailsCollectionItems,
@@ -1390,6 +1390,243 @@ describe('validateBody method', function () {
       },
       missingEndpoints: [
       ]
+    });
+  });
+
+  it('Shouldn\'t have a mismatch when a response endpoint has not an required field in body' +
+    ' and option validationPropertiesToIgnore has "RESPONSE_BODY"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(
+        numberToWordsCollectionItemsResponseBodyIncomplete,
+        numberToWordsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['RESPONSE_BODY'] }
+      );
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+  it('Shouldn\'t have a mismatch when a response endpoint has more fields than schema' +
+  ' and option validationPropertiesToIgnore has "RESPONSE_BODY"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(
+        numberToWordsCollectionItemsResponseBodyMoreFields,
+        numberToWordsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['RESPONSE_BODY'] }
+      );
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+  it('Should have a mismatch when an endpoint response\'s  has empty body' +
+  ' and option validationPropertiesToIgnore has "RESPONSE_BODY"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(
+        numberToWordsCollectionItemsResponseBodyLess,
+        numberToWordsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['RESPONSE_BODY'] }
+      );
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
     });
   });
 });
@@ -1492,6 +1729,83 @@ describe('soapMethodValidation', function () {
                 'transactionJsonPath': '$.request.method'
               }
             ],
+            responses: {
+              'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+        }
+      }
+    });
+  });
+
+  it('Shouldn\'t  have a mismatch when item request has a different method than POST in a /soap12 request' +
+  ' and option validationPropertiesToIgnore has "HTTP_METHOD"', function () {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsGET,
+        numberToWordsWSDLObject, new XMLParser(),
+        { validationPropertiesToIgnore: ['SOAP_METHOD'] });
+    expect(result).to.be.an('object').and.to.deep.include({
+      matched: true,
+      requests: {
+        '18403328-4213-4c3e-b0e9-b21a636697c3': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToDollars',
+            mismatches: [],
+            responses: {
+              '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+        },
+        '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap12 NumberToWords',
+            mismatches: [],
+            responses: {
+              'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+        },
+        '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToDollars',
+            mismatches: [],
+            responses: {
+              '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                matched: true,
+                mismatches: []
+              }
+            }
+          }],
+          requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+        },
+        'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+          endpoints: [{
+            matched: true,
+            endpointMatchScore: 1,
+            endpoint: 'POST soap NumberToWords',
+            mismatches: [],
             responses: {
               'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
                 id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',

--- a/test/unit/WsdlInformationService11.test.js
+++ b/test/unit/WsdlInformationService11.test.js
@@ -418,7 +418,7 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace);
     expect(bindingInfo.protocol).to.equal(SOAP_PROTOCOL);
@@ -502,7 +502,7 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace);
     expect(bindingInfo.protocol).to.equal(SOAP12_PROTOCOL);
@@ -577,7 +577,7 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(
         binding,
@@ -725,7 +725,7 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
       let parsed = xmlParser.parseToObject(simpleInput),
         binding = getBindings(
           parsed,
-          informationService.getRootTagName()
+          informationService.RootTagName
         )[0];
       informationService.getBindingInfoFromBindingTag(binding, undefined, undefined);
       assert.fail('we expected an error');
@@ -806,7 +806,7 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace, null);
     expect(bindingInfo.protocol).to.equal(SOAP_PROTOCOL);
@@ -892,7 +892,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace),
       operation = {};
@@ -978,7 +978,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace),
       operation = {};
@@ -1075,7 +1075,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(
         binding,
@@ -1177,7 +1177,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(
         binding,
@@ -1285,7 +1285,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(
         binding,
@@ -1388,7 +1388,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     let parsed = xmlParser.parseToObject(simpleInput),
       binding = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       )[0],
       bindingInfo = informationService.getBindingInfoFromBindingTag(
         binding,
@@ -1485,7 +1485,7 @@ describe('WSDL 1.1 parser getServiceAndExpossedInfoByBindingName', function () {
       informationService = new WsdlInformationService11(),
       xmlParser = new XMLParser();
     let parsed = xmlParser.parseToObject(simpleInput);
-    services = getServices(parsed, informationService.getRootTagName());
+    services = getServices(parsed, informationService.RootTagName);
     service = informationService.getServiceAndExpossedInfoByBindingName(
       'NumberConversionSoapBinding',
       services,
@@ -1665,7 +1665,7 @@ describe('WSDL 1.1 parser getAbstractOperationByName', function () {
       informationService = new WsdlInformationService11(),
       xmlParser = new XMLParser();
     let parsed = xmlParser.parseToObject(simpleInput);
-    services = getServices(parsed, informationService.getRootTagName());
+    services = getServices(parsed, informationService.RootTagName);
     service = informationService.getAbstractOperationByName('NumberConversionSoapType',
       'NumberToWords', parsed, '');
     expect(service).to.be.an('object');

--- a/test/unit/WsdlInformationService20.test.js
+++ b/test/unit/WsdlInformationService20.test.js
@@ -182,7 +182,7 @@ describe('WSDL 2.0 parser getAbstractOperationByName', function () {
     const informationService = new WsdlInformationService20(),
       xmlParser = new XMLParser();
     let parsed = xmlParser.parseToObject(WSDL_SAMPLE);
-    services = getServices(parsed, informationService.getRootTagName());
+    services = getServices(parsed, informationService.RootTagName);
     operation = informationService.getAbstractOperationByName('reservationInterface',
       'opCheckAvailability', parsed, '');
     expect(operation).to.be.an('object');
@@ -193,7 +193,7 @@ describe('WSDL 2.0 parser getAbstractOperationByName', function () {
     const informationService = new WsdlInformationService20(),
       xmlParser = new XMLParser();
     let parsed = xmlParser.parseToObject(WSDL_SAMPLE_AXIS);
-    services = getServices(parsed, informationService.getRootTagName());
+    services = getServices(parsed, informationService.RootTagName);
     operation = informationService.getAbstractOperationByName('ServiceInterface',
       'hi', parsed, 'wsdl2:');
     expect(operation).to.be.an('object');
@@ -352,7 +352,7 @@ describe('WSDL 2.0 parser  getBindingInfoFromBindingTag', function () {
       let parsed = xmlParser.parseToObject(WSDL_SAMPLE),
         binding = getBindings(
           parsed,
-          informationService.getRootTagName()
+          informationService.RootTagName
         )[0];
       informationService.getBindingInfoFromBindingTag(binding, undefined, undefined);
       assert.fail('we expected an error');
@@ -370,7 +370,7 @@ describe('WSDL 2.0 getServiceAndExpossedInfoByBindingName', function () {
     let parsed = xmlParser.parseToObject(WSDL_SAMPLE),
       services = getServices(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       ),
       serviceEndpoint = informationService.getServiceAndExpossedInfoByBindingName(
         'reservationSOAPBinding',
@@ -387,7 +387,7 @@ describe('WSDL 2.0 getServiceAndExpossedInfoByBindingName', function () {
     let parsed = xmlParser.parseToObject(WSDL_SAMPLE_AXIS),
       services = getServices(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       ),
       serviceEndpoint = informationService.getServiceAndExpossedInfoByBindingName(
         'SayHelloSoap11Binding',

--- a/test/unit/WsdlToPostmanCollectionMapper.test.js
+++ b/test/unit/WsdlToPostmanCollectionMapper.test.js
@@ -226,6 +226,7 @@ describe('WsdlToPostmanCollectionMapper constructor', function () {
       let mapper = new WsdlToPostmanCollectionMapper(nullWsdl);
       assert.fail('We expect an error');
       return mapper;
+
     }
     catch (error) {
       expect(error.message).to.equal(expectedMessage);

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -13,7 +13,7 @@ describe('Index getOptions', function () {
   it('Should return external options when called without parameters', function () {
     const options = getOptions();
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(2);
+    expect(options).to.not.be.empty;
   });
 });
 

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -1271,7 +1271,7 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
       expect(wsdlObject.allNameSpaces).to.be.an('array');
       expect(wsdlObject.allNameSpaces.length).to.equal(6);
       xmlns = wsdlObject.allNameSpaces.find((namespace) => {
-        return namespace.url === parser.informationService.getWSDLNamespaceURL();
+        return namespace.url === parser.informationService.WSDLNamespaceURL;
       });
       expect(xmlns.isDefault).to.equal(true);
       // asserts on namespaces
@@ -1348,7 +1348,7 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
       expect(wsdlObject.allNameSpaces).to.be.an('array');
       expect(wsdlObject.allNameSpaces.length).to.equal(7);
       xmlns = wsdlObject.allNameSpaces.find((namespace) => {
-        return namespace.url === informationService.getWSDLNamespaceURL();
+        return namespace.url === informationService.WSDLNamespaceURL;
       });
       expect(xmlns.isDefault).to.equal(true);
       // asserts on namespaces

--- a/test/unit/wsdlParserComon.test.js
+++ b/test/unit/wsdlParserComon.test.js
@@ -273,8 +273,8 @@ describe('WSDL parser common getNamespaceByKey', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByKey(
         parsed,
-        informationService.getTargetNamespaceKey(),
-        informationService.getRootTagName()
+        informationService.TargetNamespaceKey,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('targetNamespace');
@@ -296,8 +296,8 @@ describe('WSDL parser common getNamespaceByKey', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByKey(
         parsed,
-        informationService.getTHISNamespaceKey(),
-        informationService.getRootTagName()
+        informationService.THISNamespaceKey,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('tns');
@@ -319,11 +319,11 @@ describe('WSDL parser common getNamespaceByKey', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByKey(
         parsed,
-        informationService.getTargetNamespaceKey(),
-        informationService.getRootTagName()
+        informationService.TargetNamespaceKey,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
-    expect(wsdlnamespace.key).to.equal(informationService.getTargetNamespaceKey());
+    expect(wsdlnamespace.key).to.equal(informationService.TargetNamespaceKey);
     expect(wsdlnamespace.url).to.equal('http://www.dataaccess.com/webservicesserver/');
     expect(wsdlnamespace.isDefault).to.equal(false);
   });
@@ -344,7 +344,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       getNamespaceByKey(
         parsed,
         '',
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -369,7 +369,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       getNamespaceByKey(
         parsed,
         null,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -394,7 +394,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       getNamespaceByKey(
         parsed,
         undefined,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -408,8 +408,8 @@ describe('WSDL parser common getNamespaceByKey', function () {
     try {
       getNamespaceByKey(
         undefined,
-        informationService.getTargetNamespaceKey(),
-        informationService.getRootTagName()
+        informationService.TargetNamespaceKey,
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -422,8 +422,8 @@ describe('WSDL parser common getNamespaceByKey', function () {
     const informationService = new WsdlInformationService11();
     try {
       getNamespaceByKey({},
-        informationService.getTargetNamespaceKey(),
-        informationService.getRootTagName()
+        informationService.TargetNamespaceKey,
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -451,7 +451,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       wsdlnamespace = getNamespaceByKey(
         parsed,
         'xmlns:tns',
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('tns');
@@ -479,7 +479,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       getNamespaceByKey(
         parsed,
         '',
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -508,7 +508,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       getNamespaceByKey(
         parsed,
         null,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -537,7 +537,7 @@ describe('WSDL parser common getNamespaceByKey', function () {
       getNamespaceByKey(
         parsed,
         undefined,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
       assert.fail('we expected an error');
     }
@@ -612,7 +612,7 @@ describe('WSDL parser common getServices', function () {
     let parsed = parser.parseToObject(simpleInput),
       services = getServices(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(services).to.be.an('array');
     expect(services.length).to.equal(1);
@@ -688,7 +688,7 @@ describe('WSDL parser common getServices', function () {
     let parsed = parser.parseToObject(simpleInput),
       services = getServices(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(services).to.be.an('array');
     expect(services.length).to.equal(2);
@@ -734,7 +734,7 @@ describe('WSDL parser common getServices', function () {
     let parsed = parser.parseToObject(WSDL_SAMPLE),
       services = getServices(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(services).to.be.an('array');
     expect(services.length).to.equal(1);
@@ -747,7 +747,7 @@ describe('WSDL parser common getServices', function () {
     let parsed = parser.parseToObject(WSDL_SAMPLE_AXIS),
       services = getServices(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(services).to.be.an('array');
     expect(services.length).to.equal(1);
@@ -845,7 +845,7 @@ describe('WSDL parser common getBindings', function () {
     let parsed = parser.parseToObject(simpleInput),
       bindings = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(bindings).to.be.an('array');
     expect(bindings.length).to.equal(2);
@@ -916,7 +916,7 @@ describe('WSDL parser common getBindings', function () {
     let parsed = parser.parseToObject(simpleInput),
       bindings = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(bindings).to.be.an('array');
     expect(bindings.length).to.equal(1);
@@ -963,7 +963,7 @@ describe('WSDL parser common getBindings', function () {
     let parsed = parser.parseToObject(WSDL_SAMPLE),
       bindings = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(bindings).to.be.an('array');
     expect(bindings.length).to.equal(1);
@@ -976,7 +976,7 @@ describe('WSDL parser common getBindings', function () {
     let parsed = parser.parseToObject(WSDL_SAMPLE_AXIS),
       bindings = getBindings(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(bindings).to.be.an('array');
     expect(bindings.length).to.equal(3);
@@ -1085,12 +1085,12 @@ describe('WSDL parser common getNamespaceByURL', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByURL(
         parsed,
-        informationService.getWSDLNamespaceURL(),
-        informationService.getRootTagName()
+        informationService.WSDLNamespaceURL,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('xmlns');
-    expect(wsdlnamespace.url).to.equal(informationService.getWSDLNamespaceURL());
+    expect(wsdlnamespace.url).to.equal(informationService.WSDLNamespaceURL);
     expect(wsdlnamespace.isDefault).to.equal(true);
 
   });
@@ -1162,12 +1162,12 @@ describe('WSDL parser common getNamespaceByURL', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByURL(
         parsed,
-        informationService.getWSDLNamespaceURL(),
-        informationService.getRootTagName()
+        informationService.WSDLNamespaceURL,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('wsdl');
-    expect(wsdlnamespace.url).to.equal(informationService.getWSDLNamespaceURL());
+    expect(wsdlnamespace.url).to.equal(informationService.WSDLNamespaceURL);
     expect(wsdlnamespace.isDefault).to.equal(false);
 
   });
@@ -1193,12 +1193,12 @@ describe('WSDL parser common getNamespaceByURL', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByURL(
         parsed,
-        informationService.getSOAPNamespaceURL(),
-        informationService.getRootTagName()
+        informationService.SOAPNamesapceURL,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('soap');
-    expect(wsdlnamespace.url).to.equal(informationService.getSOAPNamespaceURL());
+    expect(wsdlnamespace.url).to.equal(informationService.SOAPNamesapceURL);
     expect(wsdlnamespace.isDefault).to.equal(false);
   });
 
@@ -1224,12 +1224,12 @@ describe('WSDL parser common getNamespaceByURL', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByURL(
         parsed,
-        informationService.getSOAP12NamespaceURL(),
-        informationService.getRootTagName()
+        informationService.SOAP12NamesapceURL,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('soap12');
-    expect(wsdlnamespace.url).to.equal(informationService.getSOAP12NamespaceURL());
+    expect(wsdlnamespace.url).to.equal(informationService.SOAP12NamesapceURL);
     expect(wsdlnamespace.isDefault).to.equal(false);
   });
 
@@ -1255,13 +1255,13 @@ describe('WSDL parser common getNamespaceByURL', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByURL(
         parsed,
-        informationService.getSchemaNamespaceURL(),
-        informationService.getRootTagName()
+        informationService.SchemaNamespaceURL,
+        informationService.RootTagName
 
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('xs');
-    expect(wsdlnamespace.url).to.equal(informationService.getSchemaNamespaceURL());
+    expect(wsdlnamespace.url).to.equal(informationService.SchemaNamespaceURL);
     expect(wsdlnamespace.isDefault).to.equal(false);
   });
 
@@ -1415,8 +1415,8 @@ describe('WSDL parser common getNamespaceByURL', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getNamespaceByURL(
         parsed,
-        informationService.getWSDLNamespaceURL(),
-        informationService.getRootTagName()
+        informationService.WSDLNamespaceURL,
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.equal(null);
   });
@@ -1440,7 +1440,7 @@ describe('WSDL parser common getNamespaceByURL', function () {
       wsdlnamespace = getNamespaceByURL(
         parsed,
         'http://www.w3.org/ns/wsdl/soap',
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('wsoap');
@@ -1468,7 +1468,7 @@ describe('WSDL parser common getNamespaceByURL', function () {
       wsdlnamespace = getNamespaceByURL(
         parsed,
         'http://www.w3.org/ns/wsdl',
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('object');
     expect(wsdlnamespace.key).to.equal('xmlns');
@@ -1497,12 +1497,12 @@ describe('WSDL parser common getAllNamespaces', function () {
       parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getAllNamespaces(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('array');
     expect(wsdlnamespace.length).to.equal(6);
     xmlns = wsdlnamespace.find((namespace) => {
-      return namespace.url === informationService.getWSDLNamespaceURL();
+      return namespace.url === informationService.WSDLNamespaceURL;
     });
     expect(xmlns.isDefault).to.equal(true);
   });
@@ -1543,7 +1543,7 @@ describe('WSDL parser common getAllNamespaces', function () {
       expect(wsdlnamespace).to.be.an('array');
       expect(wsdlnamespace.length).to.equal(6);
       wsdlnamespace.find((namespace) => {
-        return namespace.url === informationService.getWSDLNamespaceURL();
+        return namespace.url === informationService.WSDLNamespaceURL;
       });
     }
     catch (error) {
@@ -1567,12 +1567,12 @@ describe('WSDL parser common getAllNamespaces', function () {
       parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getAllNamespaces(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('array');
     expect(wsdlnamespace.length).to.equal(6);
     xmlns = wsdlnamespace.find((namespace) => {
-      return namespace.url === informationService.getWSDLNamespaceURL();
+      return namespace.url === informationService.WSDLNamespaceURL;
     });
     expect(xmlns.isDefault).to.equal(true);
   });
@@ -1598,7 +1598,7 @@ describe('WSDL parser common getAllNamespaces', function () {
     let parsed = parser.parseToObject(simpleInput),
       wsdlnamespace = getAllNamespaces(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(wsdlnamespace).to.be.an('array');
     expect(wsdlnamespace.length).to.equal(11);
@@ -1623,7 +1623,7 @@ describe('WSDL parser common getPrincipalPrefix', function () {
     let parsed = parser.parseToObject(simpleInput),
       principalPrefix = getPrincipalPrefix(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(principalPrefix).to.equal('');
 
@@ -1644,7 +1644,7 @@ describe('WSDL parser common getPrincipalPrefix', function () {
     let parsed = parser.parseToObject(simpleInput),
       principalPrefix = getPrincipalPrefix(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(principalPrefix).to.equal('wsdl:');
 
@@ -1703,7 +1703,7 @@ describe('WSDL parser common getPrincipalPrefix', function () {
     let parsed = parser.parseToObject(simpleInput),
       principalPrefix = getPrincipalPrefix(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(principalPrefix).to.equal('');
   });
@@ -1724,7 +1724,7 @@ describe('WSDL parser common getPrincipalPrefix', function () {
     let parsed = parser.parseToObject(simpleInput),
       principalPrefix = getPrincipalPrefix(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(principalPrefix).to.equal('wsdl2:');
   });
@@ -1774,7 +1774,7 @@ describe('WSDL parser common getElementsFromWSDL', function () {
       elements = getElementsFromWSDL(
         parsed,
         '',
-        informationService.getRootTagName(),
+        informationService.RootTagName,
         schemaNameSpace,
         thisNameSpace
       );
@@ -1802,7 +1802,7 @@ describe('WSDL parser common getElementsFromWSDL', function () {
       elements = getElementsFromWSDL(
         parsed,
         'wsdl2:',
-        informationService.getRootTagName(),
+        informationService.RootTagName,
         schemaNameSpace,
         thisNameSpace
       );
@@ -1833,7 +1833,7 @@ describe('WSDL parser common getWSDLDocumentation', function () {
     let parsed = parser.parseToObject(WSDL_1_1),
       documentation = getWSDLDocumentation(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(documentation).to.equal('This document describes number convertion service');
   });
@@ -1844,7 +1844,7 @@ describe('WSDL parser common getWSDLDocumentation', function () {
     let parsed = parser.parseToObject(WSDL_SAMPLE_AXIS),
       documentation = getWSDLDocumentation(
         parsed,
-        informationService.getRootTagName()
+        informationService.RootTagName
       );
     expect(documentation).to.equal('Please Type your service description here');
   });


### PR DESCRIPTION
Add support for option
validationPropertiesToIgnore
type array	-	default []	Specific properties (parts of a request/response pair) to ignore during validation. Must be sent as an array of strings. Valid inputs in the array: ,  BODY, RESPONSE_BODY, SOAP_METHOD

in WSDL To Postman do not validate query params neither path Variable (in SOAP WSDL urls are fixed and described in service/port/address)

For now header for requests and responses is validated according to the validateHeader option, merge this option to the validationPropertiesToIgnore options will be discussed and added as a task if needed