### PR TITLE
Fix validateTransactionName

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -109,7 +109,7 @@ class SchemaPack {
    * @param {*} callback return
    * @returns {boolean} validation
    */
-  validateTransactions(transactions, callback) {
+  validateTransaction(transactions, callback) {
     this.validate();
 
     const parser = new ParserFactory().getParser(this.input.data),

--- a/test/convert-validation/ValidationReport.test.js
+++ b/test/convert-validation/ValidationReport.test.js
@@ -39,7 +39,7 @@ describe('SchemaPack convert and validate report missmatches WSDL 1.1', function
           historyRequest.request.url.host = collectionResult.output[0].data.variable[0].value;
         });
 
-        schemaPack.validateTransactions(historyRequests, (error, result) => {
+        schemaPack.validateTransaction(historyRequests, (error, result) => {
           if (error) {
             console.error(`Test Failed ${file}`);
             fs.writeFileSync(outputDirectory + file + '-validationResult.json', JSON.stringify(error));

--- a/test/convert-validation/validateTransactions.test.js
+++ b/test/convert-validation/validateTransactions.test.js
@@ -22,32 +22,32 @@ describe('Test validate Transactions method in SchemaPack', function () {
   }, options);
 
   it('Should return an error when the Requests are null in the Collection', function () {
-    schemaPack.validateTransactions(nullRequestCollectionItems, (error) => {
+    schemaPack.validateTransaction(nullRequestCollectionItems, (error) => {
       expect(error.message).to.equal('Invalid syntax provided for requestList');
     });
   });
 
   it('Should return an error when there is not Id Collection', function () {
-    schemaPack.validateTransactions(notIdCollectionItems, (error) => {
+    schemaPack.validateTransaction(notIdCollectionItems, (error) => {
       expect(error.message).to.equal('Required field is null, empty or undefined');
     });
   });
 
   it('Should return an error when the Requests are empty in the Collection', function () {
-    schemaPack.validateTransactions(emptyRequestCollectionItems, (error) => {
+    schemaPack.validateTransaction(emptyRequestCollectionItems, (error) => {
       expect(error.message).to.equal('Required field is null, empty or undefined');
     });
   });
 
   it('Should validate when validateContentType option is true ' +
-    'and Header Content-Type was not found in the transaction', function() {
+    'and Header Content-Type was not found in the transaction', function () {
     const options = {
         validateContentType: true
       },
       schemaPackWithOptions = new SchemaPack({
         type: 'string', data: fileContent
       }, options);
-    schemaPackWithOptions.validateTransactions(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
+    schemaPackWithOptions.validateTransaction(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object').and.to.deep.include({
         matched: false,
@@ -134,14 +134,14 @@ describe('Test validate Transactions method in SchemaPack', function () {
   });
 
   it('Should validate when validateContentType option is true' +
-    ' and Header is other than text/xml', function() {
+    ' and Header is other than text/xml', function () {
     const options = {
         validateContentType: true
       },
       schemaPackWithOptions = new SchemaPack({
         type: 'string', data: fileContent
       }, options);
-    schemaPackWithOptions.validateTransactions(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
+    schemaPackWithOptions.validateTransaction(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object').and.to.deep.include({
         matched: false,
@@ -230,8 +230,8 @@ describe('Test validate Transactions method in SchemaPack', function () {
   });
 
   it('Should not validate header when validateContentType option is not provided (false by default) ' +
-    'and Header Content-Type was not found in the transaction', function() {
-    schemaPack.validateTransactions(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
+    'and Header Content-Type was not found in the transaction', function () {
+    schemaPack.validateTransaction(numberToWordsCollectionItemsNoCTHeader, (error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object').and.to.deep.include({
         matched: true,
@@ -306,8 +306,8 @@ describe('Test validate Transactions method in SchemaPack', function () {
   });
 
   it('Should not validate header when validateContentType option is not provided (false by default) ' +
-    ' and Header is other than text/xml', function() {
-    schemaPack.validateTransactions(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
+    ' and Header is other than text/xml', function () {
+    schemaPack.validateTransaction(numberToWordsCollectionItemsCTHeaderNXML, (error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object').and.to.deep.include({
         matched: true,
@@ -386,7 +386,7 @@ describe('Test validate Transactions method in SchemaPack', function () {
       expect(error).to.be.null;
       expect(result).to.be.an('object');
 
-      schemaPack.validateTransactions(numberToWordsCollectionItems, (error, result) => {
+      schemaPack.validateTransaction(numberToWordsCollectionItems, (error, result) => {
         expect(error).to.be.null;
         expect(result).to.be.an('object');
       });

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -255,7 +255,7 @@ describe('SchemaPack getOptions', function () {
 
 });
 
-describe('validateTransactions method', function () {
+describe('validateTransaction method', function () {
   const notIdCollectionItems = require('./../data/transactionsValidation/notIdCollectionItems.json');
   it('Should return an error when transactions id is null', function () {
     const
@@ -264,7 +264,7 @@ describe('validateTransactions method', function () {
         type: 'file',
         data: VALID_WSDL_PATH
       }, {});
-    schemaPack.validateTransactions(notIdCollectionItems, (error) => {
+    schemaPack.validateTransaction(notIdCollectionItems, (error) => {
       expect(error.message).to.equal('Invalid syntax provided for requestList');
     });
   });
@@ -289,7 +289,7 @@ describe('validateTransactions method', function () {
         historyRequest.request.url.host = 'http://www.dneonline.com';
       });
 
-      schemaPack.validateTransactions(historyRequests, (error, result) => {
+      schemaPack.validateTransaction(historyRequests, (error, result) => {
         expect(error).to.be.null;
         expect(result).to.be.an('object');
       });


### PR DESCRIPTION
 Currently we have validateTransactions as name of API exposed for validation against schema in wsdl-to-postman.
This should be validateTransaction as defined in openapi module.

Change wsdl-to-postman/lib/SchemaPack.js  validateTransactions(transactions, callback) { to  validateTransaction(transactions, callback) {

change every reference to point the new name.