### PR TITLE
Support schema namespace local

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -257,7 +257,7 @@ class TransactionValidator {
 
     if (rawXmlMessage) {
       const parsedXml = wsdlObject.xmlParsed,
-        cleanSchema = getCleanSchema(parsedXml, wsdlObject.schemaNamespace, wsdlObject.version),
+        cleanSchema = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version),
         errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
       if (errors.length > 0) {
         let filteredErrors = this.filterSchemaValidationErrors(errors, options);

--- a/lib/WSDLObject.js
+++ b/lib/WSDLObject.js
@@ -24,6 +24,7 @@ class WsdlObject {
     this.xmlParsed = '';
     this.version = '';
     this.documentation = '';
+    this.localSchemaNamespaces = '';
   }
 }
 

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -262,7 +262,7 @@ class WsdlInformationService11 {
       };
     }
     catch (error) {
-      throw new WsdlError('Cannot get service port from object');
+      throw new WsdlError('Cannot get service port from WSDL');
     }
   }
 
@@ -303,7 +303,7 @@ class WsdlInformationService11 {
       return operationReturn;
     }
     catch (error) {
-      throw new WsdlError('Cannot get port type from object');
+      throw new WsdlError('Cannot get port type from WSDL');
     }
   }
 
@@ -377,7 +377,7 @@ class WsdlInformationService11 {
       return portTtypes[principalPrefix + OPERATION_TAG];
     }
     catch (error) {
-      throw new WsdlError('Cannot get portypes from object');
+      throw new WsdlError('Cannot get portypes from WSDL');
     }
   }
 
@@ -404,7 +404,7 @@ class WsdlInformationService11 {
         }
       });
     if (namespace === undefined) {
-      throw new WsdlError('Cannot get binding from object');
+      throw new WsdlError('Cannot get binding from WSDL');
     }
     const protocolKey = getQNamePrefix(namespace);
     protocolPrefix = getQNamePrefixFilter(namespace);

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -313,7 +313,7 @@ class WsdlInformationService20 {
       };
     }
     catch (error) {
-      throw new WsdlError('Cannot get service endpoint from object');
+      throw new WsdlError('Cannot get service endpoint from WSDL');
     }
   }
 
@@ -351,7 +351,7 @@ class WsdlInformationService20 {
       return operationReturn;
     }
     catch (error) {
-      throw new WsdlError('Cannot get port type from object');
+      throw new WsdlError('Cannot get port type from WSDL');
     }
   }
 
@@ -379,7 +379,7 @@ class WsdlInformationService20 {
       return WSDLFoundInterface;
     }
     catch (error) {
-      throw new WsdlError('Cannot get interface from object');
+      throw new WsdlError('Cannot get interface from WSDL');
     }
   }
 

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -65,7 +65,8 @@ class WsdlParser {
         this.informationService.RootTagName),
       soap12Namespace = getNamespaceByKey(parsedXml, this.informationService.SOAP12NamespaceKey,
         this.informationService.RootTagName),
-      schemaNamespace = getSchemaNamespace(parsedXml, this.informationService.RootTagName),
+      { globalSchemaNamespace, localSchemaNamespaces } = getSchemaNamespace(parsedXml,
+        this.informationService.RootTagName),
       HTTPNamespace = getNamespaceByKey(parsedXml, this.informationService.HTTPNamespaceKey,
         this.informationService.RootTagName),
       tnsNamespace = getNamespaceByKey(parsedXml, this.informationService.THISNamespaceKey,
@@ -80,7 +81,8 @@ class WsdlParser {
     newWsdlObject.SOAPNamespace = soapNamespace;
     newWsdlObject.SOAP12Namespace = soap12Namespace;
     newWsdlObject.SOAP12Namespace = soap12Namespace;
-    newWsdlObject.schemaNamespace = schemaNamespace;
+    newWsdlObject.schemaNamespace = globalSchemaNamespace;
+    newWsdlObject.localSchemaNamespaces = localSchemaNamespaces;
     newWsdlObject.tnsNamespace = tnsNamespace;
     newWsdlObject.allNameSpaces = allNameSpaces;
     newWsdlObject.HTTPNamespace = HTTPNamespace;
@@ -128,7 +130,7 @@ class WsdlParser {
       services = getServices(parsedXml, this.informationService.RootTagName),
       bindings = getBindings(parsedXml, this.informationService.RootTagName, wsdlObject),
       elements = getElementsFromWSDL(parsedXml, principalPrefix, this.informationService.RootTagName,
-        wsdlObject.schemaNamespace, wsdlObject.tnsNamespace);
+        wsdlObject);
 
     bindings.forEach((binding) => {
       const bindingTagInfo =

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -244,20 +244,52 @@ function getBindings(parsedXml, wsdlRoot, wsdlObject) {
  * @param {object} parsedXml the binding operation object
  * @param {string} principalPrefix the wsdl prefix
  * @param {string} wsdlRoot the wsdl root
- * @param {Namespace} schemaNameSpace the schema Namespace
- * @param {Namespace} thisNameSpace the Namespace of tns
+ * @param {Namespace} wsdlObject the wsdl memory parsed object
  * @returns {Array} the [elements] object
  */
-function getElementsFromWSDL(parsedXml, principalPrefix, wsdlRoot, schemaNameSpace, thisNameSpace) {
+function getElementsFromWSDL(parsedXml, principalPrefix, wsdlRoot, wsdlObject) {
   const builder = new SchemaBuilderXSD();
   return builder.getElements(
     parsedXml,
     principalPrefix,
     wsdlRoot,
-    schemaNameSpace,
-    thisNameSpace,
+    wsdlObject,
     PARSER_ATTRIBUTE_NAME_PLACE_HOLDER
   );
+}
+
+/**
+ * Finds the schema namespace from the definitio of types
+ * creates a namespace array object with the found information
+ * @param {object} parsedXml the binding operation object
+ * @param {string} wsdlRoot the root tag for the document
+ * @param {string} principalPrefix the principal prefix
+ * @returns {Array} the [elements] object
+ */
+function getSchemaNamespacesFromTypesDefinitions(parsedXml, wsdlRoot, principalPrefix) {
+  let localSchemaNamespaces = [];
+  const descriptions = getNodeByName(parsedXml, principalPrefix, wsdlRoot),
+    types = getArrayFrom(getNodeByName(descriptions, principalPrefix, ATTRIBUTE_TYPES));
+  if (!types) {
+    return localSchemaNamespaces;
+  }
+
+  types.forEach((type) => {
+    let schemaTags = getArrayFrom(getQNamePrefix(Object.keys(type).find((key) => {
+      if (key.includes(SCHEMA_TAG)) {
+        return true;
+      }
+    })));
+    schemaTags.forEach((schemaTag) => {
+      let schemaNode = getNodeByName(type, schemaTag, XML_NAMESPACE_SEPARATOR + SCHEMA_TAG);
+      if (schemaNode) {
+        nameSpaceURL = getAttributeByName(schemaNode, XML_NAMESPACE_DECLARATION +
+          XML_NAMESPACE_SEPARATOR + schemaTag);
+        localSchemaNamespaces.push(buildNamespace(false, schemaTag, schemaTag + XML_NAMESPACE_SEPARATOR, nameSpaceURL));
+      }
+    });
+  });
+  return localSchemaNamespaces;
 }
 
 /**
@@ -269,28 +301,16 @@ function getElementsFromWSDL(parsedXml, principalPrefix, wsdlRoot, schemaNameSpa
  * @returns {Array} the [elements] object
  */
 function getSchemaNamespace(parsedXml, wsdlRoot) {
-  let schemaNamespace = getNamespaceByURL(parsedXml, SCHEMA_NS_URL, wsdlRoot);
-  if (!schemaNamespace) {
-    const principalPrefix = getPrincipalPrefix(parsedXml, wsdlRoot),
-      descriptions = getNodeByName(parsedXml, principalPrefix, wsdlRoot),
-      types = getNodeByName(descriptions, principalPrefix, ATTRIBUTE_TYPES);
-    if (!types) {
-      return schemaNamespace;
-    }
-    let schemaTag = getQNamePrefix(Object.keys(types).find((key) => {
-        if (key.includes(SCHEMA_TAG)) {
-          return true;
-        }
-      })),
-
-      schemaNode = getNodeByName(types, schemaTag, XML_NAMESPACE_SEPARATOR + SCHEMA_TAG),
-      nameSpaceURL = getAttributeByName(schemaNode, XML_NAMESPACE_DECLARATION +
-        XML_NAMESPACE_SEPARATOR + schemaTag);
-    return buildNamespace(false, schemaTag, schemaTag + XML_NAMESPACE_SEPARATOR, nameSpaceURL);
+  const principalPrefix = getPrincipalPrefix(parsedXml, wsdlRoot);
+  let globalSchemaNamespace,
+    localSchemaNamespaces;
+  globalSchemaNamespace = getNamespaceByURL(parsedXml, SCHEMA_NS_URL, wsdlRoot);
+  localSchemaNamespaces = getSchemaNamespacesFromTypesDefinitions(parsedXml, wsdlRoot, principalPrefix);
+  if (!globalSchemaNamespace) {
+    globalSchemaNamespace = localSchemaNamespaces[0];
   }
-  return schemaNamespace;
+  return { globalSchemaNamespace, localSchemaNamespaces };
 }
-
 
 /**
  * Get the bindngs operations of the document

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -61,32 +61,57 @@ class SchemaBuilderXSD {
    * @param {object} parsedXml the binding operation object
    * @param {string} principalPrefix the principal prefix of document
    * @param {string} wsdlRoot the root depending on version
-   * @param {NameSpace} schemaNamespace the schema namespace wsdlObject
-   * @param {NameSpace} tnsNamespace the tns NameSpace from wsdlObject
+   * @param {WSDLObject} wsdlObject the wsdlObject parsed object
    * @param {string} parserPlaceholder the corresponding parser prefix for ATTRIBUTEs
    * @returns {[Element]} the information of the types
    */
-  getElements(parsedXml, principalPrefix, wsdlRoot, schemaNamespace, tnsNamespace, parserPlaceholder) {
+  getElements(parsedXml, principalPrefix, wsdlRoot, wsdlObject, parserPlaceholder) {
     if (!parsedXml || typeof parsedXml !== 'object') {
       throw new WsdlError('Cannot get elements from undefined or null object');
     }
     let elementsFromMessages = [],
-      allElements = {};
+      allElements = {},
+      targetNamespace, schema;
     allElements.elements = [];
     const types = this.getTypes(parsedXml, principalPrefix, wsdlRoot);
     types.forEach((type) => {
-      const schemaTag =
-        type[schemaNamespace.prefixFilter + SCHEMA_TAG],
-        targetNamespace =
-          getXMLAttributeByName(schemaTag, parserPlaceholder, ATTRIBUTE_TARGET_NAMESPACE);
-      let schema = this.getXMLSchemaProcessed(schemaTag, schemaNamespace, tnsNamespace, parserPlaceholder);
+      let schemaTag =
+        type[wsdlObject.schemaNamespace.prefixFilter + SCHEMA_TAG],
+        localSchemaNamespace = wsdlObject.schemaNamespace;
+
+      if (!schemaTag) {
+        let { foundSchemaTag, foundLocalSchemaNamespace } = this.getLocalNamespaceDefinition(wsdlObject, type);
+        schemaTag = foundSchemaTag;
+        localSchemaNamespace = foundLocalSchemaNamespace;
+      }
+      targetNamespace =
+        getXMLAttributeByName(schemaTag, parserPlaceholder, ATTRIBUTE_TARGET_NAMESPACE);
+      schema = this.getXMLSchemaProcessed(schemaTag, localSchemaNamespace,
+        wsdlObject.tnsNamespace, parserPlaceholder);
       allElements = this.getElementsFromType(type, this.parseSchema(schema),
-        schemaNamespace.prefixFilter, targetNamespace, parserPlaceholder);
+        localSchemaNamespace.prefixFilter, targetNamespace, parserPlaceholder);
     });
     elementsFromMessages = this.getElementsFromMessages(parsedXml, principalPrefix,
       allElements.elements, allElements.simpleTypeElements, allElements.complexTypeElements,
       parserPlaceholder, wsdlRoot);
     return allElements.elements.concat(elementsFromMessages);
+  }
+
+  /**
+ * Returns the schema tag and namespace definition locally defined (inside the schema tag)
+ * @param {WSDLObject} wsdlObject the wsdlObject parsed object
+ * @param {object} type the type element from the wsdl (element tag)
+ * @returns {[Element]} the information of the types
+ */
+  getLocalNamespaceDefinition(wsdlObject, type) {
+    for (let index = 0; index < wsdlObject.localSchemaNamespaces.length; index++) {
+      if (type[wsdlObject.localSchemaNamespaces[index].prefixFilter + SCHEMA_TAG]) {
+        return {
+          foundSchemaTag: type[wsdlObject.localSchemaNamespaces[index].prefixFilter + SCHEMA_TAG],
+          foundLocalSchemaNamespace: wsdlObject.localSchemaNamespaces[index]
+        };
+      }
+    }
   }
 
   /**

--- a/lib/utils/messageWithSchemaValidation.js
+++ b/lib/utils/messageWithSchemaValidation.js
@@ -117,13 +117,39 @@ function getSchemaContentWithoutAttributes(schemaContent) {
 }
 
 /**
+ * Returns if found the local namespace definition in the types
+ * @param {WSDLObject} wsdlObject the parsed WSDLObject
+ * @param {object} wsdlTypes The types from the parsed object scheam definition
+ * @returns {object} The schema content and its corresponding namespace object
+ */
+function getLocalNamespaceDefinition(wsdlObject, wsdlTypes) {
+  let schemaContent = getSchemaContentWithoutAttributes(wsdlTypes[`${wsdlObject.schemaNamespace.key}:schema`]);
+  if (!schemaContent || Object.keys(schemaContent).length === 0) {
+    for (let index = 0; index < wsdlObject.localSchemaNamespaces.length; index++) {
+      schemaContent =
+        getSchemaContentWithoutAttributes(wsdlTypes[`${wsdlObject.localSchemaNamespaces[index].key}:schema`]);
+      if (schemaContent) {
+        return {
+          schemaContent,
+          foundNamespace: wsdlObject.localSchemaNamespaces[index]
+        };
+      }
+    }
+  }
+  return {
+    schemaContent,
+    foundNamespace: wsdlObject.schemaNamespace
+  };
+}
+
+/**
  * Returns the schema without extra attributes and without empty complexType tags
  * @param {object} parsedXml the parsed xml generated from a xmlDocument
- * @param {namespace} schemaNamespace the main namespace in schema
+ * @param {WSDLObject} wsdlObject the parsed WSDLObject
  * @param {string} wsdl_version The wsdl version '1.1' or '2.0'
  * @returns {string} The schemaBase
  */
-function getCleanSchema(parsedXml, schemaNamespace, wsdl_version) {
+function getCleanSchema(parsedXml, wsdlObject, wsdl_version) {
   if (!parsedXml || typeof parsedXml !== 'object') {
     throw new Error('Cannot get schema from undefined or null object');
   }
@@ -132,7 +158,6 @@ function getCleanSchema(parsedXml, schemaNamespace, wsdl_version) {
       principalPrefix = getPrincipalPrefix(parsedXml, wsdl_root),
       definitions,
       types,
-      schemaContent,
       schemaObject = {},
       utils = new SOAPMessageHelper(),
       schema;
@@ -142,9 +167,9 @@ function getCleanSchema(parsedXml, schemaNamespace, wsdl_version) {
     if (!types) {
       return types;
     }
-    schemaContent = getSchemaContentWithoutAttributes(types[`${schemaNamespace.key}:schema`]);
-    schemaContent[`@_xmlns:${schemaNamespace.key}`] = schemaNamespace.url;
-    schemaObject[`${schemaNamespace.key}:schema`] = schemaContent;
+    const { schemaContent, foundNamespace } = getLocalNamespaceDefinition(wsdlObject, types);
+    schemaContent[`@_xmlns:${foundNamespace.key}`] = foundNamespace.url;
+    schemaObject[`${foundNamespace.key}:schema`] = schemaContent;
     schema = utils.parseObjectToXML(schemaObject)
       .replace(/tns:/g, '')
       .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');

--- a/test/data/validWSDLs11/learnwebservices.wsdl
+++ b/test/data/validWSDLs11/learnwebservices.wsdl
@@ -1,0 +1,62 @@
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:tns="http://learnwebservices.com/services/hello"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="HelloEndpointService" targetNamespace="http://learnwebservices.com/services/hello">
+    <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://learnwebservices.com/services/hello" elementFormDefault="qualified" targetNamespace="http://learnwebservices.com/services/hello" version="1.0">
+            <xs:element name="SayHello" type="tns:SayHello"/>
+            <xs:element name="SayHelloResponse" type="tns:SayHelloResponse"/>
+            <xs:complexType name="SayHello">
+                <xs:sequence>
+                    <xs:element name="HelloRequest" type="tns:helloRequest"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="helloRequest">
+                <xs:sequence>
+                    <xs:element name="Name" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="SayHelloResponse">
+                <xs:sequence>
+                    <xs:element name="HelloResponse" type="tns:helloResponse"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:complexType name="helloResponse">
+                <xs:sequence>
+                    <xs:element name="Message" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="SayHelloResponse">
+        <wsdl:part element="tns:SayHelloResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SayHello">
+        <wsdl:part element="tns:SayHello" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:portType name="HelloEndpoint">
+        <wsdl:operation name="SayHello">
+            <wsdl:input message="tns:SayHello" name="SayHello"></wsdl:input>
+            <wsdl:output message="tns:SayHelloResponse" name="SayHelloResponse"></wsdl:output>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="HelloEndpointServiceSoapBinding" type="tns:HelloEndpoint">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="SayHello">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="SayHello">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SayHelloResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="HelloEndpointService">
+        <wsdl:port binding="tns:HelloEndpointServiceSoapBinding" name="HelloEndpointPort">
+            <soap:address location="http://www.learnwebservices.com/services/hello"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/e2e/validateOperationMessagesWithSchema.test.js
+++ b/test/e2e/validateOperationMessagesWithSchema.test.js
@@ -12,10 +12,10 @@ const fs = require('fs'),
     XMLParser
   } = require('../../lib/XMLParser');
 
-describe('Validating wsdlObject bodyMessages using validateOperationMessagesWithSchema function', function() {
+describe('Validating wsdlObject bodyMessages using validateOperationMessagesWithSchema function', function () {
   const WSDLsFiles = fs.readdirSync(validWSDLs);
   WSDLsFiles.forEach((file) => {
-    it(`Should return an empty array when body messages matches with schema. ${file}`, function() {
+    it(`Should return an empty array when body messages matches with schema. ${file}`, function () {
       const xmlDocumentContent = fs.readFileSync(validWSDLs + '/' + file, 'utf8'),
         factory = new ParserFactory(),
         xmlParser = new XMLParser(),
@@ -23,7 +23,7 @@ describe('Validating wsdlObject bodyMessages using validateOperationMessagesWith
         parser = factory.getParser(xmlDocumentContent),
         wsdlObject = parser.getWsdlObject(xmlDocumentContent, xmlParser),
         xmlParsed = xmlParser.parseToObject(xmlDocumentContent),
-        schemaToValidate = getCleanSchema(xmlParsed, wsdlObject.schemaNamespace, version);
+        schemaToValidate = getCleanSchema(xmlParsed, wsdlObject, version);
 
       let errors = validateOperationMessagesWithSchema(wsdlObject, schemaToValidate);
       expect(errors).to.be.an('array');

--- a/test/unit/SchemaBuilderXSD.test.js
+++ b/test/unit/SchemaBuilderXSD.test.js
@@ -33,13 +33,13 @@ describe('SchemaBuilderXSD getElements', function () {
   it('should get schema elements', function () {
     const builder = new SchemaBuilderXSD(),
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xsd',
         prefixFilter: 'xsd:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://tempuri.org/',
@@ -47,8 +47,10 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       fileContent = fs.readFileSync(validSchemaFolder + '/coreFileInput.wsdl', 'utf8'),
       parsedXml = parser.parseToObject(fileContent),
-      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', schemaNameSpace,
-        thisNameSpace, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      }, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
     expect(elements).to.be.a('array');
     expect(elements.length).to.eq(6);
 
@@ -106,13 +108,13 @@ describe('SchemaBuilderXSD getElements', function () {
       </types>
     </definitions>`,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://tempuri.org/',
@@ -120,8 +122,10 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace,
-        thisNameSpace, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      }, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
     expect(elements).to.be.an('array');
     expect(elements).to.be.empty;
   });
@@ -148,13 +152,13 @@ describe('SchemaBuilderXSD getElements', function () {
         </types>
       </definitions>`,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.dataaccess.com/webservicesserver/',
@@ -163,8 +167,10 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      }, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -205,13 +211,13 @@ describe('SchemaBuilderXSD getElements', function () {
   it('should get an array of types with 4 root and 1 child per root', function () {
     const simpleInput = fs.readFileSync(validSchemaFolder + '/4Root1ChildPerRoot.wsdl', 'utf8'),
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.dataaccess.com/webservicesserver/',
@@ -219,8 +225,10 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      }, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -292,13 +300,13 @@ describe('SchemaBuilderXSD getElements', function () {
   it('should get an array of types with 1 root and 1 complex type', function () {
     const simpleInput = fs.readFileSync(validSchemaFolder + '/1Root1Complextype.wsdl', 'utf8'),
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xsd',
         prefixFilter: 'xsd:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://tempuri.org/',
@@ -306,8 +314,11 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
-      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
     expect(elements).to.be.an('array');
 
     expect(elements[1].name).to.equal('TestCustomModel');
@@ -383,13 +394,13 @@ describe('SchemaBuilderXSD getElements', function () {
      </types>
   </definitions>`,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.oorsprong.org/websamples.countryinfo',
@@ -397,8 +408,11 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     let parsed = parser.parseToObject(simpleInput),
-      elements = builder.getElements(parsed, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsed, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
     expect(elements).to.be.an('array');
 
     expect(elements[0].name).to.equal('ListOfCurrenciesByCodeResponse');
@@ -485,13 +499,13 @@ describe('SchemaBuilderXSD getElements', function () {
     </types>
   </definitions>`,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xsd',
         prefixFilter: 'xsd:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'url/soap/services/getMatchClassesForTournament.php',
@@ -499,8 +513,11 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     let parsed = parser.parseToObject(simpleInput),
-      elements = builder.getElements(parsed, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsed, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
     expect(elements).to.be.an('array');
 
     expect(elements[1].name).to.equal('getMatchClassesForTournamentResponse');
@@ -528,13 +545,13 @@ describe('SchemaBuilderXSD getElements', function () {
   });
 
   it('should throw an error when parsed is undefined', function () {
-    const schemaNameSpace = {
+    const schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.oorsprong.org/websamples.countryinfo',
@@ -542,8 +559,11 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     try {
-      builder.getElements(undefined, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      builder.getElements(undefined, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
       assert.fail('we expected an error');
     }
     catch (error) {
@@ -552,13 +572,13 @@ describe('SchemaBuilderXSD getElements', function () {
   });
 
   it('should throw an error when parsed is null', function () {
-    const schemaNameSpace = {
+    const schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.oorsprong.org/websamples.countryinfo',
@@ -566,8 +586,11 @@ describe('SchemaBuilderXSD getElements', function () {
       },
       builder = new SchemaBuilderXSD();
     try {
-      builder.getElements(null, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      builder.getElements(null, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
       assert.fail('we expected an error');
     }
     catch (error) {
@@ -608,13 +631,13 @@ describe('SchemaBuilderXSD getElements', function () {
         </types>
       </definitions>`,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.dataaccess.com/webservicesserver/',
@@ -623,8 +646,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -682,13 +708,13 @@ describe('SchemaBuilderXSD getElements', function () {
         </types>
       </definitions>`,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://www.dataaccess.com/webservicesserver/',
@@ -697,8 +723,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -751,13 +780,13 @@ describe('SchemaBuilderXSD getElements', function () {
         </types> 
         </definitions > `,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 's',
         prefixFilter: 's:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'https://geoservices.tamu.edu/',
@@ -766,8 +795,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -817,13 +849,13 @@ describe('SchemaBuilderXSD getElements', function () {
         </types> 
         </definitions > `,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 's',
         prefixFilter: 's:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'https://geoservices.tamu.edu/',
@@ -832,8 +864,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -901,13 +936,13 @@ describe('SchemaBuilderXSD getElements', function () {
     </wsdl:message>
         </wsdl:definitions > `,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 's',
         prefixFilter: 's:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'https://geoservices.tamu.edu/',
@@ -916,8 +951,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
 
@@ -978,13 +1016,13 @@ describe('SchemaBuilderXSD getElements', function () {
     </wsdl:message>
         </wsdl:definitions > `,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 's',
         prefixFilter: 's:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'https://geoservices.tamu.edu/',
@@ -993,8 +1031,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
     expect(elements).to.be.an('array');
 
     expect(elements[0].name).to.equal('foobar');
@@ -1051,13 +1092,13 @@ describe('SchemaBuilderXSD getElements', function () {
 </definitions>
 `,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xsd',
         prefixFilter: 'xsd:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://tempuri.org/',
@@ -1066,8 +1107,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
     expect(elements[0].name).to.equal('TestElement');
@@ -1118,13 +1162,13 @@ describe('SchemaBuilderXSD getElements', function () {
 </definitions>
 `,
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xsd',
         prefixFilter: 'xsd:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://tempuri.org/',
@@ -1133,8 +1177,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(simpleInput),
 
-      elements = builder.getElements(parsedXml, '', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, '', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
     expect(elements[0].name).to.equal('PO');
@@ -1149,13 +1196,13 @@ describe('SchemaBuilderXSD getElements', function () {
     const
       fileContent = fs.readFileSync(validSchemaFolder + '/elementsDependOnElements.wsdl', 'utf8'),
       parser = new XMLParser(),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://queue.amazonaws.com/doc/2009-02-01/',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://queue.amazonaws.com/doc/2009-02-01/',
@@ -1164,8 +1211,11 @@ describe('SchemaBuilderXSD getElements', function () {
       builder = new SchemaBuilderXSD();
     let parsedXml = parser.parseToObject(fileContent),
 
-      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', schemaNameSpace, thisNameSpace,
-        PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
+      elements = builder.getElements(parsedXml, 'wsdl:', 'definitions', {
+        schemaNamespace,
+        tnsNamespace
+      },
+      PARSER_ATTRIBUTE_NAME_PLACE_HOLDER);
 
     expect(elements).to.be.an('array');
     expect(elements[0].name).to.equal('CreateQueueResult');
@@ -1248,7 +1298,7 @@ describe('SchemaBuilderXSD getTypes', function () {
 describe('replaceTagInSchema', function () {
   const
     fileContent = fs.readFileSync(validSchemaFolder + '/replaceAllToSequence.wsdl', 'utf8'),
-    schemaNameSpace = {
+    schemaNamespace = {
       key: 'xsd',
       prefixFilter: 'xsd:',
       url: 'http://www.w3.org/2001/XMLSchema',
@@ -1257,7 +1307,7 @@ describe('replaceTagInSchema', function () {
 
   it('Should switch all tags in document with sequence tags', function () {
     const schemaBuilder = new SchemaBuilderXSD(),
-      result = schemaBuilder.replaceTagInSchema(fileContent, schemaNameSpace, 'all', 'sequence');
+      result = schemaBuilder.replaceTagInSchema(fileContent, schemaNamespace, 'all', 'sequence');
     expect(result.includes('<xsd:all>')).to.equal(false);
   });
 });

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -25,11 +25,14 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
       }, {});
 
       schemaPack.convert((error, result) => {
-        expect(error).to.be.null;
+        expect(error, error ? error.stack : '').to.be.null;
         expect(result).to.be.an('object');
         expect(result.output).to.be.an('array');
         expect(result.output[0].data).to.be.an('object');
         expect(result.output[0].type).to.equal('collection');
+        if (file === 'failing.wsdl') {
+          fs.writeFileSync('coll.json', JSON.stringify(result.output[0].data));
+        }
       });
     });
   });
@@ -162,7 +165,7 @@ describe('SchemaPack convert unit test WSDL 2.0', function () {
       }, {});
 
       schemaPack.convert((error, result) => {
-        expect(error).to.be.null;
+        expect(error, error ? error.stack : '').to.be.null;
         expect(result).to.be.an('object');
         expect(result.output).to.be.an('array');
         expect(result.output[0].data).to.be.an('object');

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -30,9 +30,6 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
         expect(result.output).to.be.an('array');
         expect(result.output[0].data).to.be.an('object');
         expect(result.output[0].type).to.equal('collection');
-        if (file === 'failing.wsdl') {
-          fs.writeFileSync('coll.json', JSON.stringify(result.output[0].data));
-        }
       });
     });
   });

--- a/test/unit/WsdlInformationService11.test.js
+++ b/test/unit/WsdlInformationService11.test.js
@@ -336,7 +336,7 @@ describe('WSDL 1.1 parser getPortTypeOperations', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get portypes from object');
+      expect(error.message).to.equal('Cannot get portypes from WSDL');
     }
   });
 });
@@ -655,7 +655,7 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get binding from object');
+      expect(error.message).to.equal('Cannot get binding from WSDL');
     }
   });
 
@@ -1704,7 +1704,7 @@ describe('WSDL 1.1 parser getAbstractOperationByName', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get port type from object');
+      expect(error.message).to.equal('Cannot get port type from WSDL');
     }
   });
 

--- a/test/unit/WsdlInformationService20.test.js
+++ b/test/unit/WsdlInformationService20.test.js
@@ -232,7 +232,7 @@ describe('WSDL 2.0 parser getAbstractOperationByName', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get port type from object');
+      expect(error.message).to.equal('Cannot get port type from WSDL');
     }
   });
 
@@ -339,7 +339,7 @@ describe('WSDL 2.0 getInterfaceByInterfaceName', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get interface from object');
+      expect(error.message).to.equal('Cannot get interface from WSDL');
     }
   });
 });
@@ -436,7 +436,7 @@ describe('WSDL 2.0 getServiceAndExpossedInfoByBindingName', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get service endpoint from object');
+      expect(error.message).to.equal('Cannot get service endpoint from WSDL');
     }
   });
   it('should throw an error when service enpdoint is array of null not found', function () {
@@ -446,7 +446,7 @@ describe('WSDL 2.0 getServiceAndExpossedInfoByBindingName', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get service endpoint from object');
+      expect(error.message).to.equal('Cannot get service endpoint from WSDL');
     }
   });
 });

--- a/test/unit/messageWithSchemaValidation.test.js
+++ b/test/unit/messageWithSchemaValidation.test.js
@@ -221,7 +221,8 @@ describe('Tools from messageWithSchemaValidation', function () {
     it(
       'Should return a schema with base namespace, removed tns and no complexType, tags empty',
       function () {
-        const generatedCleanSchema = getCleanSchema(xmlParsedMock, schemaNamespaceMock, wsdl_version),
+        const generatedCleanSchema = getCleanSchema(xmlParsedMock, { schemaNamespace: schemaNamespaceMock },
+            wsdl_version),
           generatedCleanSchemaToCompare = generatedCleanSchema.replace(/\s/g, ''),
           expectedSchemaToCompare = expectedSchema.replace(/\s/g, '');
         expect(generatedCleanSchemaToCompare).to.be.equal(expectedSchemaToCompare);
@@ -229,7 +230,7 @@ describe('Tools from messageWithSchemaValidation', function () {
 
     it('Should throw an error if parsedXml is not provided', function () {
       try {
-        getCleanSchema(null, schemaNamespaceMock, wsdl_version);
+        getCleanSchema(null, { schemaNamespace: schemaNamespaceMock }, wsdl_version);
         assert.fail('We expect an error');
       }
       catch (error) {
@@ -243,7 +244,7 @@ describe('Tools from messageWithSchemaValidation', function () {
         'operationsArray': [{
           'name': 'NumberToWords',
           'description': `Returns the word corresponding to the positive number passed as parameter. 
-              Limited to quadrillions.`,
+                Limited to quadrillions.`,
           'style': 'document',
           'url': 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
           'input': {
@@ -328,7 +329,7 @@ describe('Tools from messageWithSchemaValidation', function () {
         }, {
           'name': 'NumberToWords',
           'description': `Returns the word corresponding to the positive number passed as parameter. 
-              Limited to quadrillions.`,
+                Limited to quadrillions.`,
           'style': 'document',
           'url': 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
           'input': {

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -461,7 +461,7 @@ describe('WSDLParser assignNamespaces', function () {
     expect(wsdlObject).to.have.all.keys('targetNamespace',
       'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
       'SOAP12Namespace', 'schemaNamespace',
-      'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
+      'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'localSchemaNamespaces', 'log',
       'operationsArray', 'securityPolicyArray',
       'securityPolicyNamespace', 'xmlParsed', 'version');
 
@@ -499,7 +499,7 @@ describe('WSDLParser assignNamespaces', function () {
     expect(wsdlObject).to.have.all.keys('targetNamespace',
       'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
       'SOAP12Namespace', 'schemaNamespace',
-      'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
+      'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'localSchemaNamespaces', 'log',
       'operationsArray', 'securityPolicyArray',
       'securityPolicyNamespace', 'xmlParsed', 'version');
 
@@ -1264,7 +1264,7 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
       expect(wsdlObject).to.have.all.keys('targetNamespace',
         'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
         'SOAP12Namespace', 'schemaNamespace',
-        'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
+        'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'localSchemaNamespaces', 'log',
         'operationsArray', 'securityPolicyArray',
         'securityPolicyNamespace', 'xmlParsed', 'version');
 
@@ -1341,7 +1341,7 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
       expect(wsdlObject).to.have.all.keys('targetNamespace',
         'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
         'SOAP12Namespace', 'schemaNamespace',
-        'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'log',
+        'tnsNamespace', 'allNameSpaces', 'documentation', 'fileName', 'localSchemaNamespaces', 'log',
         'operationsArray', 'securityPolicyArray',
         'securityPolicyNamespace', 'xmlParsed', 'version');
 

--- a/test/unit/wsdlParserComon.test.js
+++ b/test/unit/wsdlParserComon.test.js
@@ -1759,13 +1759,13 @@ describe('WSDL parser common getElementsFromWSDL', function () {
       informationService = new WsdlInformationService20();
 
     let parsed = parser.parseToObject(WSDL_SAMPLE),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://greath.example.com/2004/wsdl/resSvc',
@@ -1775,8 +1775,10 @@ describe('WSDL parser common getElementsFromWSDL', function () {
         parsed,
         '',
         informationService.RootTagName,
-        schemaNameSpace,
-        thisNameSpace
+        {
+          schemaNamespace,
+          tnsNamespace
+        }
       );
     expect(elements).to.be.an('array');
     expect(elements.length).to.equal(3);
@@ -1787,13 +1789,13 @@ describe('WSDL parser common getElementsFromWSDL', function () {
       informationService = new WsdlInformationService20();
 
     let parsed = parser.parseToObject(WSDL_SAMPLE_AXIS),
-      schemaNameSpace = {
+      schemaNamespace = {
         key: 'xs',
         prefixFilter: 'xs:',
         url: 'http://www.w3.org/2001/XMLSchema',
         isDefault: false
       },
-      thisNameSpace = {
+      tnsNamespace = {
         key: 'tns',
         prefixFilter: 'tns:',
         url: 'http://axis2.org',
@@ -1803,8 +1805,10 @@ describe('WSDL parser common getElementsFromWSDL', function () {
         parsed,
         'wsdl2:',
         informationService.RootTagName,
-        schemaNameSpace,
-        thisNameSpace
+        {
+          schemaNamespace,
+          tnsNamespace
+        }
       );
 
     expect(elements).to.be.an('array');


### PR DESCRIPTION
This WSDL is not converted is throwing and error 
http://www.learnwebservices.com/services/hello?WSDL
https://community.postman.com/t/version-8-4-0-import-wsdl-specification/23715


Retrieve all the namespaces definitions form types/schemas, when we are retrieve wsdl elements and the schema is not from the global namespace then search in local namespaces. In validation search for the corresponding namespace definition from global and local before validate message body against schema