### PR TITLE
Fix/importschema file

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -2,7 +2,8 @@ const Ajv = require('ajv'),
   {
     getCleanSchema,
     validateMessageWithSchema,
-    unwrapAndCleanBody
+    unwrapAndCleanBody,
+    getMessagePayload
   } = require('./utils/messageWithSchemaValidation'),
   transactionSchema = require('./constants/transactionSchema'),
   { parseFromXmlToObject, getNamespaceByURL } = require('./WsdlParserCommon'),
@@ -97,7 +98,7 @@ class TransactionValidator {
       }
 
       if (operationFromWSDL) {
-        const { protocol, method, name, input } = operationFromWSDL,
+        const { protocol, method, name } = operationFromWSDL,
           headerMismatches = this.validateHeaders(
             requestItem.request.header,
             requestItem.id,
@@ -185,7 +186,6 @@ class TransactionValidator {
     let responses = {},
       responsesMatched = true;
     responseItem.forEach((response) => {
-      //const body = unwrapAndCleanBody(response.body, operationFromWSDL.output.name),
       const header = response.header,
         id = response.id,
         headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true, options),
@@ -239,7 +239,7 @@ class TransactionValidator {
 
   /**
    * Validate body string and return mismatches
-   * @param {String} rawXmlMessage Message in body
+   * @param {String} body Message in body
    * @param {Object} wsdlObject Object generated from wsdl document
    * @param {Object} operationFromWSDL wsdlObject operation's
    * @param {Boolean} isResponse True if provided message is in a response, False if is in a request
@@ -248,6 +248,9 @@ class TransactionValidator {
    */
   validateBody(body, wsdlObject, operationFromWSDL, isResponse, options) {
     let mismatches = [],
+      filteredErrors,
+      errors,
+      operationName,
       rawXmlMessage;
     const { validationPropertiesToIgnore } = options,
       mismatchProperty = isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY;
@@ -259,18 +262,16 @@ class TransactionValidator {
     if (body) {
       const parsedXml = wsdlObject.xmlParsed,
         { cleanSchema, isSchemaXSDDefault } = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version);
-      //cleanSchema = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version),
-      let operationName = isResponse ? operationFromWSDL.output.name : operationFromWSDL.input.name;
+      operationName = isResponse ? operationFromWSDL.output.name : operationFromWSDL.input.name;
       if (!isSchemaXSDDefault) {
         rawXmlMessage = unwrapAndCleanBody(body, operationName);
       }
       else {
-        rawXmlMessage = body;
+        rawXmlMessage = getMessagePayload(body, operationName);
       }
-
-      let errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
+      errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
       if (errors.length > 0) {
-        let filteredErrors = this.filterSchemaValidationErrors(errors, options);
+        filteredErrors = this.filterSchemaValidationErrors(errors, options);
         mismatches = filteredErrors.map((error) => {
           return {
             property: isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY,

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -106,7 +106,7 @@ class TransactionValidator {
             options
           ),
           requestBodyMismatches = this.validateBody(
-            unwrapAndCleanBody(requestBody, input.name),
+            requestBody,
             wsdlObject,
             operationFromWSDL,
             false,
@@ -185,11 +185,11 @@ class TransactionValidator {
     let responses = {},
       responsesMatched = true;
     responseItem.forEach((response) => {
-      const body = unwrapAndCleanBody(response.body, operationFromWSDL.output.name),
-        header = response.header,
+      //const body = unwrapAndCleanBody(response.body, operationFromWSDL.output.name),
+      const header = response.header,
         id = response.id,
         headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true, options),
-        bodyMismatches = this.validateBody(body, wsdlObject, operationFromWSDL, true,
+        bodyMismatches = this.validateBody(response.body, wsdlObject, operationFromWSDL, true,
           options),
         mismatches = [...headerMismatches, ...bodyMismatches],
         matched = !mismatches.length > 0;
@@ -246,8 +246,9 @@ class TransactionValidator {
    * @param {object} options options validation process
    * @returns {Array} List of mismatches found
    */
-  validateBody(rawXmlMessage, wsdlObject, operationFromWSDL, isResponse, options) {
-    let mismatches = [];
+  validateBody(body, wsdlObject, operationFromWSDL, isResponse, options) {
+    let mismatches = [],
+      rawXmlMessage;
     const { validationPropertiesToIgnore } = options,
       mismatchProperty = isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY;
 
@@ -255,10 +256,19 @@ class TransactionValidator {
       return mismatches;
     }
 
-    if (rawXmlMessage) {
+    if (body) {
       const parsedXml = wsdlObject.xmlParsed,
-        cleanSchema = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version),
-        errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
+        { cleanSchema, isSchemaXSDDefault } = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version);
+      //cleanSchema = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version),
+      let operationName = isResponse ? operationFromWSDL.output.name : operationFromWSDL.input.name;
+      if (!isSchemaXSDDefault) {
+        rawXmlMessage = unwrapAndCleanBody(body, operationName);
+      }
+      else {
+        rawXmlMessage = body;
+      }
+
+      let errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
       if (errors.length > 0) {
         let filteredErrors = this.filterSchemaValidationErrors(errors, options);
         mismatches = filteredErrors.map((error) => {

--- a/lib/WSDLObject.js
+++ b/lib/WSDLObject.js
@@ -34,6 +34,7 @@ class NameSpace {
     this.url = '';
     this.prefixFilter = '';
     this.isDefault = '';
+    this.tnsDefinitionURL = '';
   }
 }
 

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -43,8 +43,8 @@ const
     getNodeByName,
     getAttributeByName,
     THIS_NS_PREFIX,
-    getDocumentationStringFromNode
-
+    getDocumentationStringFromNode,
+    excludeSeparatorImportedElementsName
   } = require('./WsdlParserCommon'),
   {
     getQNamePrefixFilter,
@@ -178,6 +178,7 @@ class WsdlInformationService11 {
     if (information) {
       messageName = getAttributeByName(information, ATTRIBUTE_MESSAGE);
       elementName = this.getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName);
+      elementName = excludeSeparatorImportedElementsName(elementName);
       element = elementsFromWSDL.find((element) => {
         return element.name === elementName;
       });
@@ -188,6 +189,7 @@ class WsdlInformationService11 {
     }
     return null;
   }
+
 
   /**
    * finds the element from the port type operation object

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -44,7 +44,7 @@ const
     getAttributeByName,
     THIS_NS_PREFIX,
     getDocumentationStringFromNode,
-    excludeSeparatorImportedElementsName
+    excludeSeparatorFromName
   } = require('./WsdlParserCommon'),
   {
     getQNamePrefixFilter,
@@ -178,7 +178,7 @@ class WsdlInformationService11 {
     if (information) {
       messageName = getAttributeByName(information, ATTRIBUTE_MESSAGE);
       elementName = this.getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName);
-      elementName = excludeSeparatorImportedElementsName(elementName);
+      elementName = excludeSeparatorFromName(elementName);
       element = elementsFromWSDL.find((element) => {
         return element.name === elementName;
       });

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -1,8 +1,9 @@
 const {
-    SecurityAssertionsHelper
-  } = require('./security/SecurityAssertionsHelper'),
+  SecurityAssertionsHelper
+} = require('./security/SecurityAssertionsHelper'),
   {
-    getArrayFrom
+    getArrayFrom,
+    getStringArrayFrom
   } = require('./utils/objectUtils'),
   {
     removeLineBreak
@@ -275,17 +276,20 @@ function getSchemaNamespacesFromTypesDefinitions(parsedXml, wsdlRoot, principalP
   }
 
   types.forEach((type) => {
-    let schemaTags = getArrayFrom(getQNamePrefix(Object.keys(type).find((key) => {
+    let schemaPrefixes = getStringArrayFrom(getQNamePrefix(Object.keys(type).find((key) => {
       if (key.includes(SCHEMA_TAG)) {
         return true;
       }
     })));
-    schemaTags.forEach((schemaTag) => {
-      let schemaNode = getNodeByName(type, schemaTag, XML_NAMESPACE_SEPARATOR + SCHEMA_TAG);
+    schemaPrefixes.forEach((schemaTag) => {
+      let schemaNode = getNodeByName(type, schemaTag,
+        schemaTag === '' ? SCHEMA_TAG : XML_NAMESPACE_SEPARATOR + SCHEMA_TAG);
       if (schemaNode) {
+        let urlAtribute = schemaTag === '' ? schemaTag : XML_NAMESPACE_SEPARATOR + schemaTag
         nameSpaceURL = getAttributeByName(schemaNode, XML_NAMESPACE_DECLARATION +
-          XML_NAMESPACE_SEPARATOR + schemaTag);
-        localSchemaNamespaces.push(buildNamespace(false, schemaTag, schemaTag + XML_NAMESPACE_SEPARATOR, nameSpaceURL));
+          urlAtribute);
+        let prefixFilter = schemaTag === '' ? '' : schemaTag + XML_NAMESPACE_SEPARATOR;
+        localSchemaNamespaces.push(buildNamespace(false, schemaTag, prefixFilter, nameSpaceURL));
       }
     });
   });
@@ -415,6 +419,10 @@ function getWSDLDocumentation(parsedXml, wsdlRoot) {
   }
 }
 
+function excludeSeparatorImportedElementsName(elementName) {
+  return elementName ? elementName.split(XML_NAMESPACE_SEPARATOR).reverse()[0] : elementName;
+}
+
 module.exports = {
   PARSER_ATTRIBUTE_NAME_PLACE_HOLDER,
   getPrincipalPrefix,
@@ -436,5 +444,6 @@ module.exports = {
   assignSecurity,
   getSecurity,
   getDocumentationStringFromNode,
-  getWSDLDocumentation
+  getWSDLDocumentation,
+  excludeSeparatorImportedElementsName
 };

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -1,6 +1,6 @@
 const {
-  SecurityAssertionsHelper
-} = require('./security/SecurityAssertionsHelper'),
+    SecurityAssertionsHelper
+  } = require('./security/SecurityAssertionsHelper'),
   {
     getArrayFrom,
     getStringArrayFrom
@@ -285,10 +285,12 @@ function getSchemaNamespacesFromTypesDefinitions(parsedXml, wsdlRoot, principalP
       let schemaNode = getNodeByName(type, schemaTag,
         schemaTag === '' ? SCHEMA_TAG : XML_NAMESPACE_SEPARATOR + SCHEMA_TAG);
       if (schemaNode) {
-        let urlAtribute = schemaTag === '' ? schemaTag : XML_NAMESPACE_SEPARATOR + schemaTag
+        let urlAtribute,
+          prefixFilter;
+        urlAtribute = schemaTag === '' ? schemaTag : XML_NAMESPACE_SEPARATOR + schemaTag;
         nameSpaceURL = getAttributeByName(schemaNode, XML_NAMESPACE_DECLARATION +
           urlAtribute);
-        let prefixFilter = schemaTag === '' ? '' : schemaTag + XML_NAMESPACE_SEPARATOR;
+        prefixFilter = schemaTag === '' ? '' : schemaTag + XML_NAMESPACE_SEPARATOR;
         localSchemaNamespaces.push(buildNamespace(false, schemaTag, prefixFilter, nameSpaceURL));
       }
     });
@@ -419,7 +421,12 @@ function getWSDLDocumentation(parsedXml, wsdlRoot) {
   }
 }
 
-function excludeSeparatorImportedElementsName(elementName) {
+/**
+ * Removes xml separator from string
+ * @param {string} elementName the root tag for the document to remove xml ns separator
+ * @returns {string} the elementName without ":"
+ */
+function excludeSeparatorFromName(elementName) {
   return elementName ? elementName.split(XML_NAMESPACE_SEPARATOR).reverse()[0] : elementName;
 }
 
@@ -445,5 +452,5 @@ module.exports = {
   getSecurity,
   getDocumentationStringFromNode,
   getWSDLDocumentation,
-  excludeSeparatorImportedElementsName
+  excludeSeparatorFromName
 };

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -66,14 +66,16 @@ function getAttributeByName(parentNode, attName) {
  * @param {string} key the namespace qname
  * @param {string} prefixFilter qname plus :
  * @param {string} url namespace url
+ * @param {string} tnsDefinitionURL targetnamespace url
  * @returns {NameSpace} the generated NameSpace
  */
-function buildNamespace(isDefault, key, prefixFilter, url) {
+function buildNamespace(isDefault, key, prefixFilter, url, tnsDefinitionURL) {
   let namespace = new NameSpace();
   namespace.isDefault = isDefault;
   namespace.key = key;
   namespace.prefixFilter = prefixFilter;
   namespace.url = url;
+  namespace.tnsDefinitionURL = tnsDefinitionURL;
   return namespace;
 }
 
@@ -286,12 +288,15 @@ function getSchemaNamespacesFromTypesDefinitions(parsedXml, wsdlRoot, principalP
         schemaTag === '' ? SCHEMA_TAG : XML_NAMESPACE_SEPARATOR + SCHEMA_TAG);
       if (schemaNode) {
         let urlAtribute,
+          targetNamespace,
           prefixFilter;
         urlAtribute = schemaTag === '' ? schemaTag : XML_NAMESPACE_SEPARATOR + schemaTag;
         nameSpaceURL = getAttributeByName(schemaNode, XML_NAMESPACE_DECLARATION +
           urlAtribute);
+        targetNamespace = getAttributeByName(schemaNode,
+          TARGET_NAMESPACE_SPEC);
         prefixFilter = schemaTag === '' ? '' : schemaTag + XML_NAMESPACE_SEPARATOR;
-        localSchemaNamespaces.push(buildNamespace(false, schemaTag, prefixFilter, nameSpaceURL));
+        localSchemaNamespaces.push(buildNamespace(false, schemaTag, prefixFilter, nameSpaceURL, targetNamespace));
       }
     });
   });

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -877,7 +877,7 @@ class SchemaBuilderXSD {
         traverseObject.pattern = definition.pattern !== undefined ? definition.pattern : traverseObject.pattern;
 
         hasEnumIndex = simpleType.allOf.findIndex((property) => {
-          return property.enum;// ? true : false;
+          return property.enum;
         });
         if (hasEnumIndex !== -1) {
           traverseObject.enumValues = simpleType.allOf[hasEnumIndex].enum;
@@ -925,7 +925,16 @@ class SchemaBuilderXSD {
    */
   getComplexTypeByName(complexTypeName, complexTypes) {
     let complexType,
+      complexTypeNameFound;
+
+    if (complexTypeName.startsWith('FORWARD_REFERENCE#')) {
+      complexTypeNameFound = complexTypeName.split('/').reverse()[0];
+      complexTypeNameFound = complexTypeNameFound.includes('tns:') ? complexTypeNameFound.replace('tns:', '') :
+        complexTypeNameFound;
+    }
+    else {
       complexTypeNameFound = complexTypeName.replace(DEFINITIONS_FILTER, '');
+    }
     complexType = complexTypes.find((complexType) => {
       return complexType.name === complexTypeNameFound;
     });

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -861,23 +861,25 @@ class SchemaBuilderXSD {
   processSimpleTypeSchema(typeName, simpleTypes, traverseObject) {
     let simpleType = this.getSimpleTypeByName(typeName, simpleTypes);
     if (!simpleType) {
-      this.processTypeNotFound(typeName, traverseObject)
+      this.processTypeNotFound(typeName, traverseObject);
       return;
     }
     if (simpleType.allOf) {
       this.processSimpleTypeSchema(simpleType.allOf[0].$ref, simpleTypes, traverseObject);
       if (simpleType.allOf[1]) {
-        let definition = simpleType.allOf[1];
+        let definition,
+          hasEnumIndex;
+        definition = simpleType.allOf[1];
         traverseObject.minLength = definition.minLength !== undefined ? definition.minLength : traverseObject.minLength;
         traverseObject.maxLength = definition.maxLength !== undefined ? definition.maxLength : traverseObject.maxLength;
         traverseObject.maximum = definition.maximum !== undefined ? definition.maximum : traverseObject.maximum;
         traverseObject.minimum = definition.minimum !== undefined ? definition.minimum : traverseObject.minimum;
         traverseObject.pattern = definition.pattern !== undefined ? definition.pattern : traverseObject.pattern;
 
-        let hasEnumIndex = simpleType.allOf.findIndex((property) => {
-          return property.enum ? true : false;
-        })
-        if (hasEnumIndex != -1) {
+        hasEnumIndex = simpleType.allOf.findIndex((property) => {
+          return property.enum;// ? true : false;
+        });
+        if (hasEnumIndex !== -1) {
           traverseObject.enumValues = simpleType.allOf[hasEnumIndex].enum;
           traverseObject.$ref = undefined;
         }
@@ -905,7 +907,7 @@ class SchemaBuilderXSD {
       if (isKnownType(type)) {
         traverseObject.type = type;
         traverseObject.$ref = null;
-        return
+        return;
       }
     }
     traverseObject.properties = {};

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -293,7 +293,12 @@ class SchemaBuilderXSD {
     let localSchemaTag = { ...schemaTag },
       objectSchema = {},
       schema;
-    localSchemaTag[parserPlaceholder + 'xmlns:' + schemaNamespace.key] = schemaNamespace.url;
+    if (schemaNamespace.key === '') {
+      localSchemaTag[parserPlaceholder + 'xmlns'] = undefined;
+    }
+    else {
+      localSchemaTag[parserPlaceholder + 'xmlns:' + schemaNamespace.key] = schemaNamespace.url;
+    }
     localSchemaTag[parserPlaceholder + 'xmlns:' + tnsNamespace.key] = tnsNamespace.url;
     objectSchema = {};
     objectSchema[schemaNamespace.prefixFilter + SCHEMA_TAG] = localSchemaTag;
@@ -856,9 +861,7 @@ class SchemaBuilderXSD {
   processSimpleTypeSchema(typeName, simpleTypes, traverseObject) {
     let simpleType = this.getSimpleTypeByName(typeName, simpleTypes);
     if (!simpleType) {
-      traverseObject.properties = {};
-      traverseObject.type = ERROR_ELEMENT_IDENTIFIER;
-      traverseObject.complexName = typeName;
+      this.processTypeNotFound(typeName, traverseObject)
       return;
     }
     if (simpleType.allOf) {
@@ -886,6 +889,21 @@ class SchemaBuilderXSD {
       traverseObject.pattern = simpleType.pattern;
       traverseObject.$ref = undefined;
     }
+  }
+
+  processTypeNotFound(typeName, traverseObject) {
+    if (typeName.startsWith('FORWARD_REFERENCE#')) {
+      let type = typeName.split('/').reverse()[0];
+      if (isKnownType(type)) {
+        traverseObject.type = type;
+        traverseObject.$ref = null;
+        return
+      }
+    }
+    traverseObject.properties = {};
+    traverseObject.type = ERROR_ELEMENT_IDENTIFIER;
+    traverseObject.complexName = typeName;
+    return;
   }
 
   /**
@@ -932,15 +950,23 @@ class SchemaBuilderXSD {
    */
   getSimpleTypeByName(simpleTypeName, simpleTypes) {
     let simpleType,
+      simpleTypeNameToSearch = '';
 
-      simpleTypeNameFound = simpleTypeName.replace(DEFINITIONS_FILTER, '');
+    if (simpleTypeName.startsWith('FORWARD_REFERENCE#')) {
+      simpleTypeNameToSearch = simpleTypeName.split('/').reverse()[0];
+      simpleTypeNameToSearch = simpleTypeNameToSearch.includes('tns:') ? simpleTypeNameToSearch.replace('tns:', '') :
+        simpleTypeNameToSearch;
+    }
+    else {
+      simpleTypeNameToSearch = simpleTypeName.replace(DEFINITIONS_FILTER, '');
+    }
+
     simpleType = simpleTypes.find((simpleType) => {
-      return simpleType.name === simpleTypeNameFound;
+      return simpleType.name === simpleTypeNameToSearch;
     });
 
     return simpleType;
   }
-
 }
 
 module.exports = {

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -873,6 +873,14 @@ class SchemaBuilderXSD {
         traverseObject.maximum = definition.maximum !== undefined ? definition.maximum : traverseObject.maximum;
         traverseObject.minimum = definition.minimum !== undefined ? definition.minimum : traverseObject.minimum;
         traverseObject.pattern = definition.pattern !== undefined ? definition.pattern : traverseObject.pattern;
+
+        let hasEnumIndex = simpleType.allOf.findIndex((property) => {
+          return property.enum ? true : false;
+        })
+        if (hasEnumIndex != -1) {
+          traverseObject.enumValues = simpleType.allOf[hasEnumIndex].enum;
+          traverseObject.$ref = undefined;
+        }
       }
     }
     else if (simpleType.enum) {

--- a/lib/utils/messageWithSchemaValidation.js
+++ b/lib/utils/messageWithSchemaValidation.js
@@ -75,7 +75,7 @@ function validateOperationMessagesWithSchema(wsdlObject, schemaBase) {
       validationErrors = [...validationErrors, ...validateMessageWithSchema(bodyMessage, schemaBase)];
     }
     catch (error) {
-      console.error('There was an error validating body message vs schema', error);
+      console.error('There was an error validating body message vs schema ' + operation.name, error);
     }
   });
   return validationErrors;
@@ -123,11 +123,15 @@ function getSchemaContentWithoutAttributes(schemaContent) {
  * @returns {object} The schema content and its corresponding namespace object
  */
 function getLocalNamespaceDefinition(wsdlObject, wsdlTypes) {
+  // let realNamespace = getRealNamespace(wsdlObject,
+  // 'http://www.example.com/interfaces/parking/operatorServices/v1/data');
   let schemaContent = getSchemaContentWithoutAttributes(wsdlTypes[`${wsdlObject.schemaNamespace.key}:schema`]);
   if (!schemaContent || Object.keys(schemaContent).length === 0) {
     for (let index = 0; index < wsdlObject.localSchemaNamespaces.length; index++) {
+      let schemaFilter = wsdlObject.localSchemaNamespaces[index].key === '' ? 'schema' :
+        `${wsdlObject.localSchemaNamespaces[index].key}:schema`;
       schemaContent =
-        getSchemaContentWithoutAttributes(wsdlTypes[`${wsdlObject.localSchemaNamespaces[index].key}:schema`]);
+        getSchemaContentWithoutAttributes(wsdlTypes[schemaFilter]);
       if (schemaContent) {
         return {
           schemaContent,
@@ -142,6 +146,52 @@ function getLocalNamespaceDefinition(wsdlObject, wsdlTypes) {
   };
 }
 
+// getRealNamespace(wsdlObject, targetNSUrl){
+
+//   let realNamespace;
+//   realNamespace = wsdlObject.localSchemaNamespaces.find((namespace) => {
+//     namespace.tnsDefinitionURL === targetNSUrl;
+//   });
+
+//   if (!realNamespace) {
+//     realNamespace = wsdlObject.schemaNamespace;
+//   }
+//   return realNamespace;
+// }
+
+function getCleanSchema2(schemaContent, foundNamespace) {
+  let schema,
+    schemaTag,
+    schemaObject = {},
+    utils = new SOAPMessageHelper();
+
+  if (foundNamespace.key === '') {
+    nsKey = `@_xmlns${foundNamespace.key}`;
+    schemaTag = `${foundNamespace.key}schema`;
+    schemaContent[nsKey] = foundNamespace.url;
+    schemaContent['@_targetNamespace'] = foundNamespace.tnsDefinitionURL;
+    schemaContent['@_xmlns:tns'] = foundNamespace.tnsDefinitionURL;
+    schemaContent['@_elementFormDefault'] = 'qualified';
+    schemaContent[nsKey] = foundNamespace.url;
+    schemaObject[schemaTag] = schemaContent;
+    schema = utils.parseObjectToXML(schemaObject)
+      //.replace(/tns:/g, '')
+      .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
+  }
+  else {
+    nsKey = `@_xmlns:${foundNamespace.key}`;
+    schemaTag = `${foundNamespace.key}:schema`;
+    schemaContent[nsKey] = foundNamespace.url;
+    schemaObject[schemaTag] = schemaContent;
+    schema = utils.parseObjectToXML(schemaObject)
+      .replace(/tns:/g, '')
+      .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
+  }
+
+
+  return schema;
+}
+
 /**
  * Returns the schema without extra attributes and without empty complexType tags
  * @param {object} parsedXml the parsed xml generated from a xmlDocument
@@ -154,7 +204,9 @@ function getCleanSchema(parsedXml, wsdlObject, wsdl_version) {
     throw new Error('Cannot get schema from undefined or null object');
   }
   try {
-    let wsdl_root = getWsdlRootTag(wsdl_version),
+    let nsKey,
+      schemaTag,
+      wsdl_root = getWsdlRootTag(wsdl_version),
       principalPrefix = getPrincipalPrefix(parsedXml, wsdl_root),
       definitions,
       types,
@@ -168,17 +220,23 @@ function getCleanSchema(parsedXml, wsdlObject, wsdl_version) {
       return types;
     }
     const { schemaContent, foundNamespace } = getLocalNamespaceDefinition(wsdlObject, types);
-    schemaContent[`@_xmlns:${foundNamespace.key}`] = foundNamespace.url;
-    schemaObject[`${foundNamespace.key}:schema`] = schemaContent;
-    schema = utils.parseObjectToXML(schemaObject)
-      .replace(/tns:/g, '')
-      .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
-    return schema;
+    // nsKey = foundNamespace.key === '' ? `@_xmlns${foundNamespace.key}` : `@_xmlns:${foundNamespace.key}`;
+    // schemaTag = foundNamespace.key === '' ? `${foundNamespace.key}schema` : `${foundNamespace.key}:schema`;
+    // schemaContent[nsKey] = foundNamespace.url;
+    // schemaObject[schemaTag] = schemaContent;
+    // schema = utils.parseObjectToXML(schemaObject)
+    //   .replace(/tns:/g, '')
+    //   .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
+    // return schema;
+    schema = getCleanSchema2(schemaContent, foundNamespace);
+    return { cleanSchema: schema, isSchemaXSDDefault: foundNamespace.key === '' }
   }
   catch (error) {
     throw new Error('Cannot get schema from object');
   }
 }
+
+
 
 module.exports = {
   validateOperationMessagesWithSchema,

--- a/lib/utils/messageWithSchemaValidation.js
+++ b/lib/utils/messageWithSchemaValidation.js
@@ -13,6 +13,31 @@ const libxml = require('libxmljs'),
   WSDL11_root = 'definitions',
   WSDL20_root = 'description';
 
+
+/**
+ * Gets the whole SOAP Messge and returns only the payload
+ * @param {string} message body message generated for all operations
+ * @param {string} tagName name of the message tag
+ * @returns {string} the unwrapped bodyMessage
+ */
+function getMessagePayload(message, tagName) {
+  const regex = new RegExp(`<${tagName}[\\s\\S]*?>[\\s\\S]*?<\\/${tagName}>|<${tagName}[\\s\\S]*?\\/>`, 'g'),
+    result = regex.exec(message);
+  return result ? result[0] : undefined;
+}
+
+/**
+ * Removes xmlns declaration from message (needed for validation)
+ * @param {string} message body message generated for all operations
+ * @param {string} tagName name of the message tag
+ * @returns {string} the unwrapped bodyMessage
+ */
+function removeXMLNSFromRoot(message) {
+  const nameSpaceRegex = /\S*=[\S"'].*"/,
+    cleanMessage = message ? message.replace(nameSpaceRegex, '') : '';
+  return cleanMessage;
+}
+
 /**
  * Return body message from request body message
  * @param {string} message body message generated for all operations
@@ -20,23 +45,25 @@ const libxml = require('libxmljs'),
  * @returns {string} the unwrapped bodyMessage
  */
 function unwrapAndCleanBody(message, tagName) {
-  const nameSpaceRegex = /\S*=[\S"'].*"/,
-    regex = new RegExp(`<${tagName}[\\s\\S]*?>[\\s\\S]*?<\\/${tagName}>|<${tagName}[\\s\\S]*?\\/>`, 'g'),
-    result = regex.exec(message),
-    cleanMessage = result ? result[0].replace(nameSpaceRegex, '') : '';
-  return cleanMessage;
+  return removeXMLNSFromRoot(getMessagePayload(message, tagName));
 }
 
 /**
  * Generates the body message from a nodeElement
  * @param {Element} nodeElement node taken from parsedXml
  * @param {string} protocol Protocol being used
+ * @param {boolean} cleanBody indicates if xmlns should be removed from the root node
  * @returns {string} Unwrapped body message without attributes
  */
-function getBodyMessage(nodeElement, protocol) {
+function getBodyMessage(nodeElement, protocol, cleanBody = true) {
   const soapMessageHelper = new SOAPMessageHelper();
   bodyMessage = soapMessageHelper.convertInputToMessage(nodeElement, [], protocol);
-  cleanBodyMessage = nodeElement ? unwrapAndCleanBody(bodyMessage, nodeElement.name) : '';
+  if (cleanBody) {
+    cleanBodyMessage = nodeElement ? unwrapAndCleanBody(bodyMessage, nodeElement.name) : '';
+  }
+  else {
+    cleanBodyMessage = nodeElement ? getMessagePayload(bodyMessage, nodeElement.name) : '';
+  }
   return cleanBodyMessage;
 }
 
@@ -57,14 +84,15 @@ function validateMessageWithSchema(message, schema) {
  * Validate all messages generated from the wsdlObject operationsArray
  * @param {WSDLObject} wsdlObject wsdlObject generated from a xmlDocument
  * @param {string} schemaBase Schema base from xmlDocument
+ * @param {boolean} isSchemaXSDDefault if the xsd ns is the default one
  * @returns {array} An array with all errors from all generated bodies from a wsdlObject
  */
-function validateOperationMessagesWithSchema(wsdlObject, schemaBase) {
+function validateOperationMessagesWithSchema(wsdlObject, schemaBase, isSchemaXSDDefault) {
   const operations = wsdlObject.operationsArray;
   let validationErrors = [];
   operations.forEach((operation) => {
     let protocol = operation.protocol,
-      bodyMessage = getBodyMessage(operation.input, protocol);
+      bodyMessage = getBodyMessage(operation.input, protocol, !isSchemaXSDDefault);
     if (!bodyMessage && !schemaBase) {
       return;
     }
@@ -123,8 +151,6 @@ function getSchemaContentWithoutAttributes(schemaContent) {
  * @returns {object} The schema content and its corresponding namespace object
  */
 function getLocalNamespaceDefinition(wsdlObject, wsdlTypes) {
-  // let realNamespace = getRealNamespace(wsdlObject,
-  // 'http://www.example.com/interfaces/parking/operatorServices/v1/data');
   let schemaContent = getSchemaContentWithoutAttributes(wsdlTypes[`${wsdlObject.schemaNamespace.key}:schema`]);
   if (!schemaContent || Object.keys(schemaContent).length === 0) {
     for (let index = 0; index < wsdlObject.localSchemaNamespaces.length; index++) {
@@ -146,20 +172,14 @@ function getLocalNamespaceDefinition(wsdlObject, wsdlTypes) {
   };
 }
 
-// getRealNamespace(wsdlObject, targetNSUrl){
-
-//   let realNamespace;
-//   realNamespace = wsdlObject.localSchemaNamespaces.find((namespace) => {
-//     namespace.tnsDefinitionURL === targetNSUrl;
-//   });
-
-//   if (!realNamespace) {
-//     realNamespace = wsdlObject.schemaNamespace;
-//   }
-//   return realNamespace;
-// }
-
-function getCleanSchema2(schemaContent, foundNamespace) {
+/**
+ * Identifies if the ns: declarations should be removed from schema
+ * to pass validation
+ * @param {object} schemaContent the parsed xml generated from a xmlDocument
+ * @param {object} foundNamespace the parsed WSDLObject
+ * @returns {string} The schemaBase
+ */
+function getCleanSchemaCheckNamespace(schemaContent, foundNamespace) {
   let schema,
     schemaTag,
     schemaObject = {},
@@ -175,7 +195,6 @@ function getCleanSchema2(schemaContent, foundNamespace) {
     schemaContent[nsKey] = foundNamespace.url;
     schemaObject[schemaTag] = schemaContent;
     schema = utils.parseObjectToXML(schemaObject)
-      //.replace(/tns:/g, '')
       .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
   }
   else {
@@ -187,8 +206,6 @@ function getCleanSchema2(schemaContent, foundNamespace) {
       .replace(/tns:/g, '')
       .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
   }
-
-
   return schema;
 }
 
@@ -204,44 +221,31 @@ function getCleanSchema(parsedXml, wsdlObject, wsdl_version) {
     throw new Error('Cannot get schema from undefined or null object');
   }
   try {
-    let nsKey,
-      schemaTag,
-      wsdl_root = getWsdlRootTag(wsdl_version),
+    let wsdl_root = getWsdlRootTag(wsdl_version),
       principalPrefix = getPrincipalPrefix(parsedXml, wsdl_root),
       definitions,
       types,
-      schemaObject = {},
-      utils = new SOAPMessageHelper(),
       schema;
 
     definitions = parsedXml[principalPrefix + wsdl_root];
     types = definitions[principalPrefix + 'types'];
     if (!types) {
-      return types;
+      return { cleanSchema: types, isSchemaXSDDefault: types };
     }
     const { schemaContent, foundNamespace } = getLocalNamespaceDefinition(wsdlObject, types);
-    // nsKey = foundNamespace.key === '' ? `@_xmlns${foundNamespace.key}` : `@_xmlns:${foundNamespace.key}`;
-    // schemaTag = foundNamespace.key === '' ? `${foundNamespace.key}schema` : `${foundNamespace.key}:schema`;
-    // schemaContent[nsKey] = foundNamespace.url;
-    // schemaObject[schemaTag] = schemaContent;
-    // schema = utils.parseObjectToXML(schemaObject)
-    //   .replace(/tns:/g, '')
-    //   .replace(/\s*<[\w]*:?complexType>\s*<\/[\w]*:?complexType>/g, '');
-    // return schema;
-    schema = getCleanSchema2(schemaContent, foundNamespace);
-    return { cleanSchema: schema, isSchemaXSDDefault: foundNamespace.key === '' }
+    schema = getCleanSchemaCheckNamespace(schemaContent, foundNamespace);
+    return { cleanSchema: schema, isSchemaXSDDefault: foundNamespace.key === '' };
   }
   catch (error) {
     throw new Error('Cannot get schema from object');
   }
 }
 
-
-
 module.exports = {
   validateOperationMessagesWithSchema,
   getCleanSchema,
   validateMessageWithSchema,
   getBodyMessage,
-  unwrapAndCleanBody
+  unwrapAndCleanBody,
+  getMessagePayload
 };

--- a/lib/utils/objectUtils.js
+++ b/lib/utils/objectUtils.js
@@ -4,7 +4,15 @@
  * @returns {[object]} the array of objects
  */
 function getArrayFrom(element) {
+  //if (element && !Array.isArray(element) || element === '') {
   if (element && !Array.isArray(element)) {
+    return [element];
+  }
+  return element;
+}
+
+function getStringArrayFrom(element) {
+  if (element && !Array.isArray(element) || element === '') { 
     return [element];
   }
   return element;
@@ -12,5 +20,6 @@ function getArrayFrom(element) {
 
 
 module.exports = {
-  getArrayFrom
+  getArrayFrom,
+  getStringArrayFrom
 };

--- a/lib/utils/objectUtils.js
+++ b/lib/utils/objectUtils.js
@@ -4,15 +4,20 @@
  * @returns {[object]} the array of objects
  */
 function getArrayFrom(element) {
-  //if (element && !Array.isArray(element) || element === '') {
   if (element && !Array.isArray(element)) {
     return [element];
   }
   return element;
 }
 
+/**
+ * if an element is not an array then convert it to an array
+ * if is empty string also returns array of strings
+ * @param {object} element the element the return as array
+ * @returns {[object]} the array of elements
+ */
 function getStringArrayFrom(element) {
-  if (element && !Array.isArray(element) || element === '') { 
+  if (element && !Array.isArray(element) || element === '') {
     return [element];
   }
   return element;

--- a/test/convert-validation/ValidationReport.test.js
+++ b/test/convert-validation/ValidationReport.test.js
@@ -48,7 +48,7 @@ describe('SchemaPack convert and validate report missmatches WSDL 1.1', function
           }
           if (!error && !result.matched) {
             console.error(`Test Failed ${file}`);
-            fs.writeFileSync(outputDirectory + file + '-validationResult.json', JSON.stringify(result));
+            fs.writeFileSync(outputDirectory + file + '-validationResult.json', JSON.stringify({ erors: result }));
             fs.writeFileSync(outputDirectory + file + '-collection.json',
               JSON.stringify(collectionResult.output[0].data));
           }

--- a/test/data/validWSDLs11/mergedImportedSchema.wsdl
+++ b/test/data/validWSDLs11/mergedImportedSchema.wsdl
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CountingCategoryService" targetNamespace="http://{{url}}/interfaces/parking/operatorServices/v1"
+    xmlns:tns="http://{{url}}/interfaces/parking/operatorServices/v1"
+    xmlns:countingCategoryData="http://{{url}}/interfaces/parking/operatorServices/v1/data"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://{{url}}/interfaces/parking/operatorServices/v1/data"
+        xmlns:tns="http://{{url}}/interfaces/parking/operatorServices/v1/data"
+        elementFormDefault="qualified">
+
+    <element name="SetCountingCategoryMode">
+        <complexType >
+            <sequence>
+                <element name="facilityId" type="long"/>
+                <element name="carParkNumber" type="int"/>
+                <element name="countingCategoryType" type="tns:countingCategoryType"/>
+                <element name="trafficSignalMode" type="tns:trafficSignalMode"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="SetCountingCategoryModeOut">
+        <complexType>
+            <sequence>
+                <element name="SetCountingCategoryModeResponse" type="tns:SetCountingCategoryModeResponse">
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    <complexType name="SetCountingCategoryModeResponse">
+        <sequence/>
+    </complexType>
+
+
+    <element name="SetCountingCategoryLevel">
+        <complexType >
+            <sequence>
+                <element name="facilityId" type="long"/>
+                <element name="carParkNumber" type="int"/>
+                <element name="countingCategoryType" type="tns:countingCategoryType"/>
+                <element name="currentLevel" type="int"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="SetCountingCategoryLevelOut">
+        <complexType>
+            <sequence>
+                <element name="SetCountingCategoryLevelResponse" type="tns:SetCountingCategoryLevelResponse">
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    <complexType name="SetCountingCategoryLevelResponse">
+        <sequence/>
+    </complexType>
+
+    <element name="SetExternalCountingMode">
+        <complexType >
+            <sequence>
+                <element name="facilityId" type="long"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="SetExternalCountingModeOut">
+        <complexType>
+            <sequence>
+                <element name="SetExternalCountingModeResponse" type="tns:SetExternalCountingModeResponse">
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    <complexType name="SetExternalCountingModeResponse">
+        <sequence/>
+    </complexType>
+
+
+    <simpleType name="trafficSignalMode">
+        <restriction base="string">
+            <enumeration value="AUTOMATIC"/>
+            <enumeration value="MANUAL_GREEN_FREE"/>
+            <enumeration value="MANUAL_RED_FULL"/>
+        </restriction>
+    </simpleType>
+
+    <simpleType name="countingCategoryType">
+        <restriction base="string">
+            <enumeration value="DEFAULT_COUNTING_CATEGORY_00"/>
+            <enumeration value="SHORT_TERM_PARKER_01"/>
+            <enumeration value="CONTRACT_PARKER_02"/>
+            <enumeration value="TOTAL_03"/>
+            <enumeration value="USER_DEFINED_04"/>
+            <enumeration value="USER_DEFINED_05"/>
+            <enumeration value="USER_DEFINED_06"/>
+            <enumeration value="USER_DEFINED_07"/>
+            <enumeration value="USER_DEFINED_08"/>
+            <enumeration value="USER_DEFINED_09"/>
+            <enumeration value="USER_DEFINED_10"/>
+            <enumeration value="USER_DEFINED_11"/>
+            <enumeration value="USER_DEFINED_12"/>
+            <enumeration value="USER_DEFINED_13"/>
+            <enumeration value="USER_DEFINED_14"/>
+            <enumeration value="USER_DEFINED_15"/>
+            <enumeration value="USER_DEFINED_16"/>
+            <enumeration value="USER_DEFINED_17"/>
+            <enumeration value="USER_DEFINED_18"/>
+            <enumeration value="USER_DEFINED_19"/>
+            <enumeration value="USER_DEFINED_20"/>
+            <enumeration value="USER_DEFINED_21"/>
+            <enumeration value="USER_DEFINED_22"/>
+            <enumeration value="USER_DEFINED_23"/>
+            <enumeration value="USER_DEFINED_24"/>
+            <enumeration value="USER_DEFINED_25"/>
+            <enumeration value="USER_DEFINED_26"/>
+            <enumeration value="USER_DEFINED_27"/>
+            <enumeration value="USER_DEFINED_28"/>
+            <enumeration value="USER_DEFINED_29"/>
+            <enumeration value="USER_DEFINED_30"/>
+            <enumeration value="USER_DEFINED_31"/>
+            <enumeration value="USER_DEFINED_32"/>
+            <enumeration value="USER_DEFINED_33"/>
+            <enumeration value="USER_DEFINED_34"/>
+            <enumeration value="USER_DEFINED_35"/>
+            <enumeration value="USER_DEFINED_36"/>
+            <enumeration value="USER_DEFINED_37"/>
+            <enumeration value="USER_DEFINED_38"/>
+            <enumeration value="USER_DEFINED_39"/>
+            <enumeration value="USER_DEFINED_40"/>
+            <enumeration value="USER_DEFINED_41"/>
+            <enumeration value="USER_DEFINED_42"/>
+            <enumeration value="USER_DEFINED_43"/>
+            <enumeration value="USER_DEFINED_44"/>
+            <enumeration value="USER_DEFINED_45"/>
+            <enumeration value="USER_DEFINED_46"/>
+            <enumeration value="USER_DEFINED_47"/>
+            <enumeration value="USER_DEFINED_48"/>
+            <enumeration value="USER_DEFINED_49"/>
+            <enumeration value="USER_DEFINED_50"/>
+            <enumeration value="USER_DEFINED_51"/>
+            <enumeration value="USER_DEFINED_52"/>
+            <enumeration value="USER_DEFINED_53"/>
+        </restriction>
+    </simpleType>
+</schema>
+    </wsdl:types>
+
+    <wsdl:message name="SetCountingCategoryMode">
+        <wsdl:part name="SetCountingCategoryModeRequest" element="countingCategoryData:SetCountingCategoryMode"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryModeResponse">
+        <wsdl:part name="SetCountingCategoryModeResponse" element="countingCategoryData:SetCountingCategoryModeOut"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryLevel">
+        <wsdl:part name="SetCountingCategoryLevel" element="countingCategoryData:SetCountingCategoryLevel"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryLevelResponse">
+        <wsdl:part name="SetCountingCategoryLevelResponse" element="countingCategoryData:SetCountingCategoryLevelOut"/>
+    </wsdl:message>
+    <wsdl:message name="SetExternalCountingMode">
+        <wsdl:part name="SetExternalCountingMode" element="countingCategoryData:SetExternalCountingMode"/>
+    </wsdl:message>
+    <wsdl:message name="SetExternalCountingModeResponse">
+        <wsdl:part name="SetExternalCountingModeResponse" element="countingCategoryData:SetExternalCountingModeOut"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="CountingCategoryServiceInterface">
+        <wsdl:operation name="SetCountingCategoryMode">
+            <wsdl:input name="SetCountingCategoryModeRequest" message="tns:SetCountingCategoryMode"/>
+            <wsdl:output name="SetCountingCategoryModeResponse" message="tns:SetCountingCategoryModeResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetCountingCategoryLevel">
+            <wsdl:input name="SetCountingCategoryLevelRequest" message="tns:SetCountingCategoryLevel"/>
+            <wsdl:output name="SetCountingCategoryLevelResponse" message="tns:SetCountingCategoryLevelResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetExternalCountingMode">
+            <wsdl:input name="SetExternalCountingModeRequest" message="tns:SetExternalCountingMode"/>
+            <wsdl:output name="SetExternalCountingModeResponse" message="tns:SetExternalCountingModeResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="example.CountingCategoryServiceBinding" type="tns:CountingCategoryServiceInterface">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="SetCountingCategoryMode">
+            <soap:operation soapAction="http://{{url}}/interfaces/parking/operatorServices/v1/SetCountingCategoryMode" style="document"/>
+            <wsdl:input name="SetCountingCategoryModeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetCountingCategoryModeResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetCountingCategoryLevel">
+            <soap:operation soapAction="http://{{url}}/interfaces/parking/operatorServices/v1/SetCountingCategoryLevel" style="document"/>
+            <wsdl:input name="SetCountingCategoryLevelRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetCountingCategoryLevelResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetExternalCountingMode">
+            <soap:operation soapAction="http://{{url}}/interfaces/parking/operatorServices/v1/SetExternalCountingMode" style="document"/>
+            <wsdl:input name="SetExternalCountingModeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetExternalCountingModeResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="example.CountingCategoryService">
+        <wsdl:port name="example.CountingCategoryServicePort" binding="tns:example.CountingCategoryServiceBinding">
+            <soap:address location="http://{{url}}/interfaces/parking/operatorServices/v1/CountingCategoryService"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/test/e2e/validateOperationMessagesWithSchema.test.js
+++ b/test/e2e/validateOperationMessagesWithSchema.test.js
@@ -25,7 +25,8 @@ describe('Validating wsdlObject bodyMessages using validateOperationMessagesWith
         xmlParsed = xmlParser.parseToObject(xmlDocumentContent),
         schemaToValidate = getCleanSchema(xmlParsed, wsdlObject, version);
 
-      let errors = validateOperationMessagesWithSchema(wsdlObject, schemaToValidate.cleanSchema);
+      let errors = validateOperationMessagesWithSchema(wsdlObject, schemaToValidate.cleanSchema,
+        schemaToValidate.isSchemaXSDDefault);
       expect(errors).to.be.an('array');
       expect(errors.length).to.be.equal(0);
     });

--- a/test/e2e/validateOperationMessagesWithSchema.test.js
+++ b/test/e2e/validateOperationMessagesWithSchema.test.js
@@ -25,7 +25,7 @@ describe('Validating wsdlObject bodyMessages using validateOperationMessagesWith
         xmlParsed = xmlParser.parseToObject(xmlDocumentContent),
         schemaToValidate = getCleanSchema(xmlParsed, wsdlObject, version);
 
-      let errors = validateOperationMessagesWithSchema(wsdlObject, schemaToValidate);
+      let errors = validateOperationMessagesWithSchema(wsdlObject, schemaToValidate.cleanSchema);
       expect(errors).to.be.an('array');
       expect(errors.length).to.be.equal(0);
     });

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -30,9 +30,6 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
         expect(result.output).to.be.an('array');
         expect(result.output[0].data).to.be.an('object');
         expect(result.output[0].type).to.equal('collection');
-        if (file === 'failing.wsdl') {
-          fs.writeFileSync('coll.json', JSON.stringify(result.output[0].data));
-        }
       });
     });
   });

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -30,6 +30,9 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
         expect(result.output).to.be.an('array');
         expect(result.output[0].data).to.be.an('object');
         expect(result.output[0].type).to.equal('collection');
+        if (file === 'failing.wsdl') {
+          fs.writeFileSync('coll.json', JSON.stringify(result.output[0].data));
+        }
       });
     });
   });

--- a/test/unit/messageWithSchemaValidation.test.js
+++ b/test/unit/messageWithSchemaValidation.test.js
@@ -222,7 +222,7 @@ describe('Tools from messageWithSchemaValidation', function () {
       'Should return a schema with base namespace, removed tns and no complexType, tags empty',
       function () {
         const generatedCleanSchema = getCleanSchema(xmlParsedMock, { schemaNamespace: schemaNamespaceMock },
-            wsdl_version),
+            wsdl_version).cleanSchema,
           generatedCleanSchemaToCompare = generatedCleanSchema.replace(/\s/g, ''),
           expectedSchemaToCompare = expectedSchema.replace(/\s/g, '');
         expect(generatedCleanSchemaToCompare).to.be.equal(expectedSchemaToCompare);


### PR DESCRIPTION
Review well functioning of files with schema import

The file import should work properly.

WSDL docs that have refs to external locations

Currently the files that have imports are processed and in the body soap message show a message indicating that the element could not be found.

We manually merged the file mergedImportedSchema.wsdl and this file does not create the messages correctly due that this specific file has a declaration schema xmlns="http://www.w3.org/2001/XMLSchema" without prefix so this was unexpected. Had to make changes in conversion and validation processes in order to correctly handle this file