### PR TITLE
Avoid use read file sync

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -163,24 +163,6 @@ class SchemaPack {
     }
   }
 
-  mergeAndValidate2(callback) {
-
-    const wsdlMerger = new WSDLMerger();
-    let validationResult;
-    try {
-      let merged = wsdlMerger.merge(this.input.data, this.input.xmlFiles, this.xmlParser);
-      this.input = {
-        type: 'string',
-        data: merged
-      };
-      validationResult = this.validate();
-      return callback(null, validationResult);
-    }
-    catch (error) {
-      callback(error);
-    }
-  }
-
   static getOptions(mode, criteria) {
     return getOptions(mode, criteria);
   }

--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -137,6 +137,33 @@ class SchemaPack {
    * @returns {boolean} validation
    */
   mergeAndValidate(callback) {
+    const wsdlMerger = new WSDLMerger();
+    let validationResult;
+    try {
+      wsdlMerger.merge(this.input.data, this.input.xmlFiles, this.xmlParser)
+        .then((merged) => {
+          this.input = {
+            type: 'string',
+            data: merged
+          };
+          validationResult = this.validate();
+          return callback(null, validationResult);
+        })
+        .catch((err) => {
+          this.validationResult = {
+            result: false,
+            reason: 'Error while merging files.',
+            error: err
+          };
+          return callback(null, this.validationResult);
+        });
+    }
+    catch (error) {
+      callback(error);
+    }
+  }
+
+  mergeAndValidate2(callback) {
 
     const wsdlMerger = new WSDLMerger();
     let validationResult;

--- a/lib/utils/SOAPHeader.js
+++ b/lib/utils/SOAPHeader.js
@@ -57,7 +57,7 @@ class SOAPHeader {
    * @param {string} parserAttributePlaceHolder character for attributes of parser
    * @returns {object} jObj object to parse
    */
-  processUsernameToken = (usernameTokenInput, jObj, parserAttributePlaceHolder) => {
+  processUsernameToken(usernameTokenInput, jObj, parserAttributePlaceHolder) {
 
     let usernameTokenOutput = {},
       password = {},
@@ -100,7 +100,7 @@ class SOAPHeader {
    * @param {string} parserAttributePlaceHolder character for attributes of parser
    * @returns {object} jObj object to parse
    */
-  processSAMLToken = (samlTokenInput, jObj, parserAttributePlaceHolder) => {
+  processSAMLToken(samlTokenInput, jObj, parserAttributePlaceHolder) {
 
     let samlTokenOutput = {},
       conditions = {},

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -274,24 +274,50 @@ class WSDLMerger {
    * @returns {string} the single file
    */
   merge(filesPathArray, files, xmlParser) {
+    let contentFiles = [],
+      promises = [];
+
+    if (files) {
+      filesPathArray.forEach((filePath) => {
+        contentFiles.push(files[path.resolve(filePath.fileName)]);
+      });
+      return new Promise((resolve, reject) => {
+        try {
+          let res = this.processMergeFiles(contentFiles, xmlParser);
+          resolve(res);
+        }
+        catch (err) {
+          reject(err);
+        }
+      });
+    }
+
+    filesPathArray.forEach((filePath) => {
+      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION));
+    });
+    return Promise.all(promises).then((values) => {
+      contentFiles = values;
+      return this.processMergeFiles(contentFiles, xmlParser);
+    });
+
+  }
+
+  /**
+   * Merge different files to a single WSDL
+   * @param {Array} contentFiles the content of the files in string
+   * @param {object} xmlParser the parser class to parse xml to object or vice versa
+   * @returns {string} the single file
+   */
+  processMergeFiles(contentFiles, xmlParser) {
     let parsedSchemas,
       root,
       parsedWSDL,
       wsdlVersion,
-      contentFiles = [],
-      wsdlRoot = '',
-
-      parsedXML = filesPathArray.map((filePath) => {
-        let file;
-        if (files) {
-          file = files[path.resolve(filePath.fileName)];
-        }
-        else {
-          file = fs.readFileSync(filePath.fileName, CODIFICATION);
-        }
-        contentFiles.push(file);
-        return xmlParser.parseToObject(file);
-      });
+      parsedXML,
+      wsdlRoot = '';
+    parsedXML = contentFiles.map((file) => {
+      return xmlParser.parseToObject(file);
+    });
 
     wsdlVersion = this.getFilesVersion(contentFiles);
     wsdlRoot = wsdlVersion === V11 ? 'definitions' : 'description';
@@ -366,6 +392,21 @@ class WSDLMerger {
       return filtered[0];
     }
     throw new WsdlError('There was not WSDL file in folder');
+  }
+
+  /** Read File asynchronously
+   *
+   * @param {String} filePath Path of the file.
+   * @param {String} encoding encoding
+   * @return {String} Contents of the file
+   */
+  readFileAsync(filePath, encoding) {
+    return new Promise((resolve, reject) => {
+      fs.readFile(filePath, encoding, (err, data) => {
+        if (err) { reject(err); }
+        else { resolve(data); }
+      });
+    });
   }
 }
 

--- a/test/unit/WSDLMerger.test.js
+++ b/test/unit/WSDLMerger.test.js
@@ -79,7 +79,6 @@ describe('WSDLMerger merge', function() {
 
     let processedInput = {},
       files = [],
-      merged,
       array = [{
         fileName: folderPath + '/stockquote.xsd'
       }, {
@@ -101,8 +100,10 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathDefinitions] = processedInputFiles[1];
     processedInput[folderPathService] = processedInputFiles[2];
 
-    merged = merger.merge(files, processedInput, new XMLParser());
-    expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
+    merger.merge(files, processedInput, new XMLParser())
+      .then((merged) => {
+        expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
+      });
   });
 
   it('Should create collection from folder having one root file for browser 1.1 no prefix', function() {
@@ -360,7 +361,6 @@ describe('WSDLMerger merge', function() {
       expectedOutput = fs.readFileSync(outputDir, 'utf8');
     let processedInput = {},
       files = [],
-      merged,
       array = [{
         fileName: folderPath + '/CountingCategoryData.xsd'
       },
@@ -378,8 +378,10 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
 
-    merged = merger.merge(files, processedInput, new XMLParser());
-    expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
+    merger.merge(files, processedInput, new XMLParser())
+      .then((merged) => {
+        expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
+      });
   });
 
 });


### PR DESCRIPTION
Change the use of readFileSync for readFile return a promise in merge functionality for handling asynchronous calls