### PR TITLE
Fix incorrect name

### DIFF
--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -72,6 +72,9 @@ function getCollectionNameFromFileOrEmpty(input) {
   else if (input.type === 'string') {
     name = '';
   }
+  else if (input.type === 'folder') {
+    name = '';
+  }
   else {
     return {
       result: false,

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -516,6 +516,7 @@ describe('merge and validate', function () {
           expect(result.output[0].type).to.have.equal('collection');
           expect(result.output[0].data).to.have.property('info');
           expect(result.output[0].data).to.have.property('item');
+          expect(result.output[0].data.info.name).to.equal('http://example.com/stockquote/service');
         });
       }
       else {


### PR DESCRIPTION
issue: after merging converting the file gives this name:
"name": {
"result":false,
"reason":"Invalid input type (folder)....
}

the name should be a string
Instead of creating an error we set to empty string, doing this the name will be taken from the generated (merged) file