### PR TITLE
Throw error multiple roots

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -19,6 +19,7 @@ const COLLECTION_TYPE = 'collection',
   {
     WSDLMerger
   } = require('./utils/WSDLMerger'),
+  WsdlError = require('./WsdlError'),
   {
     TransactionValidator
   } = require('./TransactionValidator');
@@ -150,11 +151,20 @@ class SchemaPack {
           return callback(null, validationResult);
         })
         .catch((err) => {
-          this.validationResult = {
-            result: false,
-            reason: 'Error while merging files.',
-            error: err
-          };
+          if (err instanceof WsdlError) {
+            this.validationResult = {
+              result: false,
+              reason: err.message,
+              error: err
+            };
+          }
+          else {
+            this.validationResult = {
+              result: false,
+              reason: 'Error while merging files.',
+              error: err
+            };
+          }
           return callback(null, this.validationResult);
         });
     }

--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -139,7 +139,8 @@ class SchemaPack {
    */
   mergeAndValidate(callback) {
     const wsdlMerger = new WSDLMerger();
-    let validationResult;
+    let validationResult,
+      errReason;
     try {
       wsdlMerger.merge(this.input.data, this.input.xmlFiles, this.xmlParser)
         .then((merged) => {
@@ -151,20 +152,13 @@ class SchemaPack {
           return callback(null, validationResult);
         })
         .catch((err) => {
-          if (err instanceof WsdlError) {
-            this.validationResult = {
-              result: false,
-              reason: err.message,
-              error: err
-            };
-          }
-          else {
-            this.validationResult = {
-              result: false,
-              reason: 'Error while merging files.',
-              error: err
-            };
-          }
+          errReason = err instanceof WsdlError ?
+            err.message : 'Error while merging files.';
+          this.validationResult = {
+            result: false,
+            reason: errReason,
+            error: err
+          };
           return callback(null, this.validationResult);
         });
     }

--- a/lib/constants/messageConstants.js
+++ b/lib/constants/messageConstants.js
@@ -2,12 +2,18 @@ const DOC_HAS_NO_SERVICE_MESSAGE = 'The specified document has no service the it
   DOC_HAS_NO_BINDINGS_MESSAGE = 'The specified document has no bindings or operations, the items were not created',
   DOC_HAS_NO_BINDINGS_OPERATIONS_MESSAGE = 'The specified document has no operations, the items were not created',
   DOC_HAS_NO_SERVICE_PORT_MESSAGE = 'The specified document has no ports the items url could not be determined',
-  ELEMENT_NOT_FOUND = 'The element or type could not be found';
+  ELEMENT_NOT_FOUND = 'The element or type could not be found',
+  MULTIPLE_ROOT_FILES = 'There are multiple files with services defined.',
+  NOT_WSDL_IN_FOLDER = 'There was not WSDL file in folder.',
+  WSDL_DIFF_VERSION = 'All WSDL must be the same version.';
 
 module.exports = {
   DOC_HAS_NO_SERVICE_MESSAGE,
   DOC_HAS_NO_BINDINGS_MESSAGE,
   DOC_HAS_NO_BINDINGS_OPERATIONS_MESSAGE,
   DOC_HAS_NO_SERVICE_PORT_MESSAGE,
-  ELEMENT_NOT_FOUND
+  ELEMENT_NOT_FOUND,
+  MULTIPLE_ROOT_FILES,
+  NOT_WSDL_IN_FOLDER,
+  WSDL_DIFF_VERSION
 };

--- a/lib/constants/messageConstants.js
+++ b/lib/constants/messageConstants.js
@@ -5,7 +5,8 @@ const DOC_HAS_NO_SERVICE_MESSAGE = 'The specified document has no service the it
   ELEMENT_NOT_FOUND = 'The element or type could not be found',
   MULTIPLE_ROOT_FILES = 'There are multiple files with services defined.',
   NOT_WSDL_IN_FOLDER = 'There was not WSDL file in folder.',
-  WSDL_DIFF_VERSION = 'All WSDL must be the same version.';
+  WSDL_DIFF_VERSION = 'All WSDL must be the same version.',
+  MISSING_XML_PARSER = 'XMLParser should be proportionated.';
 
 module.exports = {
   DOC_HAS_NO_SERVICE_MESSAGE,
@@ -15,5 +16,6 @@ module.exports = {
   ELEMENT_NOT_FOUND,
   MULTIPLE_ROOT_FILES,
   NOT_WSDL_IN_FOLDER,
-  WSDL_DIFF_VERSION
+  WSDL_DIFF_VERSION,
+  MISSING_XML_PARSER
 };

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -33,7 +33,8 @@ const path = require('path-browserify'),
   {
     MULTIPLE_ROOT_FILES,
     NOT_WSDL_IN_FOLDER,
-    WSDL_DIFF_VERSION
+    WSDL_DIFF_VERSION,
+    MISSING_XML_PARSER
   } = require('../constants/messageConstants');
 class WSDLMerger {
 
@@ -321,6 +322,9 @@ class WSDLMerger {
       wsdlVersion,
       parsedXML,
       wsdlRoot = '';
+    if (!xmlParser) {
+      throw new WsdlError(MISSING_XML_PARSER);
+    }
     parsedXML = contentFiles.map((file) => {
       return xmlParser.parseToObject(file);
     });

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -29,7 +29,12 @@ const path = require('path-browserify'),
   {
     getArrayFrom
   } = require('./objectUtils'),
-  WsdlError = require('../WsdlError');
+  WsdlError = require('../WsdlError'),
+  {
+    MULTIPLE_ROOT_FILES,
+    NOT_WSDL_IN_FOLDER,
+    WSDL_DIFF_VERSION
+  } = require('../constants/messageConstants');
 class WSDLMerger {
 
   /**
@@ -39,7 +44,7 @@ class WSDLMerger {
    * @returns {object} the root
    */
   getRoot(xmlParsedArray, wsdlRoot) {
-    let root = xmlParsedArray.find((xmlParsed) => {
+    let root = xmlParsedArray.filter((xmlParsed) => {
       let principalPrefix = getPrincipalPrefix(xmlParsed, wsdlRoot),
         hasImports = wsdlHasImports(xmlParsed, principalPrefix, wsdlRoot),
         hasServices = getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, SERVICE_TAG);
@@ -311,6 +316,7 @@ class WSDLMerger {
   processMergeFiles(contentFiles, xmlParser) {
     let parsedSchemas,
       root,
+      rootFiles,
       parsedWSDL,
       wsdlVersion,
       parsedXML,
@@ -323,7 +329,11 @@ class WSDLMerger {
     wsdlRoot = wsdlVersion === V11 ? 'definitions' : 'description';
     parsedSchemas = this.getParsedSchemasFromAllParsed(parsedXML);
     parsedWSDL = this.getParsedWSDLFromAllParsed(parsedXML, wsdlRoot);
-    root = this.getRoot(parsedWSDL, wsdlRoot);
+    rootFiles = this.getRoot(parsedWSDL, wsdlRoot);
+    if (rootFiles && rootFiles.length > 1) {
+      throw new WsdlError(MULTIPLE_ROOT_FILES);
+    }
+    root = rootFiles[0];
     this.resolveImportsFromRootFile(root, parsedWSDL, parsedSchemas, wsdlRoot, xmlParser.attributePlaceHolder);
     return xmlParser.parseObjectToXML(root);
   }
@@ -379,7 +389,7 @@ class WSDLMerger {
       if (versions.every((val) => {
         return val === undefined;
       })) {
-        throw new WsdlError('There was not WSDL file in folder');
+        throw new WsdlError(NOT_WSDL_IN_FOLDER);
       }
       let filtered = versions.filter(function (currentVersion) {
         return currentVersion !== undefined;
@@ -387,7 +397,7 @@ class WSDLMerger {
       if (!filtered.every((currentVersion, i, arr) => {
         return currentVersion === arr[0];
       })) {
-        throw new WsdlError('All WSDL must be the same version');
+        throw new WsdlError(WSDL_DIFF_VERSION);
       }
       return filtered[0];
     }

--- a/test/data/separatedFiles/multipleRoot/CountingCategoryData.xsd
+++ b/test/data/separatedFiles/multipleRoot/CountingCategoryData.xsd
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1/data"
+    xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1/data" elementFormDefault="qualified">
+
+    <element name="SetCountingCategoryMode">
+        <complexType >
+            <sequence>
+                <element name="facilityId" type="long"/>
+                <element name="carParkNumber" type="int"/>
+                <element name="countingCategoryType" type="tns:countingCategoryType"/>
+                <element name="trafficSignalMode" type="tns:trafficSignalMode"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="SetCountingCategoryModeOut">
+        <complexType>
+            <sequence>
+                <element name="SetCountingCategoryModeResponse" type="tns:SetCountingCategoryModeResponse">
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    <complexType name="SetCountingCategoryModeResponse">
+        <sequence/>
+    </complexType>
+
+
+    <element name="SetCountingCategoryLevel">
+        <complexType >
+            <sequence>
+                <element name="facilityId" type="long"/>
+                <element name="carParkNumber" type="int"/>
+                <element name="countingCategoryType" type="tns:countingCategoryType"/>
+                <element name="currentLevel" type="int"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="SetCountingCategoryLevelOut">
+        <complexType>
+            <sequence>
+                <element name="SetCountingCategoryLevelResponse" type="tns:SetCountingCategoryLevelResponse">
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    <complexType name="SetCountingCategoryLevelResponse">
+        <sequence/>
+    </complexType>
+
+    <element name="SetExternalCountingMode">
+        <complexType >
+            <sequence>
+                <element name="facilityId" type="long"/>
+            </sequence>
+        </complexType>
+    </element>
+
+    <element name="SetExternalCountingModeOut">
+        <complexType>
+            <sequence>
+                <element name="SetExternalCountingModeResponse" type="tns:SetExternalCountingModeResponse">
+                </element>
+            </sequence>
+        </complexType>
+    </element>
+    <complexType name="SetExternalCountingModeResponse">
+        <sequence/>
+    </complexType>
+
+
+    <simpleType name="trafficSignalMode">
+        <restriction base="string">
+            <enumeration value="AUTOMATIC"/>
+            <enumeration value="MANUAL_GREEN_FREE"/>
+            <enumeration value="MANUAL_RED_FULL"/>
+        </restriction>
+    </simpleType>
+
+    <simpleType name="countingCategoryType">
+        <restriction base="string">
+            <enumeration value="DEFAULT_COUNTING_CATEGORY_00"/>
+            <enumeration value="SHORT_TERM_PARKER_01"/>
+            <enumeration value="CONTRACT_PARKER_02"/>
+            <enumeration value="TOTAL_03"/>
+            <enumeration value="USER_DEFINED_04"/>
+            <enumeration value="USER_DEFINED_05"/>
+            <enumeration value="USER_DEFINED_06"/>
+            <enumeration value="USER_DEFINED_07"/>
+            <enumeration value="USER_DEFINED_08"/>
+            <enumeration value="USER_DEFINED_09"/>
+            <enumeration value="USER_DEFINED_10"/>
+            <enumeration value="USER_DEFINED_11"/>
+            <enumeration value="USER_DEFINED_12"/>
+            <enumeration value="USER_DEFINED_13"/>
+            <enumeration value="USER_DEFINED_14"/>
+            <enumeration value="USER_DEFINED_15"/>
+            <enumeration value="USER_DEFINED_16"/>
+            <enumeration value="USER_DEFINED_17"/>
+            <enumeration value="USER_DEFINED_18"/>
+            <enumeration value="USER_DEFINED_19"/>
+            <enumeration value="USER_DEFINED_20"/>
+            <enumeration value="USER_DEFINED_21"/>
+            <enumeration value="USER_DEFINED_22"/>
+            <enumeration value="USER_DEFINED_23"/>
+            <enumeration value="USER_DEFINED_24"/>
+            <enumeration value="USER_DEFINED_25"/>
+            <enumeration value="USER_DEFINED_26"/>
+            <enumeration value="USER_DEFINED_27"/>
+            <enumeration value="USER_DEFINED_28"/>
+            <enumeration value="USER_DEFINED_29"/>
+            <enumeration value="USER_DEFINED_30"/>
+            <enumeration value="USER_DEFINED_31"/>
+            <enumeration value="USER_DEFINED_32"/>
+            <enumeration value="USER_DEFINED_33"/>
+            <enumeration value="USER_DEFINED_34"/>
+            <enumeration value="USER_DEFINED_35"/>
+            <enumeration value="USER_DEFINED_36"/>
+            <enumeration value="USER_DEFINED_37"/>
+            <enumeration value="USER_DEFINED_38"/>
+            <enumeration value="USER_DEFINED_39"/>
+            <enumeration value="USER_DEFINED_40"/>
+            <enumeration value="USER_DEFINED_41"/>
+            <enumeration value="USER_DEFINED_42"/>
+            <enumeration value="USER_DEFINED_43"/>
+            <enumeration value="USER_DEFINED_44"/>
+            <enumeration value="USER_DEFINED_45"/>
+            <enumeration value="USER_DEFINED_46"/>
+            <enumeration value="USER_DEFINED_47"/>
+            <enumeration value="USER_DEFINED_48"/>
+            <enumeration value="USER_DEFINED_49"/>
+            <enumeration value="USER_DEFINED_50"/>
+            <enumeration value="USER_DEFINED_51"/>
+            <enumeration value="USER_DEFINED_52"/>
+            <enumeration value="USER_DEFINED_53"/>
+        </restriction>
+    </simpleType>
+</schema>

--- a/test/data/separatedFiles/multipleRoot/CountingCategoryService.wsdl
+++ b/test/data/separatedFiles/multipleRoot/CountingCategoryService.wsdl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CountingCategoryService" targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1"
+    xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1"
+    xmlns:countingCategoryData="http://www.example.com/interfaces/parking/operatorServices/v1/data"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+        <xsd:schema elementFormDefault="qualified" targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1">
+            <xsd:import namespace="http://www.example.com/interfaces/parking/operatorServices/v1/data" schemaLocation="CountingCategoryData.xsd"/>
+            <xsd:import schemaLocation="../../../common/v1/CommonData.xsd" namespace="http://www.example.com/interfaces/common/v1/data"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="SetCountingCategoryMode">
+        <wsdl:part name="SetCountingCategoryModeRequest" element="countingCategoryData:SetCountingCategoryMode"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryModeResponse">
+        <wsdl:part name="SetCountingCategoryModeResponse" element="countingCategoryData:SetCountingCategoryModeOut"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryLevel">
+        <wsdl:part name="SetCountingCategoryLevel" element="countingCategoryData:SetCountingCategoryLevel"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryLevelResponse">
+        <wsdl:part name="SetCountingCategoryLevelResponse" element="countingCategoryData:SetCountingCategoryLevelOut"/>
+    </wsdl:message>
+    <wsdl:message name="SetExternalCountingMode">
+        <wsdl:part name="SetExternalCountingMode" element="countingCategoryData:SetExternalCountingMode"/>
+    </wsdl:message>
+    <wsdl:message name="SetExternalCountingModeResponse">
+        <wsdl:part name="SetExternalCountingModeResponse" element="countingCategoryData:SetExternalCountingModeOut"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="CountingCategoryServiceInterface">
+        <wsdl:operation name="SetCountingCategoryMode">
+            <wsdl:input name="SetCountingCategoryModeRequest" message="tns:SetCountingCategoryMode"/>
+            <wsdl:output name="SetCountingCategoryModeResponse" message="tns:SetCountingCategoryModeResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetCountingCategoryLevel">
+            <wsdl:input name="SetCountingCategoryLevelRequest" message="tns:SetCountingCategoryLevel"/>
+            <wsdl:output name="SetCountingCategoryLevelResponse" message="tns:SetCountingCategoryLevelResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetExternalCountingMode">
+            <wsdl:input name="SetExternalCountingModeRequest" message="tns:SetExternalCountingMode"/>
+            <wsdl:output name="SetExternalCountingModeResponse" message="tns:SetExternalCountingModeResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="example.CountingCategoryServiceBinding" type="tns:CountingCategoryServiceInterface">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="SetCountingCategoryMode">
+            <soap:operation soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryMode" style="document"/>
+            <wsdl:input name="SetCountingCategoryModeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetCountingCategoryModeResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetCountingCategoryLevel">
+            <soap:operation soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryLevel" style="document"/>
+            <wsdl:input name="SetCountingCategoryLevelRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetCountingCategoryLevelResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetExternalCountingMode">
+            <soap:operation soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetExternalCountingMode" style="document"/>
+            <wsdl:input name="SetExternalCountingModeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetExternalCountingModeResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="example.CountingCategoryService">
+        <wsdl:port name="example.CountingCategoryServicePort" binding="tns:example.CountingCategoryServiceBinding">
+            <soap:address location="http://www.example.com/interfaces/parking/operatorServices/v1/CountingCategoryService"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/test/data/separatedFiles/multipleRoot/CountingCategoryServiceCopy.wsdl
+++ b/test/data/separatedFiles/multipleRoot/CountingCategoryServiceCopy.wsdl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="CountingCategoryService" targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1"
+    xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1"
+    xmlns:countingCategoryData="http://www.example.com/interfaces/parking/operatorServices/v1/data"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+        <xsd:schema elementFormDefault="qualified" targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1">
+            <xsd:import namespace="http://www.example.com/interfaces/parking/operatorServices/v1/data" schemaLocation="CountingCategoryData.xsd"/>
+            <xsd:import schemaLocation="../../../common/v1/CommonData.xsd" namespace="http://www.example.com/interfaces/common/v1/data"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="SetCountingCategoryMode">
+        <wsdl:part name="SetCountingCategoryModeRequest" element="countingCategoryData:SetCountingCategoryMode"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryModeResponse">
+        <wsdl:part name="SetCountingCategoryModeResponse" element="countingCategoryData:SetCountingCategoryModeOut"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryLevel">
+        <wsdl:part name="SetCountingCategoryLevel" element="countingCategoryData:SetCountingCategoryLevel"/>
+    </wsdl:message>
+    <wsdl:message name="SetCountingCategoryLevelResponse">
+        <wsdl:part name="SetCountingCategoryLevelResponse" element="countingCategoryData:SetCountingCategoryLevelOut"/>
+    </wsdl:message>
+    <wsdl:message name="SetExternalCountingMode">
+        <wsdl:part name="SetExternalCountingMode" element="countingCategoryData:SetExternalCountingMode"/>
+    </wsdl:message>
+    <wsdl:message name="SetExternalCountingModeResponse">
+        <wsdl:part name="SetExternalCountingModeResponse" element="countingCategoryData:SetExternalCountingModeOut"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="CountingCategoryServiceInterface">
+        <wsdl:operation name="SetCountingCategoryMode">
+            <wsdl:input name="SetCountingCategoryModeRequest" message="tns:SetCountingCategoryMode"/>
+            <wsdl:output name="SetCountingCategoryModeResponse" message="tns:SetCountingCategoryModeResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetCountingCategoryLevel">
+            <wsdl:input name="SetCountingCategoryLevelRequest" message="tns:SetCountingCategoryLevel"/>
+            <wsdl:output name="SetCountingCategoryLevelResponse" message="tns:SetCountingCategoryLevelResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetExternalCountingMode">
+            <wsdl:input name="SetExternalCountingModeRequest" message="tns:SetExternalCountingMode"/>
+            <wsdl:output name="SetExternalCountingModeResponse" message="tns:SetExternalCountingModeResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="example.CountingCategoryServiceBinding" type="tns:CountingCategoryServiceInterface">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="SetCountingCategoryMode">
+            <soap:operation soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryMode" style="document"/>
+            <wsdl:input name="SetCountingCategoryModeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetCountingCategoryModeResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetCountingCategoryLevel">
+            <soap:operation soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryLevel" style="document"/>
+            <wsdl:input name="SetCountingCategoryLevelRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetCountingCategoryLevelResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetExternalCountingMode">
+            <soap:operation soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetExternalCountingMode" style="document"/>
+            <wsdl:input name="SetExternalCountingModeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="SetExternalCountingModeResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="example.CountingCategoryService">
+        <wsdl:port name="example.CountingCategoryServicePort" binding="tns:example.CountingCategoryServiceBinding">
+            <soap:address location="http://www.example.com/interfaces/parking/operatorServices/v1/CountingCategoryService"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -9,6 +9,9 @@ const expect = require('chai').expect,
   getAllTransactionsFromCollection = require('../../lib/utils/getAllTransactions').getAllTransactionsFromCollection,
   async = require('async'),
   path = require('path'),
+  {
+    MULTIPLE_ROOT_FILES
+  } = require('../../lib/constants/messageConstants'),
   optionIds = [
     'folderStrategy',
     'validateHeader',
@@ -522,6 +525,30 @@ describe('merge and validate', function () {
       else {
         expect.fail(null, null, status.reason);
       }
+    });
+  });
+
+  it('Should throw an error when input has more than one root file (services)', function () {
+    let folderPath = path.join(__dirname, SEPARATED_FILES, '/multipleRoot'),
+      files = [],
+      array = [
+        { fileName: folderPath + '/CountingCategoryData.xsd' },
+        { fileName: folderPath + '/CountingCategoryService.wsdl' },
+        { fileName: folderPath + '/CountingCategoryServiceCopy.wsdl' }
+      ];
+    array.forEach((item) => {
+      files.push({
+        content: fs.readFileSync(item.fileName, 'utf8'),
+        fileName: item.fileName
+      });
+    });
+    const schemaPack = new SchemaPack({ type: 'folder', data: files }, {});
+    schemaPack.mergeAndValidate((err, status) => {
+      if (err) {
+        expect.fail(null, null, err);
+      }
+      expect(status.result).to.equal(false);
+      expect(status.reason).to.equal(MULTIPLE_ROOT_FILES);
     });
   });
 });

--- a/test/unit/TransactionValidator.options.test.js
+++ b/test/unit/TransactionValidator.options.test.js
@@ -694,6 +694,8 @@ describe('validateBody method with options', function () {
         }
       ),
       mismatchReason = 'The request body didn\'t match the specified schema',
+      date = new Date(),
+      dateMock = `${date.toISOString().split('T')[0]}Z`,
       expected = getExpectedWithMismatchInEndpoint(
         expectedGetPlayedMatchesBase,
         'cfae0d0e-d10c-4a15-8ba6-c80ee6e45879',
@@ -766,7 +768,7 @@ describe('validateBody method with options', function () {
             '<Person>\n                <item>\n                  <id>100</id>\n                  ' +
             '<last_name>string</last_name>\n                  <first_name>string</first_name>\n                  ' +
             '<gender>string</gender>\n                  <birth_year>string</birth_year>\n                  ' +
-            '<birth_date>2021-06-11Z</birth_date>\n                  <phone>string</phone>\n                  ' +
+            '<birth_date>' + dateMock + '</birth_date>\n                  <phone>string</phone>\n                  ' +
             '<email>string</email>\n                </item>\n              </Person>\n            </item>\n          ' +
             '</RefereesAssignments>\n        </item>\n      ' +
             '</getPlayedMatchesResult>\n    </getPlayedMatchesResponse>\n  ' +

--- a/test/unit/WSDLMerger.test.js
+++ b/test/unit/WSDLMerger.test.js
@@ -16,7 +16,8 @@ const expect = require('chai').expect,
   {
     MULTIPLE_ROOT_FILES,
     NOT_WSDL_IN_FOLDER,
-    WSDL_DIFF_VERSION
+    WSDL_DIFF_VERSION,
+    MISSING_XML_PARSER
   } = require('../../lib/constants/messageConstants');
 
 describe('WSDLMerger merge', function() {
@@ -390,7 +391,7 @@ describe('WSDLMerger merge', function() {
       });
   });
 
-  it('Should throw an error when parse is undefined', function() {
+  it('Should throw an error when xml parser is undefined', function() {
 
     const folderPath = path.join(__dirname, SEPARATED_FILES_COUNTING),
       outputDir = path.join(__dirname, SEPARATED_FILES_COUNTING + '/output.wsdl'),
@@ -667,7 +668,7 @@ describe('WSDLMerger merge', function() {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       })
       .catch((err) => {
-        expect(err.message).to.equal('Cannot read property \'parseToObject\' of undefined');
+        expect(err.message).to.equal(MISSING_XML_PARSER);
       });
   });
 
@@ -942,138 +943,11 @@ describe('WSDLMerger merge', function() {
         <schema xmlns="http://www.w3.org/2001/XMLSchema" 
         targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1/data"
           xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1/data" elementFormDefault="qualified">
-            <element name="SetCountingCategoryMode">
-                <complexType >
-                    <sequence>
-                        <element name="facilityId" type="long"/>
-                        <element name="carParkNumber" type="int"/>
-                        <element name="countingCategoryType" type="tns:countingCategoryType"/>
-                        <element name="trafficSignalMode" type="tns:trafficSignalMode"/>
-                    </sequence>
-                </complexType>
-            </element>
-        
-            <element name="SetCountingCategoryModeOut">
-                <complexType>
-                    <sequence>
-                        <element name="SetCountingCategoryModeResponse" type="tns:SetCountingCategoryModeResponse">
-                        </element>
-                    </sequence>
-                </complexType>
-            </element>
-            <complexType name="SetCountingCategoryModeResponse">
-                <sequence/>
-            </complexType>
-        
-        
-            <element name="SetCountingCategoryLevel">
-                <complexType >
-                    <sequence>
-                        <element name="facilityId" type="long"/>
-                        <element name="carParkNumber" type="int"/>
-                        <element name="countingCategoryType" type="tns:countingCategoryType"/>
-                        <element name="currentLevel" type="int"/>
-                    </sequence>
-                </complexType>
-            </element>
-        
-            <element name="SetCountingCategoryLevelOut">
-                <complexType>
-                    <sequence>
-                        <element name="SetCountingCategoryLevelResponse" type="tns:SetCountingCategoryLevelResponse">
-                        </element>
-                    </sequence>
-                </complexType>
-            </element>
-            <complexType name="SetCountingCategoryLevelResponse">
-                <sequence/>
-            </complexType>
-        
-            <element name="SetExternalCountingMode">
-                <complexType >
-                    <sequence>
-                        <element name="facilityId" type="long"/>
-                    </sequence>
-                </complexType>
-            </element>
-        
-            <element name="SetExternalCountingModeOut">
-                <complexType>
-                    <sequence>
-                        <element name="SetExternalCountingModeResponse" type="tns:SetExternalCountingModeResponse">
-                        </element>
-                    </sequence>
-                </complexType>
-            </element>
-            <complexType name="SetExternalCountingModeResponse">
-                <sequence/>
-            </complexType>
-        
-        
             <simpleType name="trafficSignalMode">
                 <restriction base="string">
                     <enumeration value="AUTOMATIC"/>
                     <enumeration value="MANUAL_GREEN_FREE"/>
                     <enumeration value="MANUAL_RED_FULL"/>
-                </restriction>
-            </simpleType>
-        
-            <simpleType name="countingCategoryType">
-                <restriction base="string">
-                    <enumeration value="DEFAULT_COUNTING_CATEGORY_00"/>
-                    <enumeration value="SHORT_TERM_PARKER_01"/>
-                    <enumeration value="CONTRACT_PARKER_02"/>
-                    <enumeration value="TOTAL_03"/>
-                    <enumeration value="USER_DEFINED_04"/>
-                    <enumeration value="USER_DEFINED_05"/>
-                    <enumeration value="USER_DEFINED_06"/>
-                    <enumeration value="USER_DEFINED_07"/>
-                    <enumeration value="USER_DEFINED_08"/>
-                    <enumeration value="USER_DEFINED_09"/>
-                    <enumeration value="USER_DEFINED_10"/>
-                    <enumeration value="USER_DEFINED_11"/>
-                    <enumeration value="USER_DEFINED_12"/>
-                    <enumeration value="USER_DEFINED_13"/>
-                    <enumeration value="USER_DEFINED_14"/>
-                    <enumeration value="USER_DEFINED_15"/>
-                    <enumeration value="USER_DEFINED_16"/>
-                    <enumeration value="USER_DEFINED_17"/>
-                    <enumeration value="USER_DEFINED_18"/>
-                    <enumeration value="USER_DEFINED_19"/>
-                    <enumeration value="USER_DEFINED_20"/>
-                    <enumeration value="USER_DEFINED_21"/>
-                    <enumeration value="USER_DEFINED_22"/>
-                    <enumeration value="USER_DEFINED_23"/>
-                    <enumeration value="USER_DEFINED_24"/>
-                    <enumeration value="USER_DEFINED_25"/>
-                    <enumeration value="USER_DEFINED_26"/>
-                    <enumeration value="USER_DEFINED_27"/>
-                    <enumeration value="USER_DEFINED_28"/>
-                    <enumeration value="USER_DEFINED_29"/>
-                    <enumeration value="USER_DEFINED_30"/>
-                    <enumeration value="USER_DEFINED_31"/>
-                    <enumeration value="USER_DEFINED_32"/>
-                    <enumeration value="USER_DEFINED_33"/>
-                    <enumeration value="USER_DEFINED_34"/>
-                    <enumeration value="USER_DEFINED_35"/>
-                    <enumeration value="USER_DEFINED_36"/>
-                    <enumeration value="USER_DEFINED_37"/>
-                    <enumeration value="USER_DEFINED_38"/>
-                    <enumeration value="USER_DEFINED_39"/>
-                    <enumeration value="USER_DEFINED_40"/>
-                    <enumeration value="USER_DEFINED_41"/>
-                    <enumeration value="USER_DEFINED_42"/>
-                    <enumeration value="USER_DEFINED_43"/>
-                    <enumeration value="USER_DEFINED_44"/>
-                    <enumeration value="USER_DEFINED_45"/>
-                    <enumeration value="USER_DEFINED_46"/>
-                    <enumeration value="USER_DEFINED_47"/>
-                    <enumeration value="USER_DEFINED_48"/>
-                    <enumeration value="USER_DEFINED_49"/>
-                    <enumeration value="USER_DEFINED_50"/>
-                    <enumeration value="USER_DEFINED_51"/>
-                    <enumeration value="USER_DEFINED_52"/>
-                    <enumeration value="USER_DEFINED_53"/>
                 </restriction>
             </simpleType>
         </schema>`,

--- a/test/unit/WSDLMerger.test.js
+++ b/test/unit/WSDLMerger.test.js
@@ -1,6 +1,7 @@
 const expect = require('chai').expect,
   SEPARATED_FILES_W3_Example = '../data/separatedFiles/W3Example',
   SEPARATED_FILES_COUNTING = '../data/separatedFiles/counting',
+  SEPARATED_FILES_MULTIPLE_ROOT = '../data/separatedFiles/multipleRoot',
   {
     WSDLMerger
   } = require('../../lib/utils/WSDLMerger'),
@@ -11,7 +12,12 @@ const expect = require('chai').expect,
   {
     removeLineBreakTabsSpaces
   } = require('../../lib/utils/textUtils'),
-  path = require('path');
+  path = require('path'),
+  {
+    MULTIPLE_ROOT_FILES,
+    NOT_WSDL_IN_FOLDER,
+    WSDL_DIFF_VERSION
+  } = require('../../lib/constants/messageConstants');
 
 describe('WSDLMerger merge', function() {
 
@@ -668,8 +674,6 @@ describe('WSDLMerger merge', function() {
   it('Should throw an error when input has not wsdl', function() {
 
     const folderPath = path.join(__dirname, SEPARATED_FILES_COUNTING),
-      outputDir = path.join(__dirname, SEPARATED_FILES_COUNTING + '/output.wsdl'),
-      folderPathService = path.join(__dirname, SEPARATED_FILES_COUNTING + '/CountingCategoryService.wsdl'),
       folderPathSchema = path.join(__dirname, SEPARATED_FILES_COUNTING + '/CountingCategoryData.xsd'),
       processedInputFiles = [
         `<?xml version="1.0" encoding="UTF-8"?>
@@ -811,8 +815,7 @@ describe('WSDLMerger merge', function() {
                 </restriction>
             </simpleType>
         </schema>`
-      ],
-      expectedOutput = fs.readFileSync(outputDir, 'utf8');
+      ];
     let processedInput = {},
       files = [],
       array = [{
@@ -827,20 +830,18 @@ describe('WSDLMerger merge', function() {
       });
     });
     processedInput[folderPathSchema] = processedInputFiles[0];
-    processedInput[folderPathService] = processedInputFiles[1];
 
     merger.merge(files, processedInput, new XMLParser())
-      .then((merged) => {
-        expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
+      .then(() => {
+        expect.fail(null, null, status.reason);
       })
       .catch((err) => {
-        expect(err.message).to.equal('There was not WSDL file in folder');
+        expect(err.message).to.equal(NOT_WSDL_IN_FOLDER);
       });
   });
 
   it('Should throw an error when input has different wsdl version', function() {
     const folderPath = path.join(__dirname, SEPARATED_FILES_W3_Example),
-      outputDir = path.join(__dirname, SEPARATED_FILES_W3_Example + '/output.wsdl'),
       folderPathService = path.join(__dirname, SEPARATED_FILES_W3_Example + '/stockquoteservice.wsdl'),
       folderPathSchema = path.join(__dirname, SEPARATED_FILES_W3_Example + '/stockquote.xsd'),
       folderPathDefinitions = path.join(__dirname, SEPARATED_FILES_W3_Example + '/stockquote.wsdl'),
@@ -897,8 +898,7 @@ describe('WSDLMerger merge', function() {
                  <port name="StockQuotePort" binding="tns:StockQuoteBinding"><soap:address 
                  location="http://example.com/stockquote"/>
          </port></service></description>"`
-      ],
-      expectedOutput = fs.readFileSync(outputDir, 'utf8');
+      ];
 
     let processedInput = {},
       files = [],
@@ -924,11 +924,399 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathService] = processedInputFiles[2];
 
     merger.merge(files, processedInput, new XMLParser())
-      .then((merged) => {
-        expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
+      .then(() => {
+        expect.fail(null, null, status.reason);
       })
       .catch((err) => {
-        expect(err.message).to.equal('All WSDL must be the same version');
+        expect(err.message).to.equal(WSDL_DIFF_VERSION);
+      });
+  });
+
+  it('Should throw an error when input has more than one root file (services)', function() {
+    const folderPath = path.join(__dirname, SEPARATED_FILES_MULTIPLE_ROOT),
+      folderPathService = path.join(__dirname, SEPARATED_FILES_MULTIPLE_ROOT + '/CountingCategoryService.wsdl'),
+      folderPathServiceCopy = path.join(__dirname, SEPARATED_FILES_MULTIPLE_ROOT + '/CountingCategoryServiceCopy.wsdl'),
+      folderPathSchema = path.join(__dirname, SEPARATED_FILES_MULTIPLE_ROOT + '/CountingCategoryData.xsd'),
+      processedInputFiles = [
+        `<?xml version="1.0" encoding="UTF-8"?>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema" 
+        targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1/data"
+          xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1/data" elementFormDefault="qualified">
+            <element name="SetCountingCategoryMode">
+                <complexType >
+                    <sequence>
+                        <element name="facilityId" type="long"/>
+                        <element name="carParkNumber" type="int"/>
+                        <element name="countingCategoryType" type="tns:countingCategoryType"/>
+                        <element name="trafficSignalMode" type="tns:trafficSignalMode"/>
+                    </sequence>
+                </complexType>
+            </element>
+        
+            <element name="SetCountingCategoryModeOut">
+                <complexType>
+                    <sequence>
+                        <element name="SetCountingCategoryModeResponse" type="tns:SetCountingCategoryModeResponse">
+                        </element>
+                    </sequence>
+                </complexType>
+            </element>
+            <complexType name="SetCountingCategoryModeResponse">
+                <sequence/>
+            </complexType>
+        
+        
+            <element name="SetCountingCategoryLevel">
+                <complexType >
+                    <sequence>
+                        <element name="facilityId" type="long"/>
+                        <element name="carParkNumber" type="int"/>
+                        <element name="countingCategoryType" type="tns:countingCategoryType"/>
+                        <element name="currentLevel" type="int"/>
+                    </sequence>
+                </complexType>
+            </element>
+        
+            <element name="SetCountingCategoryLevelOut">
+                <complexType>
+                    <sequence>
+                        <element name="SetCountingCategoryLevelResponse" type="tns:SetCountingCategoryLevelResponse">
+                        </element>
+                    </sequence>
+                </complexType>
+            </element>
+            <complexType name="SetCountingCategoryLevelResponse">
+                <sequence/>
+            </complexType>
+        
+            <element name="SetExternalCountingMode">
+                <complexType >
+                    <sequence>
+                        <element name="facilityId" type="long"/>
+                    </sequence>
+                </complexType>
+            </element>
+        
+            <element name="SetExternalCountingModeOut">
+                <complexType>
+                    <sequence>
+                        <element name="SetExternalCountingModeResponse" type="tns:SetExternalCountingModeResponse">
+                        </element>
+                    </sequence>
+                </complexType>
+            </element>
+            <complexType name="SetExternalCountingModeResponse">
+                <sequence/>
+            </complexType>
+        
+        
+            <simpleType name="trafficSignalMode">
+                <restriction base="string">
+                    <enumeration value="AUTOMATIC"/>
+                    <enumeration value="MANUAL_GREEN_FREE"/>
+                    <enumeration value="MANUAL_RED_FULL"/>
+                </restriction>
+            </simpleType>
+        
+            <simpleType name="countingCategoryType">
+                <restriction base="string">
+                    <enumeration value="DEFAULT_COUNTING_CATEGORY_00"/>
+                    <enumeration value="SHORT_TERM_PARKER_01"/>
+                    <enumeration value="CONTRACT_PARKER_02"/>
+                    <enumeration value="TOTAL_03"/>
+                    <enumeration value="USER_DEFINED_04"/>
+                    <enumeration value="USER_DEFINED_05"/>
+                    <enumeration value="USER_DEFINED_06"/>
+                    <enumeration value="USER_DEFINED_07"/>
+                    <enumeration value="USER_DEFINED_08"/>
+                    <enumeration value="USER_DEFINED_09"/>
+                    <enumeration value="USER_DEFINED_10"/>
+                    <enumeration value="USER_DEFINED_11"/>
+                    <enumeration value="USER_DEFINED_12"/>
+                    <enumeration value="USER_DEFINED_13"/>
+                    <enumeration value="USER_DEFINED_14"/>
+                    <enumeration value="USER_DEFINED_15"/>
+                    <enumeration value="USER_DEFINED_16"/>
+                    <enumeration value="USER_DEFINED_17"/>
+                    <enumeration value="USER_DEFINED_18"/>
+                    <enumeration value="USER_DEFINED_19"/>
+                    <enumeration value="USER_DEFINED_20"/>
+                    <enumeration value="USER_DEFINED_21"/>
+                    <enumeration value="USER_DEFINED_22"/>
+                    <enumeration value="USER_DEFINED_23"/>
+                    <enumeration value="USER_DEFINED_24"/>
+                    <enumeration value="USER_DEFINED_25"/>
+                    <enumeration value="USER_DEFINED_26"/>
+                    <enumeration value="USER_DEFINED_27"/>
+                    <enumeration value="USER_DEFINED_28"/>
+                    <enumeration value="USER_DEFINED_29"/>
+                    <enumeration value="USER_DEFINED_30"/>
+                    <enumeration value="USER_DEFINED_31"/>
+                    <enumeration value="USER_DEFINED_32"/>
+                    <enumeration value="USER_DEFINED_33"/>
+                    <enumeration value="USER_DEFINED_34"/>
+                    <enumeration value="USER_DEFINED_35"/>
+                    <enumeration value="USER_DEFINED_36"/>
+                    <enumeration value="USER_DEFINED_37"/>
+                    <enumeration value="USER_DEFINED_38"/>
+                    <enumeration value="USER_DEFINED_39"/>
+                    <enumeration value="USER_DEFINED_40"/>
+                    <enumeration value="USER_DEFINED_41"/>
+                    <enumeration value="USER_DEFINED_42"/>
+                    <enumeration value="USER_DEFINED_43"/>
+                    <enumeration value="USER_DEFINED_44"/>
+                    <enumeration value="USER_DEFINED_45"/>
+                    <enumeration value="USER_DEFINED_46"/>
+                    <enumeration value="USER_DEFINED_47"/>
+                    <enumeration value="USER_DEFINED_48"/>
+                    <enumeration value="USER_DEFINED_49"/>
+                    <enumeration value="USER_DEFINED_50"/>
+                    <enumeration value="USER_DEFINED_51"/>
+                    <enumeration value="USER_DEFINED_52"/>
+                    <enumeration value="USER_DEFINED_53"/>
+                </restriction>
+            </simpleType>
+        </schema>`,
+        `<?xml version="1.0" encoding="utf-8"?>
+        <wsdl:definitions name="CountingCategoryService"
+         targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1"
+            xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1"
+            xmlns:countingCategoryData="http://www.example.com/interfaces/parking/operatorServices/v1/data"
+            xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+            <wsdl:types>
+                <xsd:schema elementFormDefault="qualified" 
+                targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1">
+                    <xsd:import namespace="http://www.example.com/interfaces/parking/operatorServices/v1/data" 
+                    schemaLocation="CountingCategoryData.xsd"/>
+                    <xsd:import schemaLocation="../../../common/v1/CommonData.xsd" 
+                    namespace="http://www.example.com/interfaces/common/v1/data"/>
+                </xsd:schema>
+            </wsdl:types>
+        
+            <wsdl:message name="SetCountingCategoryMode">
+                <wsdl:part name="SetCountingCategoryModeRequest" 
+                element="countingCategoryData:SetCountingCategoryMode"/>
+            </wsdl:message>
+            <wsdl:message name="SetCountingCategoryModeResponse">
+                <wsdl:part name="SetCountingCategoryModeResponse" 
+                element="countingCategoryData:SetCountingCategoryModeOut"/>
+            </wsdl:message>
+            <wsdl:message name="SetCountingCategoryLevel">
+                <wsdl:part name="SetCountingCategoryLevel" 
+                element="countingCategoryData:SetCountingCategoryLevel"/>
+            </wsdl:message>
+            <wsdl:message name="SetCountingCategoryLevelResponse">
+                <wsdl:part name="SetCountingCategoryLevelResponse" 
+                element="countingCategoryData:SetCountingCategoryLevelOut"/>
+            </wsdl:message>
+            <wsdl:message name="SetExternalCountingMode">
+                <wsdl:part name="SetExternalCountingMode" element="countingCategoryData:SetExternalCountingMode"/>
+            </wsdl:message>
+            <wsdl:message name="SetExternalCountingModeResponse">
+                <wsdl:part name="SetExternalCountingModeResponse" 
+                element="countingCategoryData:SetExternalCountingModeOut"/>
+            </wsdl:message>
+        
+        
+            <wsdl:portType name="CountingCategoryServiceInterface">
+                <wsdl:operation name="SetCountingCategoryMode">
+                    <wsdl:input name="SetCountingCategoryModeRequest" message="tns:SetCountingCategoryMode"/>
+                    <wsdl:output name="SetCountingCategoryModeResponse" message="tns:SetCountingCategoryModeResponse"/>
+                </wsdl:operation>
+                <wsdl:operation name="SetCountingCategoryLevel">
+                    <wsdl:input name="SetCountingCategoryLevelRequest" message="tns:SetCountingCategoryLevel"/>
+                    <wsdl:output name="SetCountingCategoryLevelResponse" 
+                    message="tns:SetCountingCategoryLevelResponse"/>
+                </wsdl:operation>
+                <wsdl:operation name="SetExternalCountingMode">
+                    <wsdl:input name="SetExternalCountingModeRequest" message="tns:SetExternalCountingMode"/>
+                    <wsdl:output name="SetExternalCountingModeResponse" message="tns:SetExternalCountingModeResponse"/>
+                </wsdl:operation>
+            </wsdl:portType>
+        
+            <wsdl:binding name="example.CountingCategoryServiceBinding" type="tns:CountingCategoryServiceInterface">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SetCountingCategoryMode">
+                    <soap:operation 
+                    soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryMode" 
+                    style="document"/>
+                    <wsdl:input name="SetCountingCategoryModeRequest">
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output name="SetCountingCategoryModeResponse">
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+                <wsdl:operation name="SetCountingCategoryLevel">
+                    <soap:operation 
+                    soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryLevel" 
+                    style="document"/>
+                    <wsdl:input name="SetCountingCategoryLevelRequest">
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output name="SetCountingCategoryLevelResponse">
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+                <wsdl:operation name="SetExternalCountingMode">
+                    <soap:operation 
+                    soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetExternalCountingMode"
+                     style="document"/>
+                    <wsdl:input name="SetExternalCountingModeRequest">
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output name="SetExternalCountingModeResponse">
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+            </wsdl:binding>
+        
+            <wsdl:service name="example.CountingCategoryService">
+                <wsdl:port name="example.CountingCategoryServicePort" 
+                binding="tns:example.CountingCategoryServiceBinding">
+                    <soap:address 
+                    location="http://www.example.com/interfaces/parking/operatorServices/v1/CountingCategoryService"/>
+                </wsdl:port>
+            </wsdl:service>
+        </wsdl:definitions>`,
+        `<?xml version="1.0" encoding="utf-8"?>
+        <wsdl:definitions name="CountingCategoryService"
+         targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1"
+            xmlns:tns="http://www.example.com/interfaces/parking/operatorServices/v1"
+            xmlns:countingCategoryData="http://www.example.com/interfaces/parking/operatorServices/v1/data"
+            xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+            xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+            <wsdl:types>
+                <xsd:schema elementFormDefault="qualified" 
+                targetNamespace="http://www.example.com/interfaces/parking/operatorServices/v1">
+                    <xsd:import namespace="http://www.example.com/interfaces/parking/operatorServices/v1/data" 
+                    schemaLocation="CountingCategoryData.xsd"/>
+                    <xsd:import schemaLocation="../../../common/v1/CommonData.xsd" 
+                    namespace="http://www.example.com/interfaces/common/v1/data"/>
+                </xsd:schema>
+            </wsdl:types>
+        
+            <wsdl:message name="SetCountingCategoryMode">
+                <wsdl:part name="SetCountingCategoryModeRequest" 
+                element="countingCategoryData:SetCountingCategoryMode"/>
+            </wsdl:message>
+            <wsdl:message name="SetCountingCategoryModeResponse">
+                <wsdl:part name="SetCountingCategoryModeResponse" 
+                element="countingCategoryData:SetCountingCategoryModeOut"/>
+            </wsdl:message>
+            <wsdl:message name="SetCountingCategoryLevel">
+                <wsdl:part name="SetCountingCategoryLevel" 
+                element="countingCategoryData:SetCountingCategoryLevel"/>
+            </wsdl:message>
+            <wsdl:message name="SetCountingCategoryLevelResponse">
+                <wsdl:part name="SetCountingCategoryLevelResponse" 
+                element="countingCategoryData:SetCountingCategoryLevelOut"/>
+            </wsdl:message>
+            <wsdl:message name="SetExternalCountingMode">
+                <wsdl:part name="SetExternalCountingMode" element="countingCategoryData:SetExternalCountingMode"/>
+            </wsdl:message>
+            <wsdl:message name="SetExternalCountingModeResponse">
+                <wsdl:part name="SetExternalCountingModeResponse" 
+                element="countingCategoryData:SetExternalCountingModeOut"/>
+            </wsdl:message>
+        
+        
+            <wsdl:portType name="CountingCategoryServiceInterface">
+                <wsdl:operation name="SetCountingCategoryMode">
+                    <wsdl:input name="SetCountingCategoryModeRequest" message="tns:SetCountingCategoryMode"/>
+                    <wsdl:output name="SetCountingCategoryModeResponse" message="tns:SetCountingCategoryModeResponse"/>
+                </wsdl:operation>
+                <wsdl:operation name="SetCountingCategoryLevel">
+                    <wsdl:input name="SetCountingCategoryLevelRequest" message="tns:SetCountingCategoryLevel"/>
+                    <wsdl:output name="SetCountingCategoryLevelResponse" 
+                    message="tns:SetCountingCategoryLevelResponse"/>
+                </wsdl:operation>
+                <wsdl:operation name="SetExternalCountingMode">
+                    <wsdl:input name="SetExternalCountingModeRequest" message="tns:SetExternalCountingMode"/>
+                    <wsdl:output name="SetExternalCountingModeResponse" message="tns:SetExternalCountingModeResponse"/>
+                </wsdl:operation>
+            </wsdl:portType>
+        
+            <wsdl:binding name="example.CountingCategoryServiceBinding" type="tns:CountingCategoryServiceInterface">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="SetCountingCategoryMode">
+                    <soap:operation 
+                    soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryMode" 
+                    style="document"/>
+                    <wsdl:input name="SetCountingCategoryModeRequest">
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output name="SetCountingCategoryModeResponse">
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+                <wsdl:operation name="SetCountingCategoryLevel">
+                    <soap:operation 
+                    soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetCountingCategoryLevel" 
+                    style="document"/>
+                    <wsdl:input name="SetCountingCategoryLevelRequest">
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output name="SetCountingCategoryLevelResponse">
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+                <wsdl:operation name="SetExternalCountingMode">
+                    <soap:operation 
+                    soapAction="http://www.example.com/interfaces/parking/operatorServices/v1/SetExternalCountingMode"
+                     style="document"/>
+                    <wsdl:input name="SetExternalCountingModeRequest">
+                        <soap:body use="literal"/>
+                    </wsdl:input>
+                    <wsdl:output name="SetExternalCountingModeResponse">
+                        <soap:body use="literal"/>
+                    </wsdl:output>
+                </wsdl:operation>
+            </wsdl:binding>
+        
+            <wsdl:service name="example.CountingCategoryService">
+                <wsdl:port name="example.CountingCategoryServicePort" 
+                binding="tns:example.CountingCategoryServiceBinding">
+                    <soap:address 
+                    location="http://www.example.com/interfaces/parking/operatorServices/v1/CountingCategoryService"/>
+                </wsdl:port>
+            </wsdl:service>
+        </wsdl:definitions>`
+      ];
+
+    let processedInput = {},
+      files = [],
+      array = [{
+        fileName: folderPath + '/CountingCategoryData.xsd'
+      }, {
+        fileName: folderPath + '/CountingCategoryService.wsdl'
+      },
+      {
+        fileName: folderPath + '/CountingCategoryServiceCopy.wsdl'
+      }
+      ],
+      merger = new WSDLMerger();
+    array.forEach((item) => {
+      files.push({
+        content: fs.readFileSync(item.fileName, 'utf8'),
+        fileName: item.fileName
+      });
+    });
+
+    processedInput[folderPathSchema] = processedInputFiles[0];
+    processedInput[folderPathService] = processedInputFiles[1];
+    processedInput[folderPathServiceCopy] = processedInputFiles[2];
+    merger.merge(files, processedInput, new XMLParser())
+      .then(() => {
+        expect.fail(null, null, status.reason);
+      })
+      .catch((err) => {
+        expect(err.message).to.equal(MULTIPLE_ROOT_FILES);
       });
   });
 


### PR DESCRIPTION
To homologate behavior with OASToPM, when we found more than one root file (service definition) then throw an error via validation result


open api to postman:
 this.validationResult = {
        result: false,
        reason: 'More than one root file not supported.'
      };

WSDL to postman:
 this.validationResult = {
        result: false,
        reason: 'There are multiple files with services defined.'
      };


