### PR TITLE
Adding support in MISSING_IN_REQUEST mismatches for multiple elements…

### DIFF
--- a/lib/utils/mismatchUtils.js
+++ b/lib/utils/mismatchUtils.js
@@ -202,6 +202,31 @@ function handleInvalidTypeAndGetXpath(reason, currentBody) {
 }
 
 /**
+ * Returns the xpath's index component for the parent of the missing element
+ * @param {object} missedElement the element that is missing in request
+ * @param {string} body The body where the missed element is not present
+ * @returns {string} If the missing element's parent has multiple siblings with the same name
+ * it will returns the index component to add to the xpath '[parentIndex]', else it will
+ * return  an empty string
+ */
+function getIndexFromMultipleSiblingsWithSameName(missedElement, body) {
+  const missedParentElementPath = `/${missedElement.parent().path()}`,
+    requestElementSiblingsSameName = useValidator().findByXpathInXmlString(body, missedParentElementPath),
+    missedElementParentIndex = requestElementSiblingsSameName.map((element, index) => {
+      return {
+        index,
+        childrenNames: element.childNodes().map((node) => {
+          return node.name();
+        })
+      };
+    }).filter((element) => {
+      return !element.childrenNames.includes(missedElement.name());
+    }),
+    index = missedElementParentIndex[0].index;
+  return index > 0 ? `[${index}]` : '';
+}
+
+/**
  * reads the missing in request reason message and gets necessary data to find the mismatched
  * element and returns the xpath
  * @param {string} reason The reason message gotten from the validation with schema library
@@ -210,35 +235,34 @@ function handleInvalidTypeAndGetXpath(reason, currentBody) {
  * @returns {string} xpath corresponding to the element in reason
  */
 function handleMissingInRequestAndGetXpath(reason, currentBody, cleanBody) {
-  let result, xpath;
+  let result,
+    xpath,
+    elementNode,
+    indexComponent = '';
   if (reason.match(MISSING_IN_REQUEST_PARENT_PATTERN)) {
     result = reason.match(MISSING_IN_REQUEST_PARENT_PATTERN);
     let parent = result[1],
       element = result[2],
-      elementXpath = `//${parent}/${element}`,
-      elementNode = getElementFromMissingInRequestByPath(currentBody, cleanBody, elementXpath),
-      parentNode = elementNode.parent();
-    xpath = parentNode.path();
+      elementXpath = `//${parent}/${element}`;
+    elementNode = getElementFromMissingInRequestByPath(currentBody, cleanBody, elementXpath);
   }
   else if (reason.match(MISSING_IN_REQUEST_ONE_SIBLING_PATTERN)) {
     result = reason.match(MISSING_IN_REQUEST_ONE_SIBLING_PATTERN);
     let sibling = result[1],
       // missingElement = result[2],
-      siblingXpath = `//${sibling}`,
-      elementNode = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath),
-      parentNode = elementNode.parent();
-    xpath = parentNode.path();
+      siblingXpath = `//${sibling}`;
+    elementNode = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath);
   }
   else if (reason.match(MISSING_IN_REQUEST_MULTIPLE_SIBLINGS_PATTERN)) {
     result = reason.match(MISSING_IN_REQUEST_MULTIPLE_SIBLINGS_PATTERN);
     let sibling = result[1],
       // missingElement = result[2],
-      siblingXpath = `//${sibling}`,
-      elementNode = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath),
-      parentNode = elementNode.parent();
-    xpath = parentNode.path();
+      siblingXpath = `//${sibling}`;
+    elementNode = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath);
   }
-  return xpath;
+  xpath = elementNode.parent().path();
+  indexComponent = getIndexFromMultipleSiblingsWithSameName(elementNode, currentBody);
+  return `${xpath}${indexComponent}`;
 }
 
 /**
@@ -339,5 +363,6 @@ module.exports = {
   getElementFromMissingInRequestByPath,
   getElementFromMissingInRequestBySiblingsXpath,
   getElementFromMissingInSchemaByXpath,
-  handleInvalidTypeAndGetXpath
+  handleInvalidTypeAndGetXpath,
+  handleMissingInRequestAndGetXpath
 };

--- a/lib/utils/mismatchUtils.js
+++ b/lib/utils/mismatchUtils.js
@@ -206,8 +206,8 @@ function handleInvalidTypeAndGetXpath(reason, currentBody) {
  * @param {object} missedElement the element that is missing in request
  * @param {string} body The body where the missed element is not present
  * @returns {string} If the missing element's parent has multiple siblings with the same name
- * it will returns the index component to add to the xpath '[parentIndex]', else it will
- * return  an empty string
+ * it will return the index component to add to the xpath '[parentIndex]', else it will
+ * return an empty string
  */
 function getIndexFromMultipleSiblingsWithSameName(missedElement, body) {
   const missedParentElementPath = `/${missedElement.parent().path()}`,

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -72,7 +72,7 @@ function getOptions(mode = 'document', criteria = {}) {
       id: 'detailedBlobValidation',
       type: 'boolean',
       default: false,
-      description: 'If it is true, all the mismatches will contain detailed info about the error has generated it' +
+      description: 'If it is true, all the mismatches will contain detailed info about the error generated' +
         ' if false, the mismatch will return a general description for the error',
       external: true,
       usage: ['VALIDATION']
@@ -82,7 +82,7 @@ function getOptions(mode = 'document', criteria = {}) {
       id: 'showMissingInSchemaErrors',
       type: 'boolean',
       default: true,
-      description: 'If true (as default), it will report mismatches generated from errors with elements thas are' +
+      description: 'If true (as default), it will report mismatches generated from errors with elements that are' +
         ' not in the schema but are in the request body, if false it will not report those errors',
       external: true,
       usage: ['VALIDATION']

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -66,6 +66,36 @@ function getOptions(mode = 'document', criteria = {}) {
         'Whether to ignore mismatches resulting from unresolved variables in the Postman request',
       external: true,
       usage: ['VALIDATION']
+    },
+    {
+      name: 'Add details in the reported mismatches',
+      id: 'detailedBlobValidation',
+      type: 'boolean',
+      default: false,
+      description: 'If it is true, all the mismatches will contain detailed info about the error has generated it' +
+        ' if false, the mismatch will return a general description for the error',
+      external: true,
+      usage: ['VALIDATION']
+    },
+    {
+      name: 'Show missing in schema errors',
+      id: 'showMissingInSchemaErrors',
+      type: 'boolean',
+      default: true,
+      description: 'If true (as default), it will report mismatches generated from errors with elements thas are' +
+        ' not in the schema but are in the request body, if false it will not report those errors',
+      external: true,
+      usage: ['VALIDATION']
+    },
+    {
+      name: 'Suggest available fixes',
+      id: 'suggestAvailableFixes',
+      type: 'boolean',
+      default: false,
+      description: 'If is true, all the mismatches in the body will contain the current and wrong value in ' +
+        'your request an a suggestion with a value valid in schema',
+      external: true,
+      usage: ['VALIDATION']
     }
   ];
 

--- a/lib/xsdValidation/XMLLintFacade.js
+++ b/lib/xsdValidation/XMLLintFacade.js
@@ -16,6 +16,10 @@ class XMLElement {
     this.node = xmlNode;
   }
 
+  name() {
+    return this.node.nodeName;
+  }
+
   path() {
     const result = this.node ? this.getPath(this.node) : null;
     return result;
@@ -36,7 +40,11 @@ class XMLElement {
   }
 
   childNodes() {
-    return this.node.childNodes;
+    const nodesArray = Array.prototype.slice.call(this.node.childNodes),
+      XmlElements = nodesArray.map((node) => {
+        return new XMLElement(node);
+      });
+    return XmlElements;
   }
 
   getPrevious(node) {
@@ -172,11 +180,11 @@ class XMLLintFacade {
   getChildrenAsString(xmlString, xpath) {
     const element = this.findByXpathInXmlString(xmlString, xpath)[0],
       children = Object.values(element.childNodes()).filter((node) => {
-        let nodeName = node.nodeName;
+        let nodeName = node.name();
         return nodeName && nodeName !== '#text';
       }),
       childrenAsString = children.map((node) => {
-        return node.toString();
+        return node.node.toString();
       }).join('\n');
     return childrenAsString;
   }

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -16,7 +16,10 @@ const expect = require('chai').expect,
     'folderStrategy',
     'validateHeader',
     'validationPropertiesToIgnore',
-    'ignoreUnresolvedVariables'
+    'ignoreUnresolvedVariables',
+    'detailedBlobValidation',
+    'showMissingInSchemaErrors',
+    'suggestAvailableFixes'
   ];
 
 describe('SchemaPack convert unit test WSDL 1.1', function () {
@@ -199,7 +202,7 @@ describe('SchemaPack getOptions', function () {
   it('Should return external options when called with mode = document', function () {
     const options = SchemaPack.getOptions('document');
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(4);
+    expect(options.length).to.eq(7);
   });
 
   it('Should return external options when called with mode = use', function () {
@@ -247,7 +250,7 @@ describe('SchemaPack getOptions', function () {
   it('Should return external options when called with mode document and usage not an object', function () {
     const options = SchemaPack.getOptions('document', 2);
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(4);
+    expect(options.length).to.eq(7);
   });
 
   it('Should return default empty array in validationPropertiesToIgnore', function () {

--- a/test/unit/messageWithSchemaValidation.test.js
+++ b/test/unit/messageWithSchemaValidation.test.js
@@ -509,7 +509,6 @@ describe('Tools from messageWithSchemaValidation', function () {
 
   it('Should validate message with schema', function() {
     const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
     <xs:element name="shiporder">
       <xs:complexType>
         <xs:sequence>

--- a/test/unit/mismatchUtils.test.js
+++ b/test/unit/mismatchUtils.test.js
@@ -3,7 +3,8 @@ const { expect } = require('chai'),
     getElementFromMissingInRequestBySiblingsXpath,
     getElementFromMissingInRequestByPath,
     getElementFromMissingInSchemaByXpath,
-    handleInvalidTypeAndGetXpath
+    handleInvalidTypeAndGetXpath,
+    handleMissingInRequestAndGetXpath
   } = require('../../lib/utils/mismatchUtils');
 
 describe('testing mismatchUtils getXpathFromMissingInRequestByPath', function() {
@@ -250,5 +251,123 @@ describe('mismatchUtils getElementFromInvalidTypeByXpath', function() {
       wrongElementXpath = handleInvalidTypeAndGetXpath(reason, currentBody),
       expected = '/Substract/objB/targetElement[3]';
     expect(wrongElementXpath).to.be.equal(expected);
+  });
+});
+
+describe('handleMissingInRequestAndGetXpath method', function() {
+  it('Should return the missingElement\'s parent xpath', function() {
+    const reason = 'Element \'objC\': Missing child element(s). Expected is ( intA ).\n',
+      currentBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          
+        </objC>
+      </Substract>`,
+      cleanBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <missingInSchemaElement>test</missingInSchemaElement>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+      </Substract>`,
+      result = handleMissingInRequestAndGetXpath(reason, currentBody, cleanBody);
+    expect(result).to.be.equal('/Substract/objC');
+  });
+
+  it('Should return the missingElement\'s parent xpath when it has multiple siblings in same level', function() {
+    const reason = 'Element \'objC\': Missing child element(s). Expected is ( intA ).\n',
+      currentBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+        <objC>
+          
+        </objC>
+      </Substract>`,
+      cleanBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <missingInSchemaElement>test</missingInSchemaElement>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+      </Substract>`,
+      result = handleMissingInRequestAndGetXpath(reason, currentBody, cleanBody);
+    expect(result).to.be.equal('/Substract/objC[2]');
+  });
+
+  it('Should return the missingElement\'s parent xpath when reason message gives' +
+  ' the name of the missing element and next sibling', function() {
+    const reason = 'Element \'intA\': This element is not expected. Expected is ( missingInSchemaElement ).\n',
+      currentBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+      </Substract>`,
+      expectedBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <missingInSchemaElement>test</missingInSchemaElement>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+      </Substract>`,
+      result = handleMissingInRequestAndGetXpath(reason, currentBody, expectedBody);
+    expect(result).to.be.equal('/Substract/objB');
+  });
+
+  it('Should return the missingElement\'s parent xpath when the reason message gives the name' +
+  ' of the missed element\'s next sibling and parent has multiple siblings with the same name', function() {
+    const reason = 'Element \'intA\': This element is not expected. Expected is ( missingInSchemaElement ).\n',
+      currentBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <missingInSchemaElement>provided value</missingInSchemaElement>
+          <intA>test</intA>
+        </objB>
+        <objB>
+          <missingInSchemaElement>next provided value</missingInSchemaElement>
+          <intA>test</intA>
+        </objB>
+        <objB>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+      </Substract>`,
+      expectedBody = `<Substract>
+        <intA>200</intA>
+        <objB>
+          <missingInSchemaElement>test</missingInSchemaElement>
+          <intA>test</intA>
+        </objB>
+        <objC>
+          <intA>super test</intA>
+        </objC>
+      </Substract>`,
+      result = handleMissingInRequestAndGetXpath(reason, currentBody, expectedBody);
+    expect(result).to.be.equal('/Substract/objB[2]');
   });
 });


### PR DESCRIPTION
In this PR you can find the next:
- Adding support for multiple elements with the same name in the same level for Missing in schema mismatches.
- Adding support for path, name, and childNodes in XMLLint facade.
- Adding unit tests.
- Exposing detailedBlobValidation, showMissingInSchemaErrors and suggestAvailableFixes options in options.js file