### PR TITLE
Changes to support folder inputs on browser and native 

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -142,7 +142,7 @@ class SchemaPack {
     let validationResult,
       errReason;
     try {
-      wsdlMerger.merge(this.input.data, this.input.xmlFiles, this.xmlParser)
+      wsdlMerger.merge(this.input, this.xmlParser)
         .then((merged) => {
           this.input = {
             type: 'string',

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -310,7 +310,7 @@ class WSDLMerger {
     }
 
     filesPathArray.forEach((filePath) => {
-      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION, origin));
+      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION));
     });
     return Promise.all(promises).then((values) => {
       contentFiles = values;
@@ -422,10 +422,9 @@ class WSDLMerger {
    *
    * @param {String} filePath Path of the file.
    * @param {String} encoding encoding
-   * @param {String} origin origin of the input, e.g. browser
    * @return {String} Contents of the file
    */
-  readFileAsync(filePath, encoding, origin) {
+  readFileAsync(filePath, encoding) {
     return new Promise((resolve, reject) => {
       fs.readFile(filePath, encoding, (err, data) => {
         if (err) { reject(err); }

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -3,6 +3,7 @@ const {
     getQNameLocal,
     XML_NAMESPACE_SEPARATOR
   } = require('./XMLParsedUtils'),
+  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs'),
   CODIFICATION = 'utf8',
   {
     getNodeByName,
@@ -36,8 +37,6 @@ const {
   } = require('../constants/messageConstants');
 
 var path = require('path'),
-  fs = require('fs'),
-  fsBrowserify = require('browserify-fs'),
   pathBrowserify = require('path-browserify');
 
 class WSDLMerger {

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -426,9 +426,6 @@ class WSDLMerger {
    * @return {String} Contents of the file
    */
   readFileAsync(filePath, encoding, origin) {
-    if (origin === 'browser') {
-      fs = fsBrowserify;
-    }
     return new Promise((resolve, reject) => {
       fs.readFile(filePath, encoding, (err, data) => {
         if (err) { reject(err); }

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -287,7 +287,7 @@ class WSDLMerger {
     let contentFiles = [],
       filesPathArray = input.data,
       files = input.xmlFiles,
-      origin = input.origin,
+      origin = input.origin || '',
       promises = [];
 
     // use browserified version if the input origin is a browser

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -283,8 +283,11 @@ class WSDLMerger {
    * @param {object} xmlParser the parser class to parse xml to object or vice versa
    * @returns {string} the single file
    */
-  merge(filesPathArray, files, xmlParser) {
+  merge(input, xmlParser) {
     let contentFiles = [],
+      filesPathArray = input.data,
+      files = input.xmlFiles,
+      origin = input.origin,
       promises = [];
 
     // use browserified version if the input origin is a browser

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -277,8 +277,7 @@ class WSDLMerger {
 
   /**
    * Merge different files to a single WSDL
-   * @param {object} filesPathArray the files
-   * @param {object} files the content files
+   * @param {object} input input.data contains the file paths and input.xmlFiles contains the content files
    * @param {object} xmlParser the parser class to parse xml to object or vice versa
    * @returns {string} the single file
    */

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -35,7 +35,7 @@ const {
     MISSING_XML_PARSER
   } = require('../constants/messageConstants');
 
-var  path = require('path'),
+var path = require('path'),
   fs = require('fs'),
   fsBrowserify = require('browserify-fs'),
   pathBrowserify = require('path-browserify');

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-modules */
-const path = require('path-browserify'),
-  {
+const {
     getQNameLocal,
     XML_NAMESPACE_SEPARATOR
   } = require('./XMLParsedUtils'),
@@ -36,6 +35,10 @@ const path = require('path-browserify'),
     WSDL_DIFF_VERSION,
     MISSING_XML_PARSER
   } = require('../constants/messageConstants');
+
+var  path = require('path'),
+  pathBrowserify = require('path-browserify');
+
 class WSDLMerger {
 
   /**
@@ -282,6 +285,11 @@ class WSDLMerger {
   merge(filesPathArray, files, xmlParser) {
     let contentFiles = [],
       promises = [];
+
+    // use browserified version if the input origin is a browser
+    if (origin === 'browser') {
+      path = pathBrowserify;
+    }
 
     if (files) {
       filesPathArray.forEach((filePath) => {

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -3,7 +3,6 @@ const {
     getQNameLocal,
     XML_NAMESPACE_SEPARATOR
   } = require('./XMLParsedUtils'),
-  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs'),
   CODIFICATION = 'utf8',
   {
     getNodeByName,
@@ -37,6 +36,8 @@ const {
   } = require('../constants/messageConstants');
 
 var  path = require('path'),
+  fs = require('fs'),
+  fsBrowserify = require('browserify-fs'),
   pathBrowserify = require('path-browserify');
 
 class WSDLMerger {
@@ -307,7 +308,7 @@ class WSDLMerger {
     }
 
     filesPathArray.forEach((filePath) => {
-      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION));
+      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION, origin));
     });
     return Promise.all(promises).then((values) => {
       contentFiles = values;
@@ -419,9 +420,13 @@ class WSDLMerger {
    *
    * @param {String} filePath Path of the file.
    * @param {String} encoding encoding
+   * @param {String} origin origin of the input, e.g. browser
    * @return {String} Contents of the file
    */
-  readFileAsync(filePath, encoding) {
+  readFileAsync(filePath, encoding, origin) {
+    if (origin === 'browser') {
+      fs = fsBrowserify;
+    }
     return new Promise((resolve, reject) => {
       fs.readFile(filePath, encoding, (err, data) => {
         if (err) { reject(err); }

--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -1,9 +1,8 @@
 /* eslint-disable no-restricted-modules */
-const InputError = require('../InputError');
+const InputError = require('../InputError'),
+  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs'),
 
 var path = require('path'),
-  fs = require('fs'),
-  fsBrowserify = require('browserify-fs'),
   pathBrowserify = require('path-browserify');
 
 /** Reads the inputs from a folder and returns a mapped files object

--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-modules */
 const InputError = require('../InputError'),
-  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs'),
+  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs');
 
 var path = require('path'),
   pathBrowserify = require('path-browserify');

--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-restricted-modules */
-const InputError = require('../InputError'),
-  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs');
+const InputError = require('../InputError');
 
-var  path = require('path'),
+var path = require('path'),
+  fs = require('fs'),
+  fsBrowserify = require('browserify-fs'),
   pathBrowserify = require('path-browserify');
 
 /** Reads the inputs from a folder and returns a mapped files object
@@ -37,6 +38,9 @@ function readInput(input) {
     throw new InputError('Input.data not provided');
   }
   else if (input.type === 'file') {
+    if (input.origin === 'browser') {
+      fs = fsBrowserify;
+    }
     try {
       xml = fs.readFileSync(input.data, 'utf-8');
     }

--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -1,15 +1,18 @@
 /* eslint-disable no-restricted-modules */
 const InputError = require('../InputError'),
   fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs'),
-  path = require('path-browserify');
+  path = require('path');
 
 
 /** Reads the inputs from a folder and returns a mapped files object
- * @param {inputObject} input input object of type {type: <folder>, data: <Array>}
+ * @param {inputObject} input input object of type {type: <folder>, data: <Array>, origin, <string>}
  * @returns {object} Files with propety as the filename and value file content
  */
 function readFromFolderStringInput(input) {
   let files;
+  if (input.origin === 'browser') {
+    path = require('path-browserify');
+  }
   if ('content' in input.data[0]) {
     files = {};
     input.data.forEach((file) => {

--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -37,9 +37,6 @@ function readInput(input) {
     throw new InputError('Input.data not provided');
   }
   else if (input.type === 'file') {
-    if (input.origin === 'browser') {
-      fs = fsBrowserify;
-    }
     try {
       xml = fs.readFileSync(input.data, 'utf-8');
     }

--- a/lib/utils/readInput.js
+++ b/lib/utils/readInput.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-restricted-modules */
 const InputError = require('../InputError'),
-  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs'),
-  path = require('path');
+  fs = (process && typeof process.platform === 'string') ? require('fs') : require('browserify-fs');
 
+var  path = require('path'),
+  pathBrowserify = require('path-browserify');
 
 /** Reads the inputs from a folder and returns a mapped files object
  * @param {inputObject} input input object of type {type: <folder>, data: <Array>, origin, <string>}
@@ -11,7 +12,7 @@ const InputError = require('../InputError'),
 function readFromFolderStringInput(input) {
   let files;
   if (input.origin === 'browser') {
-    path = require('path-browserify');
+    path = pathBrowserify;
   }
   if ('content' in input.data[0]) {
     files = {};

--- a/test/unit/WSDLMerger.test.js
+++ b/test/unit/WSDLMerger.test.js
@@ -107,7 +107,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathDefinitions] = processedInputFiles[1];
     processedInput[folderPathService] = processedInputFiles[2];
 
-    merger.merge(files, processedInput, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
       .then((merged) => {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       });
@@ -385,7 +385,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
 
-    merger.merge(files, processedInput, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
       .then((merged) => {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       });
@@ -663,7 +663,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
 
-    merger.merge(files, processedInput, undefined)
+    merger.merge({ data: files, xmlFiles: processedInput}, undefined)
       .then((merged) => {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       })
@@ -832,7 +832,7 @@ describe('WSDLMerger merge', function() {
     });
     processedInput[folderPathSchema] = processedInputFiles[0];
 
-    merger.merge(files, processedInput, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
       .then(() => {
         expect.fail(null, null, status.reason);
       })
@@ -924,7 +924,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathDefinitions] = processedInputFiles[1];
     processedInput[folderPathService] = processedInputFiles[2];
 
-    merger.merge(files, processedInput, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
       .then(() => {
         expect.fail(null, null, status.reason);
       })
@@ -1185,7 +1185,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
     processedInput[folderPathServiceCopy] = processedInputFiles[2];
-    merger.merge(files, processedInput, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
       .then(() => {
         expect.fail(null, null, status.reason);
       })

--- a/test/unit/WSDLMerger.test.js
+++ b/test/unit/WSDLMerger.test.js
@@ -107,7 +107,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathDefinitions] = processedInputFiles[1];
     processedInput[folderPathService] = processedInputFiles[2];
 
-    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput }, new XMLParser())
       .then((merged) => {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       });
@@ -385,7 +385,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
 
-    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput }, new XMLParser())
       .then((merged) => {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       });
@@ -663,7 +663,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
 
-    merger.merge({ data: files, xmlFiles: processedInput}, undefined)
+    merger.merge({ data: files, xmlFiles: processedInput }, undefined)
       .then((merged) => {
         expect(removeLineBreakTabsSpaces(merged)).to.equal(removeLineBreakTabsSpaces(expectedOutput));
       })
@@ -832,7 +832,7 @@ describe('WSDLMerger merge', function() {
     });
     processedInput[folderPathSchema] = processedInputFiles[0];
 
-    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput }, new XMLParser())
       .then(() => {
         expect.fail(null, null, status.reason);
       })
@@ -924,7 +924,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathDefinitions] = processedInputFiles[1];
     processedInput[folderPathService] = processedInputFiles[2];
 
-    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput }, new XMLParser())
       .then(() => {
         expect.fail(null, null, status.reason);
       })
@@ -1185,7 +1185,7 @@ describe('WSDLMerger merge', function() {
     processedInput[folderPathSchema] = processedInputFiles[0];
     processedInput[folderPathService] = processedInputFiles[1];
     processedInput[folderPathServiceCopy] = processedInputFiles[2];
-    merger.merge({ data: files, xmlFiles: processedInput}, new XMLParser())
+    merger.merge({ data: files, xmlFiles: processedInput }, new XMLParser())
       .then(() => {
         expect.fail(null, null, status.reason);
       })


### PR DESCRIPTION
Using a new optional argument in the input object to determine the input origin and use that to decide which type of path module needs to be used. Use browserified one if input origin is browser.