### PR TITLE
Validate transaction invalid xml

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -94,6 +94,13 @@ class SchemaPack {
     });
   }
 
+  /**
+   *
+   * @description Returns the name and type of the conversion
+   *
+   * @param {*} callback return
+   * @returns {object} type and name properties
+   */
   getMetaData(callback) {
     if (!this.validationResult.result) {
       return callback(null, this.validationResult);

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -96,16 +96,19 @@ class TransactionValidator {
       const requestBody = requestItem.request.body.raw;
       let endpoints = [],
         operationFromWSDL = null;
-
-
       if (requestBody) {
-        const parsedXmlMessage = xmlParser.parseToObject(requestBody),
-          processedInfo = this.getItemRequestProcessedInfo(requestItem.request, parsedXmlMessage);
-        operationFromWSDL = this.getOperationFromWSDLObjectByUrlPathNameProtocol(
-          processedInfo,
-          wsdlObject
-        );
-        processedInfoItems.push(processedInfo);
+        try {
+          const parsedXmlMessage = xmlParser.parseToObject(requestBody),
+            processedInfo = this.getItemRequestProcessedInfo(requestItem.request, parsedXmlMessage);
+          operationFromWSDL = this.getOperationFromWSDLObjectByUrlPathNameProtocol(
+            processedInfo,
+            wsdlObject
+          );
+          processedInfoItems.push(processedInfo);
+        }
+        catch (error) {
+          operationFromWSDL = undefined;
+        }
       }
 
       if (operationFromWSDL) {

--- a/test/data/transactionsValidation/numberToWordsCollectionItemsInvalidXMLBody.json
+++ b/test/data/transactionsValidation/numberToWordsCollectionItemsInvalidXMLBody.json
@@ -1,0 +1,265 @@
+[{
+  "id": "aebb36fc-1be3-44c3-8f4a-0b5042dc17d0",
+  "name": "NumberToWords",
+  "description": {
+    "content": "Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "invalid xml",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "d36c56cf-0cf6-4273-a34d-973e842bf80f",
+    "name": "NumberToWords response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n</soap:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToWordsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToWordsResult>place your string value here</NumberToWordsResult>\n    </NumberToWordsResponse>\n  </soap:Body>\n</soap:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}, {
+  "id": "395c9db6-d6f5-45a7-90f5-09f5aab4fe92",
+  "name": "NumberToDollars",
+  "description": {
+    "content": "Returns the non-zero dollar amount of the passed number.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap:Body>\n</soap:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "8a0c6532-84f9-45c7-838a-f4bf1a6de002",
+    "name": "NumberToDollars response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap:Body>\n</soap:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToDollarsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToDollarsResult>place your string value here</NumberToDollarsResult>\n    </NumberToDollarsResponse>\n  </soap:Body>\n</soap:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}, {
+  "id": "353e33da-1eee-41c1-8865-0f72b2e1fd10",
+  "name": "NumberToWords",
+  "description": {
+    "content": "Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap12:Body>\n</soap12:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "c8a892b6-4b2e-4523-9cc3-fc3e08c835c4",
+    "name": "NumberToWords response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap12:Body>\n</soap12:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToWordsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToWordsResult>place your string value here</NumberToWordsResult>\n    </NumberToWordsResponse>\n  </soap12:Body>\n</soap12:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}, {
+  "id": "18403328-4213-4c3e-b0e9-b21a636697c3",
+  "name": "NumberToDollars",
+  "description": {
+    "content": "Returns the non-zero dollar amount of the passed number.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap12:Body>\n</soap12:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "1763f0b2-9f34-4796-a390-b94ee5c37c7c",
+    "name": "NumberToDollars response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap12:Body>\n</soap12:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToDollarsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToDollarsResult>place your string value here</NumberToDollarsResult>\n    </NumberToDollarsResponse>\n  </soap12:Body>\n</soap12:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}]

--- a/test/data/transactionsValidation/resultValidation/expectedMissingEndpointaebb36fc.js
+++ b/test/data/transactionsValidation/resultValidation/expectedMissingEndpointaebb36fc.js
@@ -1,0 +1,67 @@
+module.exports = {
+  matched: true,
+  requests: {
+    '18403328-4213-4c3e-b0e9-b21a636697c3': {
+      endpoints: [{
+        matched: true,
+        endpointMatchScore: 1,
+        endpoint: 'POST soap12 NumberToDollars',
+        mismatches: [],
+        responses: {
+          '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+            id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+            matched: true,
+            mismatches: []
+          }
+        }
+      }],
+      requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+    },
+    '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+      endpoints: [{
+        matched: true,
+        endpointMatchScore: 1,
+        endpoint: 'POST soap12 NumberToWords',
+        mismatches: [],
+        responses: {
+          'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+            id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+            matched: true,
+            mismatches: []
+          }
+        }
+      }],
+      requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+    },
+    '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+      endpoints: [{
+        matched: true,
+        endpointMatchScore: 1,
+        endpoint: 'POST soap NumberToDollars',
+        mismatches: [],
+        responses: {
+          '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+            id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+            matched: true,
+            mismatches: []
+          }
+        }
+      }],
+      requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+    },
+    'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+      endpoints: [],
+      requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+    }
+  },
+  missingEndpoints: [
+    {
+      property: 'ENDPOINT',
+      transactionJsonPath: null,
+      schemaJsonPath: 'soap NumberToWords',
+      reasonCode: 'MISSING_ENDPOINT',
+      reason: 'The endpoint "POST soap NumberToWords" is missing in collection',
+      endpoint: 'POST soap NumberToWords'
+    }
+  ]
+};

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -31,6 +31,10 @@ const notIdCollectionItems = require('./../data/transactionsValidation/notIdColl
   getMatchDetailsCollectionItems = require('./../data/transactionsValidation/getMatchDetailsCollectionItems.json'),
   numberToWordsCollectionItemsOneMissingItem =
   require('./../data/transactionsValidation/numberToWordsCollectionItemsOneMissingItem.json'),
+  numberToWordsCollectionItemsInvalidXMLBody =
+   require('./../data/transactionsValidation/numberToWordsCollectionItemsInvalidXMLBody.json'),
+  expectedMissingEndpointaebb36fc =
+  require('./../data/transactionsValidation/resultValidation/expectedMissingEndpointaebb36fc'),
   {
     assert,
     expect
@@ -851,18 +855,11 @@ describe('validateBody method', function() {
       });
       return newMismatch;
     },
-    getExpectedWithMismatchInEndpoint = (expectedBase, itemId, mismatch, type = 'request') => {
+    getExpectedWithMismatchInEndpoint = (expectedBase, itemId, mismatch) => {
       let newExpected = JSON.parse(JSON.stringify(expectedBase));
-      if (type === 'request') {
-        newExpected.matched = false;
-        newExpected.requests[itemId].endpoints[0].mismatches = [mismatch];
-        newExpected.requests[itemId].endpoints[0].matched = false;
-      }
-      else if (type === 'response') {
-        newExpected.matched = false;
-        newExpected.requests[itemId].endpoints[0].mismatches = [mismatch];
-        newExpected.requests[itemId].endpoints[0].matched = false;
-      }
+      newExpected.matched = false;
+      newExpected.requests[itemId].endpoints[0].mismatches = [mismatch];
+      newExpected.requests[itemId].endpoints[0].matched = false;
       return newExpected;
     },
     expectedBase = {
@@ -1757,6 +1754,16 @@ describe('validateBody method', function() {
         }
       }
     });
+  });
+
+  it('Should return object requests.endpoints empty missingEndpoints set when entry xml is invalid', function() {
+    const transactionValidator = new TransactionValidator(),
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsInvalidXMLBody,
+        numberToWordsWSDLObject,
+        new XMLParser());
+
+    expect(result).to.be.an('object');
+    expect(result).to.be.an('object').and.to.deep.include(expectedMissingEndpointaebb36fc);
   });
 });
 


### PR DESCRIPTION
handle invalid xml input when validate transaction is called

instead of throwing an error we should return empty endpoints for the request and add the not found endpoint in the missingEndpoints array

remove some dead code in TransactionValidator.test.js
added comments on schemapack