### PR TITLE
Collection name one folder

### DIFF
--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -32,7 +32,6 @@ const COLLECTION_TYPE = 'collection',
 class SchemaPack {
   constructor(input, options = {}) {
     this.input = input;
-    this.descriptionFromService = '';
     this.options = options;
     this.validationResult = null;
     this.wsdlObject = {};
@@ -63,7 +62,6 @@ class SchemaPack {
         let serviceInfo = parser.getServicesAndDocumentation(this.parsedXML);
         if (serviceInfo && serviceInfo.length === 1) {
           this.name = serviceInfo[0].name;
-          this.descriptionFromService = serviceInfo[0].serviceDescription;
         }
       }
     }

--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -32,6 +32,7 @@ const COLLECTION_TYPE = 'collection',
 class SchemaPack {
   constructor(input, options = {}) {
     this.input = input;
+    this.descriptionFromService = '';
     this.options = options;
     this.validationResult = null;
     this.wsdlObject = {};
@@ -52,8 +53,19 @@ class SchemaPack {
       this.input.xmlFiles = result.xml.files;
     }
     else {
-      this.input.data = result.xml;
       this.parsedXML = result.parsedXML;
+      this.input = {
+        type: 'string',
+        data: result.xml
+      };
+      if (this.parsedXML) {
+        const parser = new ParserFactory().getParser(this.input.data);
+        let serviceInfo = parser.getServicesAndDocumentation(this.parsedXML);
+        if (serviceInfo && serviceInfo.length === 1) {
+          this.name = serviceInfo[0].name;
+          this.descriptionFromService = serviceInfo[0].serviceDescription;
+        }
+      }
     }
     this.validationResult = result.valResult;
     this.validated = true;

--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -34,7 +34,6 @@ class SchemaPack {
     this.input = input;
     this.options = options;
     this.validationResult = null;
-    this.valid = null;
     this.wsdlObject = {};
     this.xmlParser = new XMLParser();
     this.validated = false;
@@ -47,13 +46,14 @@ class SchemaPack {
    * @returns {object} A validation object with format {result: <boolean>, reason: <string>}
    */
   validate() {
-    let result = new Validator().validate(this.input);
+    let result = new Validator().validate(this.input, this.xmlParser);
     if (this.input.type === 'folder') {
       this.input.data = result.xml.inputData;
       this.input.xmlFiles = result.xml.files;
     }
     else {
       this.input.data = result.xml;
+      this.parsedXML = result.parsedXML;
     }
     this.validationResult = result.valResult;
     this.validated = true;
@@ -72,7 +72,7 @@ class SchemaPack {
       collectionJSON;
     const parser = new ParserFactory().getParser(this.input.data);
     try {
-      wsdlObject = parser.getWsdlObject(this.input.data, this.xmlParser);
+      wsdlObject = parser.getWsdlObject(this.parsedXML);
       mapper = new WsdlToPostmanCollectionMapper(wsdlObject);
       postmanCollection = mapper.getPostmanCollection(this.options, this.xmlParser, this.name);
       collectionJSON = postmanCollection.toJSON();
@@ -126,7 +126,7 @@ class SchemaPack {
   validateTransaction(transactions, callback) {
     const parser = new ParserFactory().getParser(this.input.data),
       transactionValidator = new TransactionValidator(),
-      wsdlObject = parser.getWsdlObject(this.input.data, this.xmlParser);
+      wsdlObject = parser.getWsdlObject(this.parsedXML);
     let result;
     try {
       result = transactionValidator.validateTransaction(transactions, wsdlObject, this.xmlParser, this.options);
@@ -156,6 +156,9 @@ class SchemaPack {
             data: merged
           };
           validationResult = this.validate();
+          if (validationResult.result) {
+            this.parsedXML = this.xmlParser.parseToObject(merged);
+          }
           return callback(null, validationResult);
         })
         .catch((err) => {

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -13,15 +13,17 @@ class Validator {
    * @param {string} xml xml content in string representation
    * @param {boolean} result true when input is valid and viceversa
    * @param {string} reason Return the reason of the result
+   * @param {object} parsedXML The parsed xml
    * @returns {object} A valid Result object with format {result: <boolean>, reason: <string>}
    */
-  result(xml, result, reason = null) {
+  result(xml, result, reason, parsedXML = null) {
     return {
       xml,
       valResult: {
         result,
         reason
-      }
+      },
+      parsedXML
     };
   }
 
@@ -30,10 +32,12 @@ class Validator {
    * In case of files it validates if provided file path exists.
    * @param {object} input  Contains type (string/file) of input and data (stringValue/filePath)
    *                        Format: {data: <string>, type: <string>}
+   * @param {object} xmlParser xml parser
    * @returns {object} A valid result object with format {result: <boolean>, reason: <string>}
    */
-  validate(input) {
-    let xml;
+  validate(input, xmlParser) {
+    let xml,
+      parsedXML;
     if (this.inputNotProvided(input.data)) {
       return this.result(undefined, false, 'Input not provided');
     }
@@ -49,7 +53,16 @@ class Validator {
       return this.result(undefined, false, 'Not WSDL Specification found in your document');
     }
 
-    return this.result(xml, true, 'Success');
+    if (input.type !== 'folder') {
+      try {
+        parsedXML = xmlParser.parseToObject(xml);
+      }
+      catch (error) {
+        return this.result(xml, false, 'Invalid format. Input must be valid XML');
+      }
+    }
+
+    return this.result(xml, true, 'Success', parsedXML);
   }
 
   /**
@@ -80,10 +93,10 @@ class Validator {
   }
 
   /**
- * Validates if string/file content contains a valid WSDL specification.
- * @param {string} xml input.data content
- * @returns {bioolean} result of validation
- */
+   * Validates if string/file content contains a valid WSDL specification.
+   * @param {string} xml input.data content
+   * @returns {bioolean} result of validation
+   */
   notContainsWsdlSpecInString(xml) {
     if (xml.includes(WSDL_11_VALIDATOR) || xml.includes(WSDL_20_VALIDATOR)) {
       return false;

--- a/lib/WSDLObject.js
+++ b/lib/WSDLObject.js
@@ -67,6 +67,7 @@ class Operation {
     this.fault = '';
     this.portName = '';
     this.serviceName = '';
+    this.serviceDescription = '';
     this.method = '';
     this.protocol = '';
     this.xpathInfo = '';

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -109,8 +109,16 @@ class WsdlParser {
    * @returns {object} the WSDLObject
    */
   assignDocumentation(wsdlObject, parsedXml) {
-    let newWsdlObject = { ...wsdlObject };
-    newWsdlObject.documentation = getWSDLDocumentation(parsedXml, this.informationService.RootTagName);
+    let newWsdlObject = { ...wsdlObject },
+      neWSDLDocumentation = getWSDLDocumentation(parsedXml, this.informationService.RootTagName);
+    if (neWSDLDocumentation === '') {
+      let serviceInfo = this.getServicesAndDocumentation(parsedXml);
+      if (serviceInfo && serviceInfo.length === 1) {
+        this.name = serviceInfo[0].name;
+        neWSDLDocumentation = serviceInfo[0].description;
+      }
+    }
+    newWsdlObject.documentation = neWSDLDocumentation;
     return newWsdlObject;
   }
 

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -180,6 +180,7 @@ class WsdlParser {
         );
 
         wsdlOperation.url = this.informationService.getServiceURL(servicePort, bindingOperation, bindingTagInfo);
+        wsdlOperation.serviceDescription = getServiceDocumentation(service, principalPrefix);
         wsdlOperation.method = bindingTagInfo.verb ? bindingTagInfo.verb :
           this.informationService.getOperationHttpMethod(bindingOperation, newWsdlObject.HTTPNamespace);
         wsdlOperation.protocol = bindingTagInfo.protocol;
@@ -230,6 +231,11 @@ class WsdlParser {
     return newWsdlObject;
   }
 
+  /**
+   * Reads the parsedXML object, look for the services and return the information
+   * @param {object} parsedXml the content file in javascript object representation
+   * @returns {Array} services with name and description
+   */
   getServicesAndDocumentation(parsedXml) {
     const informationService = this.informationService,
       principalPrefix = getPrincipalPrefix(parsedXml, this.informationService.RootTagName);

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -27,15 +27,14 @@ class WsdlParser {
    * Creates a WSDLObject
    * that represents the information of a WSDL object and that is
    * required to create a Postman collection
-   * @param {string} xmlDocumentContent the content file in string
+   * @param {object} parsedXml the already parsed to object xml
    * @param {XMLParser} xmlParser object to parser xml string to object
    * @returns {object} the WSDLObject
    */
-  getWsdlObject(xmlDocumentContent, xmlParser) {
-    if (!xmlDocumentContent) {
+  getWsdlObject(parsedXml) {
+    if (!parsedXml) {
       throw new WsdlError('xmlDocumentContent must have a value');
     }
-    const parsedXml = xmlParser.parseToObject(xmlDocumentContent);
     let wsdlObject = new WsdlObject();
     wsdlObject = this.assignNamespaces(wsdlObject, parsedXml);
     wsdlObject = this.assignOperations(wsdlObject, parsedXml);

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -14,7 +14,8 @@ const
     getAttributeByName,
     getBindingOperation,
     assignSecurity,
-    getWSDLDocumentation
+    getWSDLDocumentation,
+    getServiceDocumentation
   } = require('./WsdlParserCommon');
 
 class WsdlParser {
@@ -220,6 +221,26 @@ class WsdlParser {
 
     return newWsdlObject;
   }
+
+  getServicesAndDocumentation(parsedXml) {
+    const informationService = this.informationService,
+      principalPrefix = getPrincipalPrefix(parsedXml, this.informationService.RootTagName);
+
+    let services = getServices(parsedXml, this.informationService.RootTagName);
+    if (services) {
+      let result = services.map((service) => {
+        let name = getAttributeByName(service, informationService.NameTag),
+          serviceDescription = getServiceDocumentation(service, principalPrefix);
+        return {
+          name: name,
+          description: serviceDescription
+        };
+      });
+      return result;
+    }
+    return [];
+  }
+
 }
 
 module.exports = {

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -459,6 +459,26 @@ function getWSDLDocumentation(parsedXml, wsdlRoot) {
 }
 
 /**
+ *  Gets the service documentation if is a node or a string
+ *  if not found any returns empty string
+ * @param {object} service the service from the wsdl
+ * @param {string} principalPrefix principal document prefix
+ * @returns {string} service from documentation
+ */
+function getServiceDocumentation(service, principalPrefix) {
+  if (!service || typeof service !== 'object') {
+    throw new WsdlError('Cannot get documentation from undefined or null object');
+  }
+  try {
+    let documentation = getNodeByName(service, principalPrefix, DOCUMENTATION_TAG);
+    return documentation ? getDocumentationStringFromNode(documentation) : '';
+  }
+  catch (error) {
+    throw new WsdlError('Cannot get documentation from object');
+  }
+}
+
+/**
  * Removes xml separator from string
  * @param {string} elementName the root tag for the document to remove xml ns separator
  * @returns {string} the elementName without ":"
@@ -551,5 +571,6 @@ module.exports = {
   excludeSeparatorFromName,
   getWSDLImports,
   wsdlHasImports,
-  getNodeByQNameLocal
+  getNodeByQNameLocal,
+  getServiceDocumentation
 };

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -467,7 +467,7 @@ function getWSDLDocumentation(parsedXml, wsdlRoot) {
  */
 function getServiceDocumentation(service, principalPrefix) {
   if (!service || typeof service !== 'object') {
-    throw new WsdlError('Cannot get documentation from undefined or null object');
+    return '';
   }
   try {
     let documentation = getNodeByName(service, principalPrefix, DOCUMENTATION_TAG);

--- a/lib/WsdlToPostmanCollectionMapper.js
+++ b/lib/WsdlToPostmanCollectionMapper.js
@@ -283,6 +283,10 @@ class WsdlToPostmanCollectionMapper {
       return this.createItemsFromOperations(groupsInfo.operations, urlVariablesData, securityPolicyArray,
         xmlParser);
     }
+    else if (groupsInfo.isGrouped && groupsInfo.groups.length === 1) {
+      return this.createItemsFromOperations(groupsInfo.groups[0].operations, urlVariablesData, securityPolicyArray,
+        xmlParser);
+    }
     groupsInfo.groups.forEach((group) => {
       let operationItems = this.createItemsFromOperations(group.operations, urlVariablesData, securityPolicyArray,
         xmlParser);

--- a/lib/WsdlToPostmanCollectionMapper.js
+++ b/lib/WsdlToPostmanCollectionMapper.js
@@ -292,7 +292,8 @@ class WsdlToPostmanCollectionMapper {
         xmlParser);
       items.push(new ItemGroup({
         name: group.groupName,
-        item: operationItems
+        item: operationItems,
+        description: group.operations[0].serviceDescription
       }));
     });
     return items;

--- a/test/data/auth/SAMLToken/SenderVouchersOverSSL.wsdl
+++ b/test/data/auth/SAMLToken/SenderVouchersOverSSL.wsdl
@@ -14,11 +14,10 @@
                     <wsp:Policy>
                         <sp:HttpsToken>
                             <wsp:Policy>
-                                <sp:RequireClientCertificate>
-                                </wsp:Policy>
-                            </sp:HttpsToken>
-                        </wsp:Policy>
-                    </sp:TransportToken>
+                                <sp:RequireClientCertificate/>
+                            </wsp:Policy>
+                        </sp:HttpsToken>
+                    </wsp:Policy>
                     <sp:AlgorithmSuite>
                         <wsp:Policy>
                             <sp:Basic256 />
@@ -30,123 +29,124 @@
                         </wsp:Policy>
                     </sp:Layout>
                     <sp:IncludeTimestamp />
-                </wsp:Policy>
-            </sp:TransportBinding>
-            <sp:SignedSupportingTokens>
-                <wsp:Policy>
-                    <sp:SamlToken sp:IncludeToken=”http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient”>
-<wsp:Policy>
-<sp:WssSamlV11Token10/>
-</wsp:Policy>
-</sp:SamlToken>
-</wsp:Policy>
-</sp:SignedSupportingTokens>
-</wsp:Policy>
+                </sp:TransportToken>
+            </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:SignedSupportingTokens>
+            <wsp:Policy>
+                <sp:SamlToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient"/>
+            </wsp:Policy>
+        </sp:SignedSupportingTokens>
+        <wsp:Policy>
+            <sp:WssSamlV11Token10/>
+        </wsp:Policy>
+
+    </wsp:Policy>
 <types>
 <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
-                        <xs:element name="NumberToWords">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="ubiNum" type="xs:unsignedLong" />
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="NumberToWordsResponse">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="NumberToWordsResult" type="xs:string" />
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="NumberToDollars">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="dNum" type="xs:decimal" />
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="NumberToDollarsResponse">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="NumberToDollarsResult" type="xs:string" />
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:schema>
-                </types>
-                <message name="NumberToWordsSoapRequest">
-                    <part name="parameters" element="tns:NumberToWords" />
-                </message>
-                <message name="NumberToWordsSoapResponse">
-                    <part name="parameters" element="tns:NumberToWordsResponse" />
-                </message>
-                <message name="NumberToDollarsSoapRequest">
-                    <part name="parameters" element="tns:NumberToDollars" />
-                </message>
-                <message name="NumberToDollarsSoapResponse">
-                    <part name="parameters" element="tns:NumberToDollarsResponse" />
-                </message>
-                <portType name="NumberConversionSoapType">
-                    <operation name="NumberToWords">
-                        <documentation>Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.</documentation>
-                        <input message="tns:NumberToWordsSoapRequest" />
-                        <output message="tns:NumberToWordsSoapResponse" />
-                    </operation>
-                    <operation name="NumberToDollars">
-                        <documentation>Returns the non-zero dollar amount of the passed number.</documentation>
-                        <input message="tns:NumberToDollarsSoapRequest" />
-                        <output message="tns:NumberToDollarsSoapResponse" />
-                    </operation>
-                </portType>
-                <binding name="NumberConversionSoapBinding" type="tns:NumberConversionSoapType">
-                    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
-                    <operation name="NumberToWords">
-                        <soap:operation soapAction="" style="document" />
-                        <input>
-                            <soap:body use="literal" />
-                        </input>
-                        <output>
-                            <soap:body use="literal" />
-                        </output>
-                    </operation>
-                    <operation name="NumberToDollars">
-                        <soap:operation soapAction="" style="document" />
-                        <input>
-                            <soap:body use="literal" />
-                        </input>
-                        <output>
-                            <soap:body use="literal" />
-                        </output>
-                    </operation>
-                </binding>
-                <binding name="NumberConversionSoapBinding12" type="tns:NumberConversionSoapType">
-                    <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
-                    <operation name="NumberToWords">
-                        <soap12:operation soapAction="" style="document" />
-                        <input>
-                            <soap12:body use="literal" />
-                        </input>
-                        <output>
-                            <soap12:body use="literal" />
-                        </output>
-                    </operation>
-                    <operation name="NumberToDollars">
-                        <soap12:operation soapAction="" style="document" />
-                        <input>
-                            <soap12:body use="literal" />
-                        </input>
-                        <output>
-                            <soap12:body use="literal" />
-                        </output>
-                    </operation>
-                </binding>
-                <service name="NumberConversion">
-                    <documentation>The Number Conversion Web Service, implemented with Visual DataFlex, provides functions that convert numbers into words or dollar amounts.</documentation>
-                    <port name="NumberConversionSoap" binding="tns:NumberConversionSoapBinding">
-                        <soap:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso" />
-                    </port>
-                    <port name="NumberConversionSoap12" binding="tns:NumberConversionSoapBinding12">
-                        <soap12:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso" />
-                    </port>
-                </service>
-            </definitions>
+<xs:element name="NumberToWords">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="ubiNum" type="xs:unsignedLong" />
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+<xs:element name="NumberToWordsResponse">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="NumberToWordsResult" type="xs:string" />
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+<xs:element name="NumberToDollars">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="dNum" type="xs:decimal" />
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+<xs:element name="NumberToDollarsResponse">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="NumberToDollarsResult" type="xs:string" />
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+</xs:schema>
+</types>
+<message name="NumberToWordsSoapRequest">
+<part name="parameters" element="tns:NumberToWords" />
+</message>
+<message name="NumberToWordsSoapResponse">
+<part name="parameters" element="tns:NumberToWordsResponse" />
+</message>
+<message name="NumberToDollarsSoapRequest">
+<part name="parameters" element="tns:NumberToDollars" />
+</message>
+<message name="NumberToDollarsSoapResponse">
+<part name="parameters" element="tns:NumberToDollarsResponse" />
+</message>
+<portType name="NumberConversionSoapType">
+<operation name="NumberToWords">
+<documentation>Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.</documentation>
+<input message="tns:NumberToWordsSoapRequest" />
+<output message="tns:NumberToWordsSoapResponse" />
+</operation>
+<operation name="NumberToDollars">
+<documentation>Returns the non-zero dollar amount of the passed number.</documentation>
+<input message="tns:NumberToDollarsSoapRequest" />
+<output message="tns:NumberToDollarsSoapResponse" />
+</operation>
+</portType>
+<binding name="NumberConversionSoapBinding" type="tns:NumberConversionSoapType">
+<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+<operation name="NumberToWords">
+<soap:operation soapAction="" style="document" />
+<input>
+    <soap:body use="literal" />
+</input>
+<output>
+    <soap:body use="literal" />
+</output>
+</operation>
+<operation name="NumberToDollars">
+<soap:operation soapAction="" style="document" />
+<input>
+    <soap:body use="literal" />
+</input>
+<output>
+    <soap:body use="literal" />
+</output>
+</operation>
+</binding>
+<binding name="NumberConversionSoapBinding12" type="tns:NumberConversionSoapType">
+<soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+<operation name="NumberToWords">
+<soap12:operation soapAction="" style="document" />
+<input>
+    <soap12:body use="literal" />
+</input>
+<output>
+    <soap12:body use="literal" />
+</output>
+</operation>
+<operation name="NumberToDollars">
+<soap12:operation soapAction="" style="document" />
+<input>
+    <soap12:body use="literal" />
+</input>
+<output>
+    <soap12:body use="literal" />
+</output>
+</operation>
+</binding>
+<service name="NumberConversion">
+<documentation>The Number Conversion Web Service, implemented with Visual DataFlex, provides functions that convert numbers into words or dollar amounts.</documentation>
+<port name="NumberConversionSoap" binding="tns:NumberConversionSoapBinding">
+<soap:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso" />
+</port>
+<port name="NumberConversionSoap12" binding="tns:NumberConversionSoapBinding12">
+<soap12:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso" />
+</port>
+</service>
+</definitions>

--- a/test/data/auth/usernameToken/NoPassword.wsdl
+++ b/test/data/auth/usernameToken/NoPassword.wsdl
@@ -8,7 +8,7 @@
     <wsp:Policy>
         <sp:SupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
             <wsp:Policy>
-                <sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient" />
+                <sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient" >
                 <wsp:Policy>
                     <sp:NoPassword/>
                 </wsp:Policy>

--- a/test/data/auth/usernameToken/NoSecurityBinding.wsdl
+++ b/test/data/auth/usernameToken/NoSecurityBinding.wsdl
@@ -5,7 +5,7 @@
   xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
   xmlns:tns="http://www.dataaccess.com/webservicesserver/" name="NumberConversion" targetNamespace="http://www.dataaccess.com/webservicesserver/">
   <wsp:Policy>
-    <sp:SupportingTokens>
+    <sp:SupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
       <wsp:Policy>
         <sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
         </sp:UsernameToken>

--- a/test/data/auth/usernameToken/TimeStampNoncePwdHash.wsdl
+++ b/test/data/auth/usernameToken/TimeStampNoncePwdHash.wsdl
@@ -8,7 +8,7 @@
     <wsp:Policy>
         <sp:SupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
             <wsp:Policy>
-                <sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient" />
+                <sp:UsernameToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient" >
                 <wsp:Policy>
                     <sp:HashPassword/>
                 </wsp:Policy>

--- a/test/e2e/authentication.test.js
+++ b/test/e2e/authentication.test.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect,
   usernameTokenExamples = 'test/data/auth/usernameToken',
   SAMLTokenExamples = 'test/data/auth/SAMLToken',
   sslExmaple = 'test/data/validWSDLs11/usernameTokenSSL.wsdl',
-  collName = 'http://www.dataaccess.com/webservicesserver/',
+  collName = 'NumberConversion',
   namesArray = ['NumberToWords', 'NumberToDollars', 'NumberToWords', 'NumberToDollars'],
   descArray = ['Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.',
     'Returns the non-zero dollar amount of the passed number.',
@@ -44,7 +44,105 @@ const expect = require('chai').expect,
     value: 'text/xml; charset=utf-8'
   }],
   defMethod = 'POST',
-  reqBody = [
+  usernameToken = { NoPassword: [
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+        '  <soap:Header>\n' +
+        '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap:Header>\n' +
+        '  <soap:Body>\n' +
+        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <ubiNum>18446744073709</ubiNum>\n' +
+        '    </NumberToWords>\n' +
+        '  </soap:Body>\n' +
+        '</soap:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+        '  <soap:Header>\n' +
+        '    <wsse:Security soap:mustUnderstand="1" ' +
+        'xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap:Header>\n' +
+        '  <soap:Body>\n' +
+        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <dNum>1</dNum>\n' +
+        '    </NumberToDollars>\n' +
+        '  </soap:Body>\n' +
+        '</soap:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+        '  <soap12:Header>\n' +
+        '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap12:Header>\n' +
+        '  <soap12:Body>\n' +
+        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <ubiNum>18446744073709</ubiNum>\n' +
+        '    </NumberToWords>\n' +
+        '  </soap12:Body>\n' +
+        '</soap12:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+        '  <soap12:Header>\n' +
+        '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap12:Header>\n' +
+        '  <soap12:Body>\n' +
+        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <dNum>1</dNum>\n' +
+        '    </NumberToDollars>\n' +
+        '  </soap12:Body>\n' +
+        '</soap12:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    }
+  ],
+  NoSecurityBinding: [
     {
       mode: 'raw',
       raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -162,6 +260,243 @@ const expect = require('chai').expect,
       }
     }
   ],
+  UsernameToken: [
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+        '  <soap:Header>\n' +
+        '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">' +
+        'place password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap:Header>\n' +
+        '  <soap:Body>\n' +
+        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <ubiNum>18446744073709</ubiNum>\n' +
+        '    </NumberToWords>\n' +
+        '  </soap:Body>\n' +
+        '</soap:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+        '  <soap:Header>\n' +
+        '    <wsse:Security soap:mustUnderstand="1" ' +
+        'xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">' +
+        'place password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap:Header>\n' +
+        '  <soap:Body>\n' +
+        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <dNum>1</dNum>\n' +
+        '    </NumberToDollars>\n' +
+        '  </soap:Body>\n' +
+        '</soap:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+        '  <soap12:Header>\n' +
+        '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">' +
+        'place password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap12:Header>\n' +
+        '  <soap12:Body>\n' +
+        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <ubiNum>18446744073709</ubiNum>\n' +
+        '    </NumberToWords>\n' +
+        '  </soap12:Body>\n' +
+        '</soap12:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+        '  <soap12:Header>\n' +
+        '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">' +
+        'place password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap12:Header>\n' +
+        '  <soap12:Body>\n' +
+        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <dNum>1</dNum>\n' +
+        '    </NumberToDollars>\n' +
+        '  </soap12:Body>\n' +
+        '</soap12:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    }
+  ],
+  TimeStampNoncePwdHash: [
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+        '  <soap:Header>\n' +
+        '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' +
+        'place hashed password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap:Header>\n' +
+        '  <soap:Body>\n' +
+        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <ubiNum>18446744073709</ubiNum>\n' +
+        '    </NumberToWords>\n' +
+        '  </soap:Body>\n' +
+        '</soap:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+        '  <soap:Header>\n' +
+        '    <wsse:Security soap:mustUnderstand="1" ' +
+        'xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' +
+        'place hashed password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap:Header>\n' +
+        '  <soap:Body>\n' +
+        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <dNum>1</dNum>\n' +
+        '    </NumberToDollars>\n' +
+        '  </soap:Body>\n' +
+        '</soap:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+        '  <soap12:Header>\n' +
+        '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' +
+        'place hashed password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap12:Header>\n' +
+        '  <soap12:Body>\n' +
+        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <ubiNum>18446744073709</ubiNum>\n' +
+        '    </NumberToWords>\n' +
+        '  </soap12:Body>\n' +
+        '</soap12:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    },
+    {
+      mode: 'raw',
+      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+        '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+        '  <soap12:Header>\n' +
+        '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:UsernameToken>\n' +
+        '        <wsse:Username>place username here</wsse:Username>\n' +
+        '        <wsse:Password Type=' +
+        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' +
+        'place hashed password here</wsse:Password>\n' +
+        '        <wsse:Nonce EncodingType="...#Base64Binary">place nonce here</wsse:Nonce>\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:UsernameToken>\n' +
+        '    </wsse:Security>\n' +
+        '  </soap12:Header>\n' +
+        '  <soap12:Body>\n' +
+        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+        '      <dNum>1</dNum>\n' +
+        '    </NumberToDollars>\n' +
+        '  </soap12:Body>\n' +
+        '</soap12:Envelope>\n',
+      options: {
+        raw: {
+          language: 'xml'
+        }
+      }
+    }
+  ]
+  },
   reqBodySSL = [
     {
       mode: 'raw',
@@ -260,81 +595,91 @@ const expect = require('chai').expect,
       }
     }
   ],
-  reqBodySAML = [
-    {
-      mode: 'raw',
-      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
-        '  <soap:Header>\n' +
-        '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
-        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
-        '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
-        '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
-        '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
-        '        <saml2:Subject>\n' +
-        '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
-        'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
-        '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
-        '        </saml2:Subject>\n' +
-        '      </saml2:Assertion>\n' +
-        '    </wsse:Security>\n' +
-        '  </soap:Header>\n' +
-        '  <soap:Body>\n' +
-        '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
-        '      <ubiNum>18446744073709</ubiNum>\n' +
-        '    </NumberToWords>\n' +
-        '  </soap:Body>\n' +
-        '</soap:Envelope>\n',
-      options: {
-        raw: {
-          language: 'xml'
+  saml = {
+    SenderVouchersOverSSL: [
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+          '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+          '  <soap:Header>\n' +
+          '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+          '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+          '      <wsse:Timestamp xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility">\n' +
+          '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+          '      </wsse:Timestamp>\n' +
+          '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
+          '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
+          '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
+          '        <saml2:Subject>\n' +
+          '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
+          'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
+          '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:sender-vouches"/>\n' +
+          '        </saml2:Subject>\n' +
+          '      </saml2:Assertion>\n' +
+          '    </wsse:Security>\n' +
+          '  </soap:Header>\n' +
+          '  <soap:Body>\n' +
+          '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+          '      <ubiNum>18446744073709</ubiNum>\n' +
+          '    </NumberToWords>\n' +
+          '  </soap:Body>\n' +
+          '</soap:Envelope>\n',
+        options: {
+          raw: {
+            language: 'xml'
+          }
         }
-      }
-    },
-    {
-      mode: 'raw',
-      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
-        '  <soap:Header>\n' +
-        '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
-        '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
-        '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
-        '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
-        '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
-        '        <saml2:Subject>\n' +
-        '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
-        'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
-        '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
-        '        </saml2:Subject>\n' +
-        '      </saml2:Assertion>\n' +
-        '    </wsse:Security>\n' +
-        '  </soap:Header>\n' +
-        '  <soap:Body>\n' +
-        '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
-        '      <dNum>1</dNum>\n' +
-        '    </NumberToDollars>\n' +
-        '  </soap:Body>\n' +
-        '</soap:Envelope>\n',
-      options: {
-        raw: {
-          language: 'xml'
+      },
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+          '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+          '  <soap:Header>\n' +
+          '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+          '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+          '      <wsse:Timestamp xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility">\n' +
+          '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+          '      </wsse:Timestamp>\n' +
+          '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
+          '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
+          '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
+          '        <saml2:Subject>\n' +
+          '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
+          'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
+          '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:sender-vouches"/>\n' +
+          '        </saml2:Subject>\n' +
+          '      </saml2:Assertion>\n' +
+          '    </wsse:Security>\n' +
+          '  </soap:Header>\n' +
+          '  <soap:Body>\n' +
+          '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+          '      <dNum>1</dNum>\n' +
+          '    </NumberToDollars>\n' +
+          '  </soap:Body>\n' +
+          '</soap:Envelope>\n',
+        options: {
+          raw: {
+            language: 'xml'
+          }
         }
-      }
-    },
-    {
-      mode: 'raw',
-      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+      },
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
         '  <soap12:Header>\n' +
         '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
         '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:Timestamp xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility">\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:Timestamp>\n' +
         '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
         '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
         '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
         '        <saml2:Subject>\n' +
         '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
         'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
-        '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
+        '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:sender-vouches"/>\n' +
         '        </saml2:Subject>\n' +
         '      </saml2:Assertion>\n' +
         '    </wsse:Security>\n' +
@@ -345,26 +690,29 @@ const expect = require('chai').expect,
         '    </NumberToWords>\n' +
         '  </soap12:Body>\n' +
         '</soap12:Envelope>\n',
-      options: {
-        raw: {
-          language: 'xml'
+        options: {
+          raw: {
+            language: 'xml'
+          }
         }
-      }
-    },
-    {
-      mode: 'raw',
-      raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+      },
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
         '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
         '  <soap12:Header>\n' +
         '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
         '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+        '      <wsse:Timestamp xmlns:wsu="http://schemas.xmlsoap.org/ws/2003/06/utility">\n' +
+        '        <wsu:Created>2007-03-28T18:42:03Z</wsu:Created>\n' +
+        '      </wsse:Timestamp>\n' +
         '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
         '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
         '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
         '        <saml2:Subject>\n' +
         '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
         'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
-        '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
+        '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:sender-vouches"/>\n' +
         '        </saml2:Subject>\n' +
         '      </saml2:Assertion>\n' +
         '    </wsse:Security>\n' +
@@ -375,13 +723,135 @@ const expect = require('chai').expect,
         '    </NumberToDollars>\n' +
         '  </soap12:Body>\n' +
         '</soap12:Envelope>\n',
-      options: {
-        raw: {
-          language: 'xml'
+        options: {
+          raw: {
+            language: 'xml'
+          }
         }
       }
-    }
-  ],
+    ],
+    SAMLV11Token: [
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+          '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+          '  <soap:Header>\n' +
+          '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+          '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+          '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
+          '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
+          '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
+          '        <saml2:Subject>\n' +
+          '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
+          'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
+          '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
+          '        </saml2:Subject>\n' +
+          '      </saml2:Assertion>\n' +
+          '    </wsse:Security>\n' +
+          '  </soap:Header>\n' +
+          '  <soap:Body>\n' +
+          '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+          '      <ubiNum>18446744073709</ubiNum>\n' +
+          '    </NumberToWords>\n' +
+          '  </soap:Body>\n' +
+          '</soap:Envelope>\n',
+        options: {
+          raw: {
+            language: 'xml'
+          }
+        }
+      },
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+          '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n' +
+          '  <soap:Header>\n' +
+          '    <wsse:Security soap:mustUnderstand="1" xmlns:wsse=' +
+          '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+          '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
+          '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
+          '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
+          '        <saml2:Subject>\n' +
+          '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
+          'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
+          '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
+          '        </saml2:Subject>\n' +
+          '      </saml2:Assertion>\n' +
+          '    </wsse:Security>\n' +
+          '  </soap:Header>\n' +
+          '  <soap:Body>\n' +
+          '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+          '      <dNum>1</dNum>\n' +
+          '    </NumberToDollars>\n' +
+          '  </soap:Body>\n' +
+          '</soap:Envelope>\n',
+        options: {
+          raw: {
+            language: 'xml'
+          }
+        }
+      },
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+          '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+          '  <soap12:Header>\n' +
+          '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+          '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+          '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
+          '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
+          '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
+          '        <saml2:Subject>\n' +
+          '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
+          'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
+          '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
+          '        </saml2:Subject>\n' +
+          '      </saml2:Assertion>\n' +
+          '    </wsse:Security>\n' +
+          '  </soap12:Header>\n' +
+          '  <soap12:Body>\n' +
+          '    <NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+          '      <ubiNum>18446744073709</ubiNum>\n' +
+          '    </NumberToWords>\n' +
+          '  </soap12:Body>\n' +
+          '</soap12:Envelope>\n',
+        options: {
+          raw: {
+            language: 'xml'
+          }
+        }
+      },
+      {
+        mode: 'raw',
+        raw: '<?xml version="1.0" encoding="utf-8"?>\n' +
+          '<soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">\n' +
+          '  <soap12:Header>\n' +
+          '    <wsse:Security soap12:mustUnderstand="1" xmlns:wsse=' +
+          '"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">\n' +
+          '      <saml2:Assertion ID="place id here" IssueInstant="place issue instant" Version="2.0">\n' +
+          '        <saml2:Issuer>www.opensaml.org</saml2:Issuer>\n' +
+          '        <saml2:Conditions NotBefore="place not before" NotOnOrAfter="place not on or after"/>\n' +
+          '        <saml2:Subject>\n' +
+          '          <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">' +
+          'joe,ou=people,ou=saml demo,o=example.com</saml2:NameID>\n' +
+          '          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>\n' +
+          '        </saml2:Subject>\n' +
+          '      </saml2:Assertion>\n' +
+          '    </wsse:Security>\n' +
+          '  </soap12:Header>\n' +
+          '  <soap12:Body>\n' +
+          '    <NumberToDollars xmlns="http://www.dataaccess.com/webservicesserver/">\n' +
+          '      <dNum>1</dNum>\n' +
+          '    </NumberToDollars>\n' +
+          '  </soap12:Body>\n' +
+          '</soap12:Envelope>\n',
+        options: {
+          raw: {
+            language: 'xml'
+          }
+        }
+      }
+    ] },
   status = 'OK',
   code = 200,
   resBody = ['<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -439,7 +909,8 @@ describe('Test the convertion of valid WSDL files with authetication mechanisms'
   var authFolder = fs.readdirSync(usernameTokenExamples);
   async.each(authFolder, function (file, cb) {
     it('Should validate the convertion of a file with ' + file, function () {
-      let fileContent = fs.readFileSync(usernameTokenExamples + '/' + file, 'utf8');
+      let fileContent = fs.readFileSync(usernameTokenExamples + '/' + file, 'utf8'),
+        expected = usernameToken[file.split('.').slice(0, -1).join('.')];
       Index.convert(
         { type: 'string', data: fileContent },
         { folderStrategy: 'No folders' },
@@ -462,7 +933,7 @@ describe('Test the convertion of valid WSDL files with authetication mechanisms'
               expect(conversionResult.output[0].data.item[i].request.header).to.be.eql(header);
               expect(conversionResult.output[0].data.item[i].request.method).to.be.eql(defMethod);
               let fixedBody = fixBodyMessage(conversionResult.output[0].data.item[i].request.body.raw);
-              expect(fixedBody).to.be.eql(reqBody[i].raw);
+              expect(fixedBody).to.be.eql(expected[i].raw);
               expect(conversionResult.output[0].data.item[i].request.description.content).to.be.eql(descArray[i]);
               expect(conversionResult.output[0].data.item[i].request.description.type).to.be.eql(descType);
               // Expects for Response
@@ -475,7 +946,7 @@ describe('Test the convertion of valid WSDL files with authetication mechanisms'
               expect(conversionResult.output[0].data.item[i].response[0].originalRequest.header).to.be.eql(header);
               expect(conversionResult.output[0].data.item[i].response[0].originalRequest.method).to.be.eql(defMethod);
               fixedBody = fixBodyMessage(conversionResult.output[0].data.item[i].response[0].originalRequest.body.raw);
-              expect(fixedBody).to.be.eql(reqBody[i].raw);
+              expect(fixedBody).to.be.eql(expected[i].raw);
               expect(conversionResult.output[0].data.item[i].response[0].status).to.be.eql(status);
               expect(conversionResult.output[0].data.item[i].response[0].code).to.be.eql(code);
               expect(conversionResult.output[0].data.item[i].response[0].header).to.be.eql(header);
@@ -549,7 +1020,8 @@ describe('Authenticacion with SAML11 Token', function () {
   var authFolder = fs.readdirSync(SAMLTokenExamples);
   async.each(authFolder, function (file, cb) {
     it('Should validate the convertion of a file with SAML11 Token ' + file, function () {
-      let fileContent = fs.readFileSync(SAMLTokenExamples + '/' + file, 'utf8');
+      let fileContent = fs.readFileSync(SAMLTokenExamples + '/' + file, 'utf8'),
+        expected = saml[file.split('.').slice(0, -1).join('.')];
       Index.convert(
         { type: 'string', data: fileContent },
         { folderStrategy: 'No folders' },
@@ -572,7 +1044,7 @@ describe('Authenticacion with SAML11 Token', function () {
               expect(conversionResult.output[0].data.item[i].request.header).to.be.eql(header);
               expect(conversionResult.output[0].data.item[i].request.method).to.be.eql(defMethod);
               let fixedBody = fixBodyMessage(conversionResult.output[0].data.item[i].request.body.raw);
-              expect(fixedBody).to.be.eql(reqBodySAML[i].raw);
+              expect(fixedBody).to.be.eql(expected[i].raw);
               expect(conversionResult.output[0].data.item[i].request.description.content).to.be.eql(descArray[i]);
               expect(conversionResult.output[0].data.item[i].request.description.type).to.be.eql(descType);
               // Expects for Response
@@ -587,7 +1059,7 @@ describe('Authenticacion with SAML11 Token', function () {
 
               fixedBody = fixBodyMessage(conversionResult.output[0].data.item[i].response[0]
                 .originalRequest.body.raw);
-              expect(fixedBody).to.be.eql(reqBodySAML[i].raw);
+              expect(fixedBody).to.be.eql(expected[i].raw);
               expect(conversionResult.output[0].data.item[i].response[0].status).to.be.eql(status);
               expect(conversionResult.output[0].data.item[i].response[0].code).to.be.eql(code);
               expect(conversionResult.output[0].data.item[i].response[0].header).to.be.eql(header);

--- a/test/e2e/validateOperationMessagesWithSchema.test.js
+++ b/test/e2e/validateOperationMessagesWithSchema.test.js
@@ -21,7 +21,7 @@ describe('Validating wsdlObject bodyMessages using validateOperationMessagesWith
         xmlParser = new XMLParser(),
         version = factory.getWsdlVersion(xmlDocumentContent),
         parser = factory.getParser(xmlDocumentContent),
-        wsdlObject = parser.getWsdlObject(xmlDocumentContent, xmlParser),
+        wsdlObject = parser.getWsdlObject(xmlParser.parseToObject(xmlDocumentContent)),
         xmlParsed = xmlParser.parseToObject(xmlDocumentContent),
         schemaToValidate = getCleanSchema(xmlParsed, wsdlObject, version, xmlParser);
 

--- a/test/unit/ConversionSpecialCases.test.js
+++ b/test/unit/ConversionSpecialCases.test.js
@@ -31,7 +31,7 @@ describe('SchemaPack convert special cases WSDL 1.1', function() {
       expect(result.output[0].type).to.equal('collection');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item[0].item.length).to.equal(8);
+      expect(result.output[0].data.item.length).to.equal(8);
       expect(result.output[0].data.info.description.content.includes(DOC_HAS_NO_SERVICE_MESSAGE))
         .to.equal(true);
     });
@@ -94,7 +94,7 @@ describe('SchemaPack convert special cases WSDL 1.1', function() {
       expect(result.output[0].type).to.equal('collection');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item[0].item.length).to.equal(4);
+      expect(result.output[0].data.item.length).to.equal(4);
       expect(result.output[0].data.info.description.content.includes(DOC_HAS_NO_SERVICE_PORT_MESSAGE_2))
         .to.equal(true);
     });
@@ -159,8 +159,8 @@ describe('SchemaPack convert special cases WSDL 1.1', function() {
       expect(result.output[0].type).to.equal('collection');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item[0].item.length).to.equal(2);
-      expect(result.output[0].data.item[0].item[1].request.body.raw.includes(ELEMENT_NOT_FOUND))
+      expect(result.output[0].data.item.length).to.equal(2);
+      expect(result.output[0].data.item[1].request.body.raw.includes(ELEMENT_NOT_FOUND))
         .to.equal(true);
     });
   });
@@ -183,7 +183,7 @@ describe('SchemaPack convert special cases WSDL 2.0', function() {
       expect(result.output[0].type).to.equal('collection');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item[0].item.length).to.equal(3);
+      expect(result.output[0].data.item.length).to.equal(3);
       expect(result.output[0].data.info.description.content.includes(DOC_HAS_NO_SERVICE_MESSAGE))
         .to.equal(true);
     });
@@ -246,7 +246,7 @@ describe('SchemaPack convert special cases WSDL 2.0', function() {
       expect(result.output[0].type).to.equal('collection');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item[0].item.length).to.equal(3);
+      expect(result.output[0].data.item.length).to.equal(3);
       expect(result.output[0].data.info.description.content.includes(DOC_HAS_NO_SERVICE_PORT_MESSAGE_2))
         .to.equal(true);
     });

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -56,7 +56,7 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
       expect(result.output).to.be.an('array');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].type).to.equal('collection');
-      expect(result.output[0].data.info.name).to.equal('calculator-soap11and12.wsdl');
+      expect(result.output[0].data.info.name).to.equal('Calculator');
     });
   });
 
@@ -74,7 +74,7 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
       expect(result.output).to.be.an('array');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].type).to.equal('collection');
-      expect(result.output[0].data.info.name).to.equal('http://tempuri.org/');
+      expect(result.output[0].data.info.name).to.equal('Calculator');
     });
   });
 
@@ -317,7 +317,7 @@ describe('getMetaData method', function () {
       }, {});
     schemaPack.getMetaData(function (x, y) {
       expect(x).to.eq(null);
-      expect(y.name).to.eq('calculator-soap11and12.wsdl');
+      expect(y.name).to.eq('Calculator');
     });
   });
 
@@ -348,7 +348,7 @@ describe('getMetaData method', function () {
 
 describe('merge and validate', function () {
 
-  it('Should create collection from folder having one root file for browser', function () {
+  it('Should create collection from folder having one root file for browser', function (done) {
     let folderPath = path.join(__dirname, SEPARATED_FILES, '/W3Example'),
       files = [],
       array = [
@@ -381,6 +381,7 @@ describe('merge and validate', function () {
           expect(result.output[0].data).to.have.property('info');
           expect(result.output[0].data).to.have.property('item');
         });
+        done();
       }
       else {
         expect.fail(null, null, status.reason);
@@ -388,7 +389,7 @@ describe('merge and validate', function () {
     });
   });
 
-  it('Should create collection from folder having one root file for browser ex 2', function () {
+  it('Should create collection from folder having one root file for browser ex 2', function (done) {
     let folderPath = path.join(__dirname, SEPARATED_FILES, '/counting'),
       files = [],
       array = [
@@ -419,6 +420,7 @@ describe('merge and validate', function () {
           expect(result.output[0].type).to.have.equal('collection');
           expect(result.output[0].data).to.have.property('info');
           expect(result.output[0].data).to.have.property('item');
+          done();
         });
       }
       else {
@@ -427,7 +429,7 @@ describe('merge and validate', function () {
     });
   });
 
-  it('Should create collection from folder having only one file for browser', function () {
+  it('Should create collection from folder having only one file for browser', function (done) {
     let folderPath = path.join(__dirname, SEPARATED_FILES, '/W3Example'),
       files = [],
       array = [
@@ -457,6 +459,7 @@ describe('merge and validate', function () {
           expect(result.output[0].type).to.have.equal('collection');
           expect(result.output[0].data).to.have.property('info');
           expect(result.output[0].data).to.have.property('item');
+          done();
         });
       }
       else {
@@ -465,7 +468,7 @@ describe('merge and validate', function () {
     });
   });
 
-  it('Should create collection from folder having only one file no imports for browser', function () {
+  it('Should create collection from folder having only one file no imports for browser', function (done) {
     let folderPath = path.join(__dirname, SEPARATED_FILES, '/W3Example'),
       files = [],
       array = [
@@ -492,6 +495,7 @@ describe('merge and validate', function () {
           expect(result.output[0].type).to.have.equal('collection');
           expect(result.output[0].data).to.have.property('info');
           expect(result.output[0].data).to.have.property('item');
+          done();
         });
       }
       else {
@@ -500,7 +504,32 @@ describe('merge and validate', function () {
     });
   });
 
-  it('Should create collection from folder send only file info', function () {
+  it('Should throw an error when input has more than one root file (services)', function (done) {
+    let folderPath = path.join(__dirname, SEPARATED_FILES, '/multipleRoot'),
+      files = [],
+      array = [
+        { fileName: folderPath + '/CountingCategoryData.xsd' },
+        { fileName: folderPath + '/CountingCategoryService.wsdl' },
+        { fileName: folderPath + '/CountingCategoryServiceCopy.wsdl' }
+      ];
+    array.forEach((item) => {
+      files.push({
+        content: fs.readFileSync(item.fileName, 'utf8'),
+        fileName: item.fileName
+      });
+    });
+    const schemaPack = new SchemaPack({ type: 'folder', data: files }, {});
+    schemaPack.mergeAndValidate((err, status) => {
+      if (err) {
+        expect.fail(null, null, err);
+      }
+      expect(status.result).to.equal(false);
+      expect(status.reason).to.equal(MULTIPLE_ROOT_FILES);
+      done();
+    });
+  });
+
+  it('Should create collection from folder send only file info', function (done) {
     let folderPath = path.join(__dirname, SEPARATED_FILES, '/W3Example'),
       array = [
         { fileName: folderPath + '/stockquote.xsd' },
@@ -522,36 +551,13 @@ describe('merge and validate', function () {
           expect(result.output[0].type).to.have.equal('collection');
           expect(result.output[0].data).to.have.property('info');
           expect(result.output[0].data).to.have.property('item');
-          expect(result.output[0].data.info.name).to.equal('http://example.com/stockquote/service');
+          expect(result.output[0].data.info.name).to.equal('StockQuoteService');
+          done();
         });
       }
       else {
         expect.fail(null, null, status.reason);
       }
-    });
-  });
-
-  it('Should throw an error when input has more than one root file (services)', function () {
-    let folderPath = path.join(__dirname, SEPARATED_FILES, '/multipleRoot'),
-      files = [],
-      array = [
-        { fileName: folderPath + '/CountingCategoryData.xsd' },
-        { fileName: folderPath + '/CountingCategoryService.wsdl' },
-        { fileName: folderPath + '/CountingCategoryServiceCopy.wsdl' }
-      ];
-    array.forEach((item) => {
-      files.push({
-        content: fs.readFileSync(item.fileName, 'utf8'),
-        fileName: item.fileName
-      });
-    });
-    const schemaPack = new SchemaPack({ type: 'folder', data: files }, {});
-    schemaPack.mergeAndValidate((err, status) => {
-      if (err) {
-        expect.fail(null, null, err);
-      }
-      expect(status.result).to.equal(false);
-      expect(status.reason).to.equal(MULTIPLE_ROOT_FILES);
     });
   });
 });

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -116,7 +116,7 @@ describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
     });
   });
 
-  it('Should get an object representing PM Collection with one folder', function () {
+  it('Should get an object representing PM Collection with no folder when has one service', function () {
     let fileContent = fs.readFileSync(validWSDLs + '/calculator-soap11and12.wsdl', 'utf8');
     const options = { folderStrategy: 'Service' },
       schemaPack = new SchemaPack({
@@ -131,9 +131,26 @@ describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].type).to.equal('collection');
       expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item.length).to.equal(1);
-      expect(result.output[0].data.item[0].name).to.equal('Calculator');
+      expect(result.output[0].data.item.length).to.equal(8);
+    });
+  });
 
+  it('Should get an object representing PM Collection with 2 folder when has one Port/Endpoint', function () {
+    let fileContent = fs.readFileSync(validWSDLs + '/calculator-soap11and12.wsdl', 'utf8');
+    const options = { folderStrategy: 'Port/Endpoint' },
+      schemaPack = new SchemaPack({
+        data: fileContent,
+        type: 'string'
+      }, options);
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output).to.be.an('array');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].type).to.equal('collection');
+      expect(result.output[0].data.item).to.be.an('array');
+      expect(result.output[0].data.item.length).to.equal(2);
     });
   });
 

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -135,25 +135,6 @@ describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
     });
   });
 
-  it('Should get an object representing PM Collection with 2 folder when has one Port/Endpoint', function () {
-    let fileContent = fs.readFileSync(validWSDLs + '/calculator-soap11and12.wsdl', 'utf8');
-    const options = { folderStrategy: 'Port/Endpoint' },
-      schemaPack = new SchemaPack({
-        data: fileContent,
-        type: 'string'
-      }, options);
-
-    schemaPack.convert((error, result) => {
-      expect(error).to.be.null;
-      expect(result).to.be.an('object');
-      expect(result.output).to.be.an('array');
-      expect(result.output[0].data).to.be.an('object');
-      expect(result.output[0].type).to.equal('collection');
-      expect(result.output[0].data.item).to.be.an('array');
-      expect(result.output[0].data.item.length).to.equal(2);
-    });
-  });
-
   it('Should get an object representing PM Collection without folder', function () {
     let fileContent = fs.readFileSync(validWSDLs + '/calculator-soap11and12.wsdl', 'utf8');
     const options = { folderStrategy: 'No folders' },

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -29,7 +29,7 @@ describe('getMetaData', function () {
       data: VALID_WSDL_PATH
     }, function (x, y) {
       expect(x).to.eq(null);
-      expect(y.name).to.eq('calculator-soap11and12.wsdl');
+      expect(y.name).to.eq('Calculator');
     });
 
   });

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -2,6 +2,9 @@ const expect = require('chai').expect,
   {
     Validator
   } = require('./../../lib/Validator'),
+  {
+    XMLParser
+  } = require('./../../lib/XMLParser'),
   SEPARATED_FILES = 'test/data/separatedFiles',
   fs = require('fs');
 
@@ -10,7 +13,7 @@ describe('Validator result', function () {
   it('Should return a validatorResult format', function () {
     const validatorResult = new Validator().result(true, 'Some reason');
     expect(validatorResult).to.be.an('object')
-      .that.have.all.keys('xml', 'valResult');
+      .that.have.all.keys('xml', 'valResult', 'parsedXML');
   });
 });
 
@@ -68,7 +71,7 @@ describe('Validator validate', function () {
   it('Should return a failed validationResult when input.data is null', function () {
     const nullInput = mockInput(null),
       validator = new Validator();
-    expect(validator.validate(nullInput).valResult).to.be.an('object')
+    expect(validator.validate(nullInput, new XMLParser()).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Input not provided'
@@ -88,7 +91,7 @@ describe('Validator validate', function () {
   it('Should return a failed validationResult when input.data is empty', function () {
     const emptyInput = mockInput(''),
       validator = new Validator();
-    expect(validator.validate(emptyInput).valResult).to.be.an('object')
+    expect(validator.validate(emptyInput, new XMLParser()).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Input not provided'
@@ -99,7 +102,7 @@ describe('Validator validate', function () {
 string`, function () {
     const input = mockInput('Does not contains WSDL validation', 'string'),
       validator = new Validator();
-    expect(validator.validate(input).valResult).to.be.an('object')
+    expect(validator.validate(input, new XMLParser()).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: 'Not WSDL Specification found in your document'
@@ -109,7 +112,7 @@ string`, function () {
   it('Should return a failed validationResult if input type is not supported', function () {
     const input = mockInput('Any type data', 'NotSupportedType'),
       validator = new Validator();
-    expect(validator.validate(input).valResult).to.be.an('object')
+    expect(validator.validate(input, new XMLParser()).valResult).to.be.an('object')
       .and.to.include({
         result: false,
         reason: `Invalid input type (${input.type}). Type must be file/string/folder.`
@@ -120,10 +123,21 @@ string`, function () {
     function () {
       const definitionsInput = mockInput('<definitions ...> ... </ definitions>', 'string'),
         validator = new Validator();
-      expect(validator.validate(definitionsInput).valResult).to.be.an('object')
+      expect(validator.validate(definitionsInput, new XMLParser()).valResult).to.be.an('object')
         .and.to.include({
           result: true,
           reason: 'Success'
+        });
+    });
+
+  it('Should return  ',
+    function () {
+      const definitionsInput = mockInput('</dsefinitions> </ definitions>', 'string'),
+        validator = new Validator();
+      expect(validator.validate(definitionsInput, new XMLParser()).valResult).to.be.an('object')
+        .and.to.include({
+          result: false,
+          reason: 'Invalid format. Input must be valid XML'
         });
     });
 
@@ -131,7 +145,7 @@ string`, function () {
     function () {
       const descriptionInput = mockInput('<description ...> ... </ description>', 'string'),
         validator = new Validator();
-      expect(validator.validate(descriptionInput).valResult).to.be.an('object')
+      expect(validator.validate(descriptionInput, new XMLParser()).valResult).to.be.an('object')
         .and.to.include({
           result: true,
           reason: 'Success'
@@ -157,7 +171,7 @@ string`, function () {
 
       const input = mockInput(files, 'folder'),
         validator = new Validator(),
-        result = validator.validate(input);
+        result = validator.validate(input, new XMLParser());
       expect(result.valResult).to.be.an('object')
         .and.to.include({
           result: true,

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -1258,8 +1258,9 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
 
   it('should get an object in memory representing wsdlObject validate all namespaces found',
     function () {
-      const parser = new WsdlParser(new WsdlInformationService11());
-      let wsdlObject = parser.getWsdlObject(NUMBERCONVERSION_INPUT, new XMLParser());
+      const parser = new WsdlParser(new WsdlInformationService11()),
+        xmlParser = new XMLParser();
+      let wsdlObject = parser.getWsdlObject(xmlParser.parseToObject(NUMBERCONVERSION_INPUT));
       expect(wsdlObject).to.be.an('object');
       expect(wsdlObject).to.have.all.keys('targetNamespace',
         'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',
@@ -1335,8 +1336,9 @@ describe('WSDL 1.1 parser getWsdlObject', function () {
   it('should get an object in memory representing wsdlObject 2.0',
     function () {
       const informationService = new WsdlInformationService20(),
-        parser = new WsdlParser(informationService);
-      let wsdlObject = parser.getWsdlObject(WSDL_SAMPLE_2_0, new XMLParser());
+        parser = new WsdlParser(informationService),
+        xmlParser = new XMLParser();
+      let wsdlObject = parser.getWsdlObject(xmlParser.parseToObject(WSDL_SAMPLE_2_0));
       expect(wsdlObject).to.be.an('object');
       expect(wsdlObject).to.have.all.keys('targetNamespace',
         'wsdlNamespace', 'SOAPNamespace', 'HTTPNamespace',


### PR DESCRIPTION
Parse the document in constructor so we could add the "if only one service take the name of the collection from the name of the service" rule in getMetadata and in convert.
Assign the name if only one service implementation

Also if there is only one folder omit the folder

add the documentation from the service to the folder is there is folder

Modified some security file examples that where incorrect and adequate the test assertions.