### PR TITLE
Wrong element substitution in suggestion

### DIFF
--- a/lib/utils/mismatchUtils.js
+++ b/lib/utils/mismatchUtils.js
@@ -20,7 +20,7 @@ const { XMLXSDValidator } = require('../xsdValidation/XMLXSDValidator'),
  * @returns {object} an instance of validator Library
  */
 function useValidator() {
-  const lib = new XMLXSDValidator().getValidatorLibrary();
+  const lib = new XMLXSDValidator('libxmljs').getValidatorLibrary();
   return lib;
 }
 
@@ -201,19 +201,18 @@ function fillElementData(name, node, keyXpath, keyIsItsParent) {
  * @returns {number} The position between its siblings
  */
 function getElementPosition(node) {
-  const position = node.parent().childNodes().filter((child) => {
-    return child.name() !== 'text';
-  }).map((child, index) => {
-    if (child.name() === node.name()) {
-      return {
-        index,
-        elementString: child.toString()
-      };
-    }
-  }).find((data) => {
-    return data;
-  });
-  return position;
+  const parentChildren = useValidator().getChildrenElements(node.parent()),
+    positionData = parentChildren.map((child, index) => {
+      if (child.name() === node.name()) {
+        return {
+          index,
+          elementString: child.toString()
+        };
+      }
+    }).find((data) => {
+      return data;
+    });
+  return positionData;
 }
 
 /**
@@ -224,9 +223,7 @@ function getElementPosition(node) {
  */
 function addNodeInString(node, nodeString) {
   const documentToModify = useValidator().parseXmlString(nodeString),
-    documentChildren = documentToModify.childNodes().filter((child) => {
-      return child.name() !== 'text';
-    }),
+    documentChildren = useValidator().getChildrenElements(documentToModify),
     nodePosition = getElementPosition(node),
     stringElements = documentChildren.map((child) => {
       return child.toString();
@@ -243,10 +240,11 @@ function addNodeInString(node, nodeString) {
  */
 function removeNodeFromString(node, nodeString) {
   const documentToModify = useValidator().parseXmlString(nodeString),
-    documentChildren = documentToModify.childNodes().filter((child) => {
-      return child.name() !== 'text' && child.name() !== node.name();
+    documentChildren = useValidator().getChildrenElements(documentToModify),
+    childrenWithNodeRemoved = documentChildren.filter((child) => {
+      return child.name() !== node.name();
     }),
-    stringElements = documentChildren.map((child) => {
+    stringElements = childrenWithNodeRemoved.map((child) => {
       return child.toString();
     }).join('\n');
   return stringElements;
@@ -325,7 +323,7 @@ function getIndexFromMultipleSiblingsWithSameName(missedElement, body) {
       return !element.childrenNames.includes(missedElement.name());
     }),
     index = missedElementParentIndex[0].index;
-  return index > 0 ? `[${index}]` : '';
+  return index > 0 ? `[${index + 1}]` : '';
 }
 
 /**
@@ -457,16 +455,12 @@ function getMismatchWithSuggestedFix(mismatch, currentBody, bodyFromSchema, deta
       getElementChildrenAsString(suggestedElement, reasonCode);
   }
   newMismatch.suggestedFix = {
-    key: key ? key : elementData.keyXpath,
+    key: key ? key : `/${elementData.keyXpath}`,
     actualValue,
     suggestedValue
   };
   return newMismatch;
 }
-
-// function replaceElementInNode() {
-//   return
-// }
 
 module.exports = {
   getBodyMismatchObject,

--- a/lib/utils/mismatchUtils.js
+++ b/lib/utils/mismatchUtils.js
@@ -20,26 +20,35 @@ const { XMLXSDValidator } = require('../xsdValidation/XMLXSDValidator'),
  * @returns {object} an instance of validator Library
  */
 function useValidator() {
-  const lib = new XMLXSDValidator('xmllint').getValidatorLibrary();
+  const lib = new XMLXSDValidator().getValidatorLibrary();
   return lib;
 }
 
 /**
+ * Gets the node from an element from a xmlString
+ * @param {string} xmlString The xmlString where we will find the element
+ * @param {string} xpath The xpath from the element we want to get
+ * @returns {object} The node of the element
+ */
+function getElementFromStringByXpath(xmlString, xpath) {
+  const element = useValidator().findByXpathInXmlString(xmlString, xpath);
+  return element;
+}
+
+/**
  * return the element that corresponds with specific key in a message
- * @param {string} body message in request or response
- * @param {string} xpath the xpath for the element we are finding
+ * @param {object} element The node we want to get the children (text or strigifyed elements)
  * @param {string} reasonCode the reason code for current mismatch
  * @returns {string} the specific element from the key in the message or empty string
  */
-function getElementChildrenFromBodyByXpath(body, xpath, reasonCode) {
+function getElementChildrenAsString(element, reasonCode) {
   let result;
   if ([INVALID_TYPE_REASON_CODE, INVALID_RESPONSE_BODY_REASON_CODE, INVALID_BODY_REASON_CODE].includes(reasonCode)) {
-    result = useValidator().getElementText(body, `${xpath}`);
+    result = useValidator().getElementText(element);
   }
   else {
-    result = useValidator().getChildrenAsString(body, xpath);
+    result = useValidator().getChildrenAsString(element);
   }
-
   return result;
 }
 
@@ -169,19 +178,111 @@ function getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, s
 }
 
 /**
+ * Creates an object with all necessary data from the element in next steps
+ * @param {string} name the name of the element
+ * @param {object} node The node of the element
+ * @param {string} keyXpath The xpath to the element that has wrong values
+ * (if is missing in request or missing in schema error it drives to the paren element)
+ * @param {boolean} keyIsItsParent If the keyXpath point to the element or to the parent
+ * @returns {object} An object with the neccesary data to generate the suggestedValue
+ */
+function fillElementData(name, node, keyXpath, keyIsItsParent) {
+  return {
+    name,
+    node,
+    keyXpath,
+    keyIsItsParent
+  };
+}
+
+/**
+ * Get the element's position between its siblings
+ * @param {object} node The element we want to know the position between its siblings
+ * @returns {number} The position between its siblings
+ */
+function getElementPosition(node) {
+  const position = node.parent().childNodes().filter((child) => {
+    return child.name() !== 'text';
+  }).map((child, index) => {
+    if (child.name() === node.name()) {
+      return {
+        index,
+        elementString: child.toString()
+      };
+    }
+  }).find((data) => {
+    return data;
+  });
+  return position;
+}
+
+/**
+ * Add a provided element in a stringifyed node and returns the string representation
+ * @param {object} node The element we want to add in xml node string
+ * @param {string} nodeString the xml node string where we want to add the element
+ * @returns {string} The provided xml node string with the specifyed element added
+ */
+function addNodeInString(node, nodeString) {
+  const documentToModify = useValidator().parseXmlString(nodeString),
+    documentChildren = documentToModify.childNodes().filter((child) => {
+      return child.name() !== 'text';
+    }),
+    nodePosition = getElementPosition(node),
+    stringElements = documentChildren.map((child) => {
+      return child.toString();
+    });
+  stringElements.splice(0, nodePosition.index, nodePosition.elementString);
+  return stringElements.join('\n');
+}
+
+/**
+ * Removes an element from a provided node string
+ * @param {object} node The element we want to remove from a string
+ * @param {string} nodeString the xmlString where we want to remove an element
+ * @returns {string} The provoided xml node string with the specifyed element removed
+ */
+function removeNodeFromString(node, nodeString) {
+  const documentToModify = useValidator().parseXmlString(nodeString),
+    documentChildren = documentToModify.childNodes().filter((child) => {
+      return child.name() !== 'text' && child.name() !== node.name();
+    }),
+    stringElements = documentChildren.map((child) => {
+      return child.toString();
+    }).join('\n');
+  return stringElements;
+}
+
+/**
+ * Generates the suggested fix from a specific reaconCode
+ * @param {object} node The node where an error was issued
+ * @param {string} currentValue The request value that the user sent and has some error
+ * @param {string} reasonCode The mismatch reasonCode for this kind of error
+ * @returns {string} the siggested value for the specific reasonCode
+ */
+function getSuggestedFixFromCurrentValue(node, currentValue, reasonCode) {
+  if (reasonCode === MISSING_IN_REQUEST_REASON_CODE) {
+    return addNodeInString(node, currentValue);
+  }
+  else if (reasonCode === MISSING_IN_SCHEMA_REASON_CODE) {
+    return removeNodeFromString(node, currentValue);
+  }
+}
+
+/**
  * gets the self closing element in expected body that has some not expected value in request body
  * and returns it
  * @param {string} reason The reason message gotten from validation with schema library
  * @param {string} cleanBody Body generated from schema without namespaces neither envelopes
  * @returns {string} xpath corresponding to the element in reason
  */
-function handleInvalidBodyAndGetXpath(reason, cleanBody) {
+function handleInvalidBodyAndGetElementData(reason, cleanBody) {
   const result = reason.match(INVALID_BODY_PATTERN),
-    elementName = result[1],
-    expectedElementXpath = `//${elementName}[count(*)=0]`,
-    expectedElementNode = useValidator().findByXpathInXmlString(cleanBody, expectedElementXpath)[0],
-    xpath = expectedElementNode.path();
-  return xpath;
+    name = result[1],
+    elementXpath = `//${name}[count(*)=0]`,
+    node = useValidator().findByXpathInXmlString(cleanBody, elementXpath)[0],
+    keyXpath = node.path(),
+    elementData = fillElementData(name, node, keyXpath, false);
+  return elementData;
 }
 
 /**
@@ -191,14 +292,15 @@ function handleInvalidBodyAndGetXpath(reason, cleanBody) {
  * @param {string} currentBody Body generated from request message without namespaces neither envelopes
  * @returns {string} xpath corresponding to the element in reason
  */
-function handleInvalidTypeAndGetXpath(reason, currentBody) {
+function handleInvalidTypeAndGetElementData(reason, currentBody) {
   const result = reason.match(INVALID_TYPE_PATTERN),
-    elementName = result[1],
-    elementValue = result[2],
-    wrongElementXpath = `//${elementName}[text()="${elementValue}"]`,
-    wrongElementNode = useValidator().findByXpathInXmlString(currentBody, wrongElementXpath)[0],
-    xpath = wrongElementNode.path(elementValue);
-  return xpath;
+    name = result[1],
+    value = result[2],
+    elementXpath = `//${name}[text()="${value}"]`,
+    node = useValidator().findByXpathInXmlString(currentBody, elementXpath)[0],
+    keyXpath = node.path(),
+    elementData = fillElementData(name, node, keyXpath, false);
+  return elementData;
 }
 
 /**
@@ -234,35 +336,38 @@ function getIndexFromMultipleSiblingsWithSameName(missedElement, body) {
  * @param {string} cleanBody Body generated from schema without namespaces neither envelopes
  * @returns {string} xpath corresponding to the element in reason
  */
-function handleMissingInRequestAndGetXpath(reason, currentBody, cleanBody) {
+function handleMissingInRequestAndGetElementData(reason, currentBody, cleanBody) {
   let result,
     xpath,
-    elementNode,
-    indexComponent = '';
+    node,
+    name,
+    indexComponent = '',
+    elementData;
   if (reason.match(MISSING_IN_REQUEST_PARENT_PATTERN)) {
     result = reason.match(MISSING_IN_REQUEST_PARENT_PATTERN);
+    name = result[2];
     let parent = result[1],
-      element = result[2],
-      elementXpath = `//${parent}/${element}`;
-    elementNode = getElementFromMissingInRequestByPath(currentBody, cleanBody, elementXpath);
+      elementXpath = `//${parent}/${name}`;
+    node = getElementFromMissingInRequestByPath(currentBody, cleanBody, elementXpath);
   }
   else if (reason.match(MISSING_IN_REQUEST_ONE_SIBLING_PATTERN)) {
     result = reason.match(MISSING_IN_REQUEST_ONE_SIBLING_PATTERN);
+    name = result[2];
     let sibling = result[1],
-      // missingElement = result[2],
       siblingXpath = `//${sibling}`;
-    elementNode = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath);
+    node = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath);
   }
   else if (reason.match(MISSING_IN_REQUEST_MULTIPLE_SIBLINGS_PATTERN)) {
     result = reason.match(MISSING_IN_REQUEST_MULTIPLE_SIBLINGS_PATTERN);
+    name = result[2];
     let sibling = result[1],
-      // missingElement = result[2],
       siblingXpath = `//${sibling}`;
-    elementNode = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath);
+    node = getElementFromMissingInRequestBySiblingsXpath(currentBody, cleanBody, siblingXpath);
   }
-  xpath = elementNode.parent().path();
-  indexComponent = getIndexFromMultipleSiblingsWithSameName(elementNode, currentBody);
-  return `${xpath}${indexComponent}`;
+  xpath = node.parent().path();
+  indexComponent = getIndexFromMultipleSiblingsWithSameName(node, currentBody);
+  elementData = fillElementData(name, node, `${xpath}${indexComponent}`, true);
+  return elementData;
 }
 
 /**
@@ -273,14 +378,15 @@ function handleMissingInRequestAndGetXpath(reason, currentBody, cleanBody) {
  * @param {string} cleanBody Body generated from schema without namespaces neither envelopes
  * @returns {string} xpath corresponding to the element in reason
  */
-function handleMissingInSchemaAndGetXpath(reason, currentBody, cleanBody) {
+function handleMissingInSchemaAndGetElementData(reason, currentBody, cleanBody) {
   const result = reason.match(MISSING_IN_SCHEMA_PATTERN),
-    elementName = result[1],
-    elementXpath = `//${elementName}`,
-    elementNode = getElementFromMissingInSchemaByXpath(currentBody, cleanBody, elementXpath),
-    parentNode = elementNode.parent(),
-    xpath = parentNode.path();
-  return xpath;
+    name = result[1],
+    elementXpath = `//${name}`,
+    node = getElementFromMissingInSchemaByXpath(currentBody, cleanBody, elementXpath),
+    parentNode = node.parent(),
+    keyXpath = parentNode.path(),
+    elementData = fillElementData(name, node, keyXpath, true);
+  return elementData;
 }
 
 /**
@@ -290,30 +396,30 @@ function handleMissingInSchemaAndGetXpath(reason, currentBody, cleanBody) {
  * @param {string} cleanBody expected body clean generated from the schema
  * @returns {string} the corresponding xpath depending on the reasonCode
  */
-function getKeyXpath(mismatch, currentBody, cleanBody) {
+function getElementData(mismatch, currentBody, cleanBody) {
   const {
     reasonCode,
     reason
   } = mismatch;
+  let data;
 
   if ([INVALID_BODY_REASON_CODE, INVALID_RESPONSE_BODY_REASON_CODE].includes(reasonCode)) {
     // if gets in there is an error in the body content
-    result = handleInvalidBodyAndGetXpath(reason, cleanBody);
+    data = handleInvalidBodyAndGetElementData(reason, cleanBody);
   }
   else if (reasonCode === INVALID_TYPE_REASON_CODE) {
     // reason contains key, wrong value and expected type
-    result = handleInvalidTypeAndGetXpath(reason, currentBody);
+    data = handleInvalidTypeAndGetElementData(reason, currentBody);
   }
   else if (reasonCode === MISSING_IN_REQUEST_REASON_CODE) {
     // reason contains missing element's parent key, expected element key
-    result = handleMissingInRequestAndGetXpath(reason, currentBody, cleanBody);
+    data = handleMissingInRequestAndGetElementData(reason, currentBody, cleanBody);
   }
   else if (reasonCode === MISSING_IN_SCHEMA_REASON_CODE) {
     // reason contains not expected key
-    result = handleMissingInSchemaAndGetXpath(reason, currentBody, cleanBody);
+    data = handleMissingInSchemaAndGetElementData(reason, currentBody, cleanBody);
   }
-
-  return result;
+  return data;
 }
 
 /**
@@ -327,9 +433,11 @@ function getKeyXpath(mismatch, currentBody, cleanBody) {
 function getMismatchWithSuggestedFix(mismatch, currentBody, bodyFromSchema, detailedBlobValidation) {
   let newMismatch = JSON.parse(JSON.stringify(mismatch)),
     key = '',
+    actualElement,
     actualValue,
+    suggestedElement,
     suggestedValue,
-    xpath = '';
+    elementData;
   const {
     reasonCode
   } = newMismatch;
@@ -340,29 +448,34 @@ function getMismatchWithSuggestedFix(mismatch, currentBody, bodyFromSchema, deta
     suggestedValue = bodyFromSchema;
   }
   else {
-    xpath = getKeyXpath(newMismatch, currentBody, bodyFromSchema);
-    actualValue = getElementChildrenFromBodyByXpath(currentBody, xpath, reasonCode);
-    suggestedValue = getElementChildrenFromBodyByXpath(
-      bodyFromSchema,
-      xpath,
-      reasonCode
-    );
+    elementData = getElementData(newMismatch, currentBody, bodyFromSchema);
+    actualElement = getElementFromStringByXpath(currentBody, elementData.keyXpath);
+    actualValue = getElementChildrenAsString(actualElement, reasonCode);
+    suggestedElement = getElementFromStringByXpath(bodyFromSchema, elementData.keyXpath);
+    suggestedValue = elementData.keyIsItsParent ?
+      getSuggestedFixFromCurrentValue(elementData.node, actualElement.toString(), reasonCode) :
+      getElementChildrenAsString(suggestedElement, reasonCode);
   }
   newMismatch.suggestedFix = {
-    key: key ? key : xpath,
+    key: key ? key : elementData.keyXpath,
     actualValue,
     suggestedValue
   };
   return newMismatch;
 }
 
+// function replaceElementInNode() {
+//   return
+// }
+
 module.exports = {
   getBodyMismatchObject,
   getMismatchWithSuggestedFix,
-  getElementChildrenFromBodyByXpath,
   getElementFromMissingInRequestByPath,
   getElementFromMissingInRequestBySiblingsXpath,
   getElementFromMissingInSchemaByXpath,
-  handleInvalidTypeAndGetXpath,
-  handleMissingInRequestAndGetXpath
+  handleInvalidTypeAndGetElementData,
+  handleMissingInRequestAndGetElementData,
+  getElementData,
+  addNodeInString
 };

--- a/lib/utils/mismatchUtils.js
+++ b/lib/utils/mismatchUtils.js
@@ -20,7 +20,7 @@ const { XMLXSDValidator } = require('../xsdValidation/XMLXSDValidator'),
  * @returns {object} an instance of validator Library
  */
 function useValidator() {
-  const lib = new XMLXSDValidator('libxmljs').getValidatorLibrary();
+  const lib = new XMLXSDValidator('libxmljs2').getValidatorLibrary();
   return lib;
 }
 

--- a/lib/xsdValidation/LibXMLjs2Facade.js
+++ b/lib/xsdValidation/LibXMLjs2Facade.js
@@ -60,6 +60,13 @@ class LibXMLjs2Facade {
     }).join('\n');
     return result;
   }
+
+  getChildrenElements(node) {
+    const children = node.childNodes().filter((child) => {
+      return child.name() !== 'text';
+    });
+    return children;
+  }
 }
 
 module.exports = {

--- a/lib/xsdValidation/LibXMLjs2Facade.js
+++ b/lib/xsdValidation/LibXMLjs2Facade.js
@@ -43,19 +43,21 @@ class LibXMLjs2Facade {
     return elements;
   }
 
-  getElementText(xmlString, xpath) {
-    const element = this.findByXpathInXmlString(xmlString, xpath),
-      text = element.length > 0 ? element[0].text() : '';
+  parseXmlString(xmlString) {
+    return libxml.parseXmlString(xmlString);
+  }
+
+  getElementText(element) {
+    const text = element.length > 0 ? element[0].text() : '';
     return text;
   }
 
-  getChildrenAsString(xmlString, xpath) {
-    const element = this.findByXpathInXmlString(xmlString, xpath)[0],
-      result = element.childNodes().filter((child) => {
-        return child.name() !== 'text';
-      }).map((element) => {
-        return element.toString();
-      }).join('\n');
+  getChildrenAsString(element) {
+    const result = element[0].childNodes().filter((child) => {
+      return child.name() !== 'text';
+    }).map((element) => {
+      return element.toString();
+    }).join('\n');
     return result;
   }
 }

--- a/lib/xsdValidation/LibXMLjsFacade.js
+++ b/lib/xsdValidation/LibXMLjsFacade.js
@@ -43,6 +43,10 @@ class LibXMLjsFacade {
     return elements;
   }
 
+  parseXmlString(xmlString) {
+    return libxml.parseXmlString(xmlString);
+  }
+
   getElementText(xmlString, xpath) {
     const element = this.findByXpathInXmlString(xmlString, xpath),
       text = element.length > 0 ? element[0].text() : '';

--- a/lib/xsdValidation/LibXMLjsFacade.js
+++ b/lib/xsdValidation/LibXMLjsFacade.js
@@ -47,20 +47,25 @@ class LibXMLjsFacade {
     return libxml.parseXmlString(xmlString);
   }
 
-  getElementText(xmlString, xpath) {
-    const element = this.findByXpathInXmlString(xmlString, xpath),
-      text = element.length > 0 ? element[0].text() : '';
+  getElementText(element) {
+    const text = element.length > 0 ? element[0].text() : '';
     return text;
   }
 
-  getChildrenAsString(xmlString, xpath) {
-    let element = this.findByXpathInXmlString(xmlString, xpath)[0],
-      result = element.childNodes().filter((child) => {
-        return child.name() !== 'text';
-      }).map((element) => {
-        return element.toString();
-      }).join('\n');
+  getChildrenAsString(element) {
+    let result = element[0].childNodes().filter((child) => {
+      return child.name() !== 'text';
+    }).map((element) => {
+      return element.toString();
+    }).join('\n');
     return result;
+  }
+
+  getChildrenElements(node) {
+    const children = node.childNodes().filter((child) => {
+      return child.name() !== 'text';
+    });
+    return children;
   }
 }
 

--- a/lib/xsdValidation/XMLLintFacade.js
+++ b/lib/xsdValidation/XMLLintFacade.js
@@ -160,6 +160,10 @@ class XMLLintFacade {
     return adaptedErrors;
   }
 
+  parseFromString(xmlString) {
+    return new xmldom().parseFromString(xmlString);
+  }
+
   findByXpathInXmlString(xmlString, xpath) {
     const document = new xmldom().parseFromString(xmlString),
       textValuePattern = /\[text\(\)=".*"\]/,

--- a/lib/xsdValidation/XMLLintFacade.js
+++ b/lib/xsdValidation/XMLLintFacade.js
@@ -2,6 +2,7 @@ const { XSDValidationError } = require('./XSDValidationError'),
   xmllint = require('xmllint'),
   xpathTool = require('xpath'),
   xmldom = require('xmldom').DOMParser,
+  xmlSerializer = require('xmldom').XMLSerializer,
   INVALID_TYPE = 'is not a valid value of the atomic type',
   NOT_EXPECTED = 'This element is not expected',
   NOT_ALLOWED = 'Character content is not allowed',
@@ -14,6 +15,7 @@ class XMLElement {
   constructor(xmlNode, textValueComponent = '') {
     this.textValueComponent = textValueComponent;
     this.node = xmlNode;
+    this.nodeString = new xmlSerializer().serializeToString(this.node);
   }
 
   name() {
@@ -37,6 +39,11 @@ class XMLElement {
 
   text() {
     return this.node.textContent;
+  }
+
+  toString() {
+    const nodeString = this.nodeString;
+    return nodeString;
   }
 
   childNodes() {
@@ -160,8 +167,8 @@ class XMLLintFacade {
     return adaptedErrors;
   }
 
-  parseFromString(xmlString) {
-    return new xmldom().parseFromString(xmlString);
+  parseXmlString(xmlString) {
+    return new XMLElement(new xmldom().parseFromString(xmlString).childNodes[0]);
   }
 
   findByXpathInXmlString(xmlString, xpath) {
@@ -175,15 +182,13 @@ class XMLLintFacade {
     return elements;
   }
 
-  getElementText(xmlString, xpath) {
-    const element = this.findByXpathInXmlString(xmlString, xpath),
-      text = element.length > 0 ? element[0].text() : '';
+  getElementText(element) {
+    const text = element.length > 0 ? element[0].text() : '';
     return text;
   }
 
-  getChildrenAsString(xmlString, xpath) {
-    const element = this.findByXpathInXmlString(xmlString, xpath)[0],
-      children = Object.values(element.childNodes()).filter((node) => {
+  getChildrenAsString(element) {
+    const children = Object.values(element[0].childNodes()).filter((node) => {
         let nodeName = node.name();
         return nodeName && nodeName !== '#text';
       }),
@@ -191,6 +196,13 @@ class XMLLintFacade {
         return node.node.toString();
       }).join('\n');
     return childrenAsString;
+  }
+
+  getChildrenElements(node) {
+    const children = node.childNodes().filter((child) => {
+      return child.name() !== '#text';
+    });
+    return children;
   }
 }
 

--- a/test/unit/TransactionValidator.options.test.js
+++ b/test/unit/TransactionValidator.options.test.js
@@ -571,7 +571,7 @@ describe('validateBody method with options', function () {
           {
             key: '/NumberToWords',
             actualValue: '<ubiNum>18446744073709</ubiNum>\n<WRONGFIELD>WRONG</WRONGFIELD>',
-            suggestedValue: '<ubiNum>100</ubiNum>'
+            suggestedValue: '<ubiNum>18446744073709</ubiNum>'
           }
         )
       );

--- a/test/unit/TransactionValidator.options.test.js
+++ b/test/unit/TransactionValidator.options.test.js
@@ -394,7 +394,7 @@ describe('validateBody method with options', function () {
           'INVALID_TYPE'
         ),
         {
-          key: '/Subtract/intA',
+          key: '//Subtract/intA',
           actualValue: '{{}}',
           suggestedValue: '100'
         }
@@ -406,7 +406,7 @@ describe('validateBody method with options', function () {
           'INVALID_TYPE'
         ),
         {
-          key: '/Subtract/intB',
+          key: '//Subtract/intB',
           actualValue: '{{}}',
           suggestedValue: '100'
         }
@@ -569,7 +569,7 @@ describe('validateBody method with options', function () {
             'MISSING_IN_SCHEMA'
           ),
           {
-            key: '/NumberToWords',
+            key: '//NumberToWords',
             actualValue: '<ubiNum>18446744073709</ubiNum>\n<WRONGFIELD>WRONG</WRONGFIELD>',
             suggestedValue: '<ubiNum>18446744073709</ubiNum>'
           }
@@ -602,7 +602,7 @@ describe('validateBody method with options', function () {
             'MISSING_IN_REQUEST'
           ),
           {
-            key: '/NumberToWords',
+            key: '//NumberToWords',
             actualValue: '',
             suggestedValue: '<ubiNum>100</ubiNum>'
           }
@@ -636,7 +636,7 @@ describe('validateBody method with options', function () {
             'INVALID_TYPE'
           ),
           {
-            key: '/NumberToWords/ubiNum',
+            key: '//NumberToWords/ubiNum',
             actualValue: 'WRONG TYPE',
             suggestedValue: '100'
           }
@@ -669,7 +669,7 @@ describe('validateBody method with options', function () {
             'INVALID_TYPE'
           ),
           {
-            key: '/getPlayedMatchesResponse/getPlayedMatchesResult/item/MatchId',
+            key: '//getPlayedMatchesResponse/getPlayedMatchesResult/item/MatchId',
             actualValue: 'WRONGVALUE',
             suggestedValue: '100'
           }

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -1428,7 +1428,7 @@ describe('validateBody method', function() {
                     ' because the content type is empty.\n',
                   suggestedFix: {
                     actualValue: '\n        ',
-                    key: '/getMatchDetailsResponse/getMatchDetailsResult/item/UpdateTimeStamp',
+                    key: '//getMatchDetailsResponse/getMatchDetailsResult/item/UpdateTimeStamp',
                     suggestedValue: ''
                   }
                 }]

--- a/test/unit/mismatchUtils.test.js
+++ b/test/unit/mismatchUtils.test.js
@@ -314,7 +314,7 @@ describe('handleMissingInRequestAndGetElementData method', function() {
         </objC>
       </Substract>`,
       elementData = handleMissingInRequestAndGetElementData(reason, currentBody, cleanBody);
-    expect(elementData.keyXpath).to.be.equal('/Substract/objC[2]');
+    expect(elementData.keyXpath).to.be.equal('/Substract/objC[3]');
     expect(elementData.node.name()).to.be.equal('intA');
   });
 
@@ -376,7 +376,7 @@ describe('handleMissingInRequestAndGetElementData method', function() {
         </objC>
       </Substract>`,
       elementData = handleMissingInRequestAndGetElementData(reason, currentBody, expectedBody);
-    expect(elementData.keyXpath).to.be.equal('/Substract/objB[2]');
+    expect(elementData.keyXpath).to.be.equal('/Substract/objB[3]');
     expect(elementData.node.name()).to.be.equal('missingInSchemaElement');
   });
 });


### PR DESCRIPTION
- Fix index from xpath when there are multiple siblings with same name in the same level. index based on 1.
- Support to remove the not expected element from the request body in missing in schema errors
- Support to add the missing element to the request body in missing in request errors
- Adding double slash to the generated xpaths