### PR TITLE
Multiple faults

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -128,7 +128,9 @@ class TransactionValidator {
             operationFromWSDL,
             false,
             options,
-            xmlParser
+            xmlParser,
+            operationFromWSDL.input[0].name,
+            operationFromWSDL.input[0]
           ),
 
           soapMethodMismatches = this.validateSoapMethod(protocol, requestItem.request.method, operationFromWSDL,
@@ -139,7 +141,7 @@ class TransactionValidator {
             ...soapMethodMismatches
           ],
           { responses, responsesMatched } = this.getResponsesValidation(requestItem.response, wsdlObject,
-            operationFromWSDL, validateHeadersOption, options, xmlParser);
+            operationFromWSDL, validateHeadersOption, options, xmlParser, validationPropertiesToIgnore);
 
         endpoints = [
           this.getEndpointResult(endpointMismatches, `${method} ${protocol} ${name}`, responses)
@@ -199,25 +201,56 @@ class TransactionValidator {
    * @param {boolean} validateHeadersOption if validate headers option value, False by default
    * @param {object} options options for validation process
    * @param {object} xmlParser the parse class to parse xml to object or vice versa
+   * @param {Array} validationPropertiesToIgnore properties to ignore during validation
    * @returns {Object} {responses, responsesMatched} responses contains the list of validated responses
    *                    responsesMatched is false if any response failed
    */
   getResponsesValidation(responseItem, wsdlObject, operationFromWSDL, validateHeadersOption,
-    options, xmlParser) {
+    options, xmlParser, validationPropertiesToIgnore) {
     let responses = {},
       responsesMatched = true;
     responseItem.forEach((response) => {
       const header = response.header,
         id = response.id,
-        headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true, options),
+        headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true, options);
+      let bodyMismatches = [],
+        mismatches,
+        matched;
+      if (!response.body || response.body === '') {
+        if (!validationPropertiesToIgnore || !validationPropertiesToIgnore.includes(RESPONSE_BODY_PROPERTY)) {
+          bodyMismatches = [
+            {
+              property: RESPONSE_BODY_PROPERTY,
+              transactionJsonPath: '$.response.body',
+              schemaJsonPath: operationFromWSDL.xpathInfo.xpath,
+              reasonCode: INVALID_RESPONSE_BODY_REASON_CODE,
+              reason: RESPONSE_BODY_NOT_PROVIDED_MSG
+            }
+          ];
+        }
+      }
+      else {
+        let parsedXmlMessage = xmlParser.parseToObject(response.body),
+          info = this.getItemRequestProcessedInfo(response, parsedXmlMessage),
+          operationOutput = operationFromWSDL.output.find((currentOutput) => {
+            return currentOutput.name === info.name;
+          });
+
+        if (!operationOutput) {
+          operationOutput = operationFromWSDL.fault.find((currentFault) => {
+            return currentFault.name === info.name;
+          });
+
+        }
+
         bodyMismatches = this.validateBody(response.body, wsdlObject, operationFromWSDL, true,
-          options, xmlParser),
-        mismatches = [...headerMismatches, ...bodyMismatches],
-        matched = !mismatches.length > 0;
+          options, xmlParser, info.name, operationOutput);
+      }
+      mismatches = [...headerMismatches, ...bodyMismatches];
+      matched = !mismatches.length > 0;
       if (!matched) {
         responsesMatched = false;
       }
-
       responses[id] = {
         id,
         matched,
@@ -262,24 +295,21 @@ class TransactionValidator {
    * generate a correct body from the wsdl schema
    * @param {object} wsdlObject the wsdlObject from the wsdl file
    * @param {object} operationFromWsdl the current operation object
-   * @param {boolean} isResponse defines if the operation is from a request or a response
+   * @param {object} elementFromWSDLMessage the wsdl element for creating the message
    * @param {object} xmlParser injects the parse that will be used
    * @param {boolean} detailed defines if generated body will contain all namespaces and envelope tags or not
+   * @param {string} rootTagName root tagname
    * @returns {string} the correct body from the wsdl document schema
    */
-  getBodyFromSchema(wsdlObject, operationFromWsdl, isResponse, xmlParser, detailed) {
-    const operationName = isResponse ?
-        operationFromWsdl.output.name :
-        operationFromWsdl.input.name,
-      messageHelper = new SOAPMessageHelper();
-    let message = messageHelper.convertInputToMessage(
-      isResponse ? operationFromWsdl.output : operationFromWsdl.input,
+  getBodyFromSchema(wsdlObject, operationFromWsdl, elementFromWSDLMessage, xmlParser, detailed, rootTagName) {
+    const messageHelper = new SOAPMessageHelper();
+    let message = messageHelper.convertInputToMessage(elementFromWSDLMessage,
       wsdlObject.securityPolicyArray,
       operationFromWsdl.protocol,
       xmlParser
     );
     if (detailed) {
-      message = unwrapAndCleanBody(message, operationName);
+      message = unwrapAndCleanBody(message, rootTagName);
     }
     return message;
   }
@@ -305,14 +335,16 @@ class TransactionValidator {
    * @param {Boolean} isResponse True if provided message is in a response, False if is in a request
    * @param {object} options options validation process
    * @param {object} xmlParser the parser class to parse xml to object or vice versa
+   * @param {object} rootTagName the tag name root element from message
+   * @param {object} elementFromWSDLMessage the element from message
    * @returns {Array} List of mismatches found
    */
-  validateBody(body, wsdlObject, operationFromWSDL, isResponse, options, xmlParser) {
+  validateBody(body, wsdlObject, operationFromWSDL, isResponse, options, xmlParser, rootTagName,
+    elementFromWSDLMessage) {
     let mismatches = [],
       filteredErrors,
       errors,
       namespaceURL,
-      rootTagName,
       rawXmlMessage;
     const {
         validationPropertiesToIgnore,
@@ -327,7 +359,7 @@ class TransactionValidator {
 
     if (body) {
       const parsedXml = wsdlObject.xmlParsed;
-      rootTagName = isResponse ? operationFromWSDL.output.name : operationFromWSDL.input.name;
+      // rootTagName = isResponse ? operationFromWSDL.output.name : operationFromWSDL.input.name;
       namespaceURL = getMessageNamespace(body, rootTagName);
       let { cleanSchema, isSchemaXSDDefault } = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version,
         xmlParser, namespaceURL);
@@ -348,9 +380,10 @@ class TransactionValidator {
               expectedBody = this.getBodyFromSchema(
                 wsdlObject,
                 operationFromWSDL,
-                isResponse,
+                elementFromWSDLMessage,
                 xmlParser,
-                detailedBlobValidation
+                detailedBlobValidation,
+                rootTagName
               );
             mismatch = getMismatchWithSuggestedFix(
               mismatch,
@@ -683,7 +716,7 @@ class TransactionValidator {
         (isIncludedOrEmpty &&
           operation.name === itemRequestProcessedInfo.name &&
           operation.protocol === itemRequestProcessedInfo.protocol) ||
-          (operation.soapActionSegment !== '' &&
+        (operation.soapActionSegment !== '' &&
           operation.soapActionSegment === itemRequestProcessedInfo.soapActionSegment)
       );
     };

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -129,7 +129,6 @@ class TransactionValidator {
             false,
             options,
             xmlParser,
-            operationFromWSDL.input[0].name,
             operationFromWSDL.input[0]
           ),
 
@@ -244,7 +243,7 @@ class TransactionValidator {
         }
 
         bodyMismatches = this.validateBody(response.body, wsdlObject, operationFromWSDL, true,
-          options, xmlParser, info.name, operationOutput);
+          options, xmlParser, operationOutput);
       }
       mismatches = [...headerMismatches, ...bodyMismatches];
       matched = !mismatches.length > 0;
@@ -298,10 +297,9 @@ class TransactionValidator {
    * @param {object} elementFromWSDLMessage the wsdl element for creating the message
    * @param {object} xmlParser injects the parse that will be used
    * @param {boolean} detailed defines if generated body will contain all namespaces and envelope tags or not
-   * @param {string} rootTagName root tagname
    * @returns {string} the correct body from the wsdl document schema
    */
-  getBodyFromSchema(wsdlObject, operationFromWsdl, elementFromWSDLMessage, xmlParser, detailed, rootTagName) {
+  getBodyFromSchema(wsdlObject, operationFromWsdl, elementFromWSDLMessage, xmlParser, detailed) {
     const messageHelper = new SOAPMessageHelper();
     let message = messageHelper.convertInputToMessage(elementFromWSDLMessage,
       wsdlObject.securityPolicyArray,
@@ -309,7 +307,7 @@ class TransactionValidator {
       xmlParser
     );
     if (detailed) {
-      message = unwrapAndCleanBody(message, rootTagName);
+      message = unwrapAndCleanBody(message, elementFromWSDLMessage.name);
     }
     return message;
   }
@@ -335,11 +333,10 @@ class TransactionValidator {
    * @param {Boolean} isResponse True if provided message is in a response, False if is in a request
    * @param {object} options options validation process
    * @param {object} xmlParser the parser class to parse xml to object or vice versa
-   * @param {object} rootTagName the tag name root element from message
    * @param {object} elementFromWSDLMessage the element from message
    * @returns {Array} List of mismatches found
    */
-  validateBody(body, wsdlObject, operationFromWSDL, isResponse, options, xmlParser, rootTagName,
+  validateBody(body, wsdlObject, operationFromWSDL, isResponse, options, xmlParser,
     elementFromWSDLMessage) {
     let mismatches = [],
       filteredErrors,
@@ -359,15 +356,14 @@ class TransactionValidator {
 
     if (body) {
       const parsedXml = wsdlObject.xmlParsed;
-      // rootTagName = isResponse ? operationFromWSDL.output.name : operationFromWSDL.input.name;
-      namespaceURL = getMessageNamespace(body, rootTagName);
+      namespaceURL = getMessageNamespace(body, elementFromWSDLMessage.name);
       let { cleanSchema, isSchemaXSDDefault } = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version,
         xmlParser, namespaceURL);
       if (!isSchemaXSDDefault) {
-        rawXmlMessage = unwrapAndCleanBody(body, rootTagName);
+        rawXmlMessage = unwrapAndCleanBody(body, elementFromWSDLMessage.name);
       }
       else {
-        rawXmlMessage = getMessagePayload(body, rootTagName);
+        rawXmlMessage = getMessagePayload(body, elementFromWSDLMessage.name);
       }
       errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
       if (errors.length > 0) {
@@ -382,8 +378,7 @@ class TransactionValidator {
                 operationFromWSDL,
                 elementFromWSDLMessage,
                 xmlParser,
-                detailedBlobValidation,
-                rootTagName
+                detailedBlobValidation
               );
             mismatch = getMismatchWithSuggestedFix(
               mismatch,

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -172,19 +172,29 @@ class WsdlInformationService11 {
    * @returns {object} the WSDLObject
    */
   getElementFromPortTypeInterfaceOperation(parsedXml, portTypeOperation, elementsFromWSDL, principalPrefix, tag) {
-    const information = getNodeByName(portTypeOperation, principalPrefix, tag);
-    let messageName, elementName, element;
+    let information = getNodeByName(portTypeOperation, principalPrefix, tag),
+      messageName, elementName,
+      elementsArray = [];
     if (information) {
-      messageName = getAttributeByName(information, ATTRIBUTE_MESSAGE);
-      elementName = this.getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName);
-      elementName = excludeSeparatorFromName(elementName);
-      element = elementsFromWSDL.find((element) => {
-        return element.name === elementName;
-      });
-      if (element === undefined) {
-        return createErrorElement(elementName);
+      if (!Array.isArray(information)) {
+        information = [information];
       }
-      return element;
+      information.forEach((informationTag) => {
+        let foundElement;
+        messageName = getAttributeByName(informationTag, ATTRIBUTE_MESSAGE);
+        elementName = this.getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName);
+        elementName = excludeSeparatorFromName(elementName);
+        foundElement = elementsFromWSDL.find((element) => {
+          return element.name === elementName;
+        });
+        if (foundElement === undefined) {
+          elementsArray.push(createErrorElement(elementName));
+        }
+        else {
+          elementsArray.push(foundElement);
+        }
+      });
+      return elementsArray;
     }
     return null;
   }

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -34,6 +34,7 @@ const
   INPUT_TAG = 'input',
   OUTPUT_TAG = 'output',
   FAULT_TAG = 'fault',
+  ATTRIBUTE_SOAP_ACTION = 'soapAction',
   {
     getArrayFrom
   } = require('./utils/objectUtils'),
@@ -158,8 +159,13 @@ class WsdlInformationService11 {
    * @returns {string} the documentation
    */
   getOperationDocumentation(portTypeOperation, principalPrefix) {
-    let documentation = getNodeByName(portTypeOperation, principalPrefix, DOCUMENTATION_TAG);
-    return documentation ? getDocumentationStringFromNode(documentation) : '';
+    try {
+      let documentation = getNodeByName(portTypeOperation, principalPrefix, DOCUMENTATION_TAG);
+      return documentation ? getDocumentationStringFromNode(documentation) : '';
+    }
+    catch (error) {
+      return '';
+    }
   }
 
   /**
@@ -337,7 +343,7 @@ class WsdlInformationService11 {
       }
     }
     catch (error) {
-      throw new WsdlError('Cannot get style info from binding operation');
+      return '';
     }
     return '';
   }
@@ -357,11 +363,11 @@ class WsdlInformationService11 {
       if (bindingTagInfo.protocol === SOAP_PROTOCOL ||
         bindingTagInfo.protocol === SOAP12_PROTOCOL) {
         return getAttributeByName(getNodeByName(bindingOperation, bindingTagInfo.protocolPrefix, OPERATION_TAG),
-          'soapAction');
+          ATTRIBUTE_SOAP_ACTION);
       }
     }
     catch (error) {
-      throw new WsdlError('Cannot get soapAction info from binding operation');
+      return '';
     }
     return '';
   }

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -141,7 +141,7 @@ class WsdlInformationService20 {
       }
     }
     catch (error) {
-      throw new WsdlError('Cannot get soapAction info from binding operation');
+      return '';
     }
     return '';
   }
@@ -229,8 +229,13 @@ class WsdlInformationService20 {
    * @returns {string} the documentation value
    */
   getOperationDocumentation(interfaceOperation, principalPrefix) {
-    let documentation = getNodeByName(interfaceOperation, principalPrefix, DOCUMENTATION_TAG);
-    return documentation ? getDocumentationStringFromNode(documentation) : '';
+    try {
+      let documentation = getNodeByName(interfaceOperation, principalPrefix, DOCUMENTATION_TAG);
+      return documentation ? getDocumentationStringFromNode(documentation) : '';
+    }
+    catch (error) {
+      return '';
+    }
   }
 
   /**

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -29,7 +29,7 @@ const
   OPERATION_TAG = 'operation',
   ENDPOINT_TAG = 'endpoint',
   BINDING_TAG = 'binding',
-  FAULT_TAG = 'fault',
+  INTERNAL_FAULT_TAG = 'fault',
   DOCUMENTATION_TAG = 'documentation',
   NAME_TAG = 'name',
   INPUT_TAG = 'input',
@@ -67,7 +67,7 @@ class WsdlInformationService20 {
     this.InputTagName = INPUT_TAG;
     this.NameTag = NAME_TAG;
     this.OutputTagName = OUTPUT_TAG;
-    this.FaultTagName = FAULT_TAG;
+    this.FaultTagName = OUTFAULT_TAG;
     this.SOAPNamesapceURL = SOAP_NS_URL;
     this.SOAPNamesapceURL = SOAP_NS_URL;
     this.SOAP12NamesapceURL = SOAP_12_NS_URL;
@@ -440,7 +440,8 @@ class WsdlInformationService20 {
    */
   getElementFromInterfaceOperationInOut(interfaceOperation, elementsFromWSDL, principalPrefix, tag) {
     const information = interfaceOperation[principalPrefix + tag];
-    let elementName, element;
+    let elementName, element,
+      elements = [];
     if (information) {
       elementName = getAttributeByName(information, ATTRIBUTE_ELEMENT);
       element = elementsFromWSDL.find((element) => {
@@ -448,9 +449,12 @@ class WsdlInformationService20 {
         return element.name === fixedName;
       });
       if (element === undefined) {
-        return createErrorElement(elementName);
+        elements.push(createErrorElement(elementName));
       }
-      return element;
+      else {
+        elements.push(element);
+      }
+      return elements;
     }
     return null;
   }
@@ -474,7 +478,7 @@ class WsdlInformationService20 {
     const faultReference = getAttributeByName(information, ATTRIBUTE_REF);
 
     if (faultReference) {
-      faults = getArrayFrom(getNodeByName(interfaceElement, principalPrefix, FAULT_TAG));
+      faults = getArrayFrom(getNodeByName(interfaceElement, principalPrefix, INTERNAL_FAULT_TAG));
       if (faults) {
         let foundFault = faults.find((fault) => {
           let fixedName = getQNameLocal(faultReference);
@@ -486,7 +490,7 @@ class WsdlInformationService20 {
               let fixedName = getQNameLocal(elementName);
               return element.name === fixedName;
             });
-          return element;
+          return [element];
         }
       }
     }

--- a/lib/WsdlToPostmanCollectionMapper.js
+++ b/lib/WsdlToPostmanCollectionMapper.js
@@ -353,7 +353,7 @@ class WsdlToPostmanCollectionMapper {
           header: this.getReqHeaders(operation),
           body: {
             mode: 'raw',
-            raw: this.getBodyMessage(operation.input, securityPolicyArray, operation.protocol,
+            raw: this.getBodyMessage(operation.input[0], securityPolicyArray, operation.protocol,
               xmlParser),
             options: {
               raw: {
@@ -396,20 +396,28 @@ class WsdlToPostmanCollectionMapper {
    * @returns {Array} the array of responses
    */
   getResponses(operation, securityPolicyArray, xmlParser) {
-    let incorrectResponse,
-      correctResponse,
-      responses = [];
+    let responses = [];
     if (operation.output) {
-      correctResponse = this.buildResponseObject(' response', 'OK', 200,
-        operation, this.getBodyMessage(operation.input, securityPolicyArray, operation.protocol, xmlParser),
-        operation.output,
-        xmlParser);
-      responses.push(correctResponse);
+
+      if (Array.isArray(operation.output)) {
+        let correctResponses = operation.output.map((currentOutput) => {
+          return this.buildResponseObject(' response', 'OK', 200,
+            operation, this.getBodyMessage(operation.input[0], securityPolicyArray, operation.protocol, xmlParser),
+            currentOutput,
+            xmlParser);
+        });
+        responses = responses.concat(correctResponses);
+      }
     }
     if (operation.fault) {
-      incorrectResponse = this.buildResponseObject(' fault', 'not OK', 500,
-        operation, 'incorrect body message', operation.fault, xmlParser);
-      responses.push(incorrectResponse);
+
+      if (Array.isArray(operation.fault)) {
+        let incorrectResponses = operation.fault.map((currentFault) => {
+          return this.buildResponseObject(` fault - ${currentFault.name}`, 'not OK', 500,
+            operation, 'incorrect body message', currentFault, xmlParser);
+        });
+        responses = responses.concat(incorrectResponses);
+      }
     }
     return responses;
   }

--- a/lib/utils/knownTypes.js
+++ b/lib/utils/knownTypes.js
@@ -1,6 +1,9 @@
 const RandExp = require('randexp'),
   DATE_PATTERN = '-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])' +
     '-(0[1-9]|[12][0-9]|3[01])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+  DATE_TIME_PATTERN = '-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])' +
+    '-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]' +
+    '(\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
   NUMERIC_MINIMUM_RANDOM = 2,
   NUMERIC_MAXIMUM_RANDOM = 100,
   NUMERIC_MAXIMUM = 18446744073709,
@@ -60,6 +63,14 @@ function getFromDate() {
 }
 
 /**
+ * Returns an example of a date
+ * @returns {string} the generated example
+ */
+function getFromDateTime() {
+  return new Date().toISOString();
+}
+
+/**
  * Determines if the element has a date pattern
  * @param {Element} element the element for getting and example
  * @returns {boolean} if is a date pattern
@@ -69,17 +80,31 @@ function isDatePattern(element) {
 }
 
 /**
+ * Determines if the element has a date pattern
+ * @param {Element} element the element for getting and example
+ * @returns {boolean} if is a date pattern
+ */
+function isDateTimePattern(element) {
+  return element.pattern === DATE_TIME_PATTERN;
+}
+
+
+/**
  * Returns an example of the element information when is string and uses
  * a pattern
  * @param {Element} element the element for getting and example
  * @returns {string} the generated example
  */
 function getFromPattern(element) {
-  let result = isDatePattern(element) ? getFromDate(element) :
-    new RandExp(
-      element.pattern
-    ).gen();
-  return result;
+  if (isDatePattern(element)) {
+    return getFromDate(element);
+  }
+  if (isDateTimePattern(element)) {
+    return getFromDateTime(element);
+  }
+  return new RandExp(
+    element.pattern
+  ).gen();
 }
 
 /**

--- a/lib/utils/messageWithSchemaValidation.js
+++ b/lib/utils/messageWithSchemaValidation.js
@@ -117,7 +117,7 @@ function validateOperationMessagesWithSchema(wsdlObject, schemaBase, isSchemaXSD
   let validationErrors = [];
   operations.forEach((operation) => {
     let protocol = operation.protocol,
-      bodyMessage = getBodyMessage(operation.input, protocol, !isSchemaXSDDefault);
+      bodyMessage = getBodyMessage(operation.input[0], protocol, !isSchemaXSDDefault);
     if (!bodyMessage && !schemaBase) {
       return;
     }

--- a/test/data/transactionsValidation/wsdlObjects/calculator.js
+++ b/test/data/transactionsValidation/wsdlObjects/calculator.js
@@ -5,7 +5,7 @@ module.exports = {
       description: "Adds two integers. This is a test WebService. ©DNE Online",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -53,8 +53,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -86,7 +86,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap",
       serviceName: "Calculator",
@@ -102,7 +102,7 @@ module.exports = {
       description: "",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -150,8 +150,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -183,7 +183,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap",
       serviceName: "Calculator",
@@ -199,7 +199,7 @@ module.exports = {
       description: "",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -247,8 +247,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -280,7 +280,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap",
       serviceName: "Calculator",
@@ -296,7 +296,7 @@ module.exports = {
       description: "",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -344,8 +344,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -377,7 +377,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap",
       serviceName: "Calculator",
@@ -393,7 +393,7 @@ module.exports = {
       description: "Adds two integers. This is a test WebService. ©DNE Online",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -441,8 +441,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -474,7 +474,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap12",
       serviceName: "Calculator",
@@ -490,7 +490,7 @@ module.exports = {
       description: "",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -538,8 +538,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -571,7 +571,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap12",
       serviceName: "Calculator",
@@ -587,7 +587,7 @@ module.exports = {
       description: "",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -635,8 +635,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -668,7 +668,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap12",
       serviceName: "Calculator",
@@ -684,7 +684,7 @@ module.exports = {
       description: "",
       style: "document",
       url: "http://www.dneonline.com/calculator.asmx",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -732,8 +732,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -765,7 +765,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "CalculatorSoap12",
       serviceName: "Calculator",

--- a/test/data/transactionsValidation/wsdlObjects/getMatchDetails.js
+++ b/test/data/transactionsValidation/wsdlObjects/getMatchDetails.js
@@ -5,7 +5,7 @@ module.exports = {
             description: "Returns the details - including results - that belong to a match.",
             style: undefined,
             url: "url/soap/services/getMatchDetails.php",
-            input: {
+            input: [{
                 children: [
                     {
                         children: [
@@ -53,8 +53,8 @@ module.exports = {
                 pattern: undefined,
                 enum: undefined,
                 isElement: true,
-            },
-            output: {
+            }],
+            output: [{
                 children: [
                     {
                         children: [
@@ -262,7 +262,7 @@ module.exports = {
                 pattern: undefined,
                 enum: undefined,
                 isElement: true,
-            },
+            }],
             fault: null,
             portName: "getMatchDetailsPort",
             serviceName: "getMatchDetailsService",

--- a/test/data/transactionsValidation/wsdlObjects/getPlayedMatches.js
+++ b/test/data/transactionsValidation/wsdlObjects/getPlayedMatches.js
@@ -5,7 +5,7 @@ module.exports = {
       description: "Returns the matches in a tournament/league which has result registered..",
       style: undefined,
       url: "http://{{url}}/soap/services/getPlayedMatches.php",
-      input: {
+      input: [{
         children: [
           {
             children: [
@@ -53,8 +53,8 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
-      output: {
+      }],
+      output: [{
         children: [
           {
             children: [
@@ -870,7 +870,7 @@ module.exports = {
         pattern: undefined,
         enum: undefined,
         isElement: true,
-      },
+      }],
       fault: null,
       portName: "getPlayedMatchesPort",
       serviceName: "getPlayedMatchesService",

--- a/test/data/transactionsValidation/wsdlObjects/numberToWords.js
+++ b/test/data/transactionsValidation/wsdlObjects/numberToWords.js
@@ -5,7 +5,7 @@ module.exports = {
     description: 'Returns the word corresponding to the positive number passed as parameter.',
     style: 'document',
     url: 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-    input: {
+    input: [{
       children: [{
         children: [],
         name: 'ubiNum',
@@ -18,8 +18,8 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/',
-    },
-    output: {
+    }],
+    output: [{
       children: [{
         children: [],
         name: 'NumberToWordsResult',
@@ -30,8 +30,8 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
-    fault: {
+    }],
+    fault: [{
       children: [{
         children: [],
         name: 'faultcode',
@@ -42,7 +42,7 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: ''
-    },
+    }],
     portName: 'NumberConversionSoap',
     serviceName: 'NumberConversion',
     method: 'POST',
@@ -60,7 +60,7 @@ module.exports = {
     description: 'Returns the non-zero dollar amount of the passed number.',
     style: 'document',
     url: 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-    input: {
+    input: [{
       children: [{
         children: [],
         name: 'dNum',
@@ -71,8 +71,8 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
-    output: {
+    }],
+    output: [{
       children: [{
         children: [],
         name: 'NumberToDollarsResult',
@@ -83,7 +83,7 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
+    }],
     fault: undefined,
     portName: 'NumberConversionSoap',
     serviceName: 'NumberConversion',
@@ -100,7 +100,7 @@ module.exports = {
     description: 'Returns the word corresponding to the positive number passed as parameter.',
     style: 'document',
     url: 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-    input: {
+    input: [{
       children: [{
         children: [],
         name: 'ubiNum',
@@ -113,8 +113,8 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
-    output: {
+    }],
+    output: [{
       children: [{
         children: [],
         name: 'NumberToWordsResult',
@@ -125,7 +125,7 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
+    }],
     fault: undefined,
     portName: 'NumberConversionSoap12',
     serviceName: 'NumberConversion',
@@ -142,7 +142,7 @@ module.exports = {
     description: 'Returns the non-zero dollar amount of the passed number.',
     style: 'document',
     url: 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-    input: {
+    input: [{
       children: [child = {
         children: [],
         name: 'dNum',
@@ -153,8 +153,8 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
-    output: {
+    }],
+    output: [{
       children: [{
         children: [],
         name: 'NumberToDollarsResult',
@@ -165,7 +165,7 @@ module.exports = {
       isComplex: true,
       type: 'complex',
       namespace: 'http://www.dataaccess.com/webservicesserver/'
-    },
+    }],
     fault: undefined,
     portName: 'NumberConversionSoap12',
     serviceName: 'NumberConversion',

--- a/test/data/validWSDLs11/manyfaults.wsdl
+++ b/test/data/validWSDLs11/manyfaults.wsdl
@@ -1,0 +1,107 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:tns="http://{{url}}/"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="serviceManyFaults" targetNamespace="http://{{url}}/">
+  <wsdl:types>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+      xmlns:tns="http://{{url}}/" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://{{url}}/">
+      <xs:element name="checkPetExistance" type="tns:checkPetExistance"/>
+      <xs:element name="checkPetExistanceResponse" type="tns:checkPetExistanceResponse"/>
+      <xs:complexType name="checkPetExistance">
+        <xs:sequence>
+          <xs:element name="wsSessionId" type="xs:string"/>
+          <xs:element name="fiscalID" type="xs:string"/>
+          <xs:element name="documentType" type="xs:byte"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="checkPetExistanceResponse">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="getPetResult" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="AccessDeniedException" type="tns:AccessDeniedException"/>
+      <xs:complexType name="AccessDeniedException">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="errorCode" type="xs:int"/>
+          <xs:element minOccurs="0" name="message" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="InstantiationException" type="tns:InstantiationException"/>
+      <xs:complexType name="InstantiationException">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="message" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="IllegalAccessException" type="tns:IllegalAccessException"/>
+      <xs:complexType name="IllegalAccessException">
+        <xs:sequence>
+          <xs:element minOccurs="0" name="message" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="checkPetExistanceResponse">
+    <wsdl:part element="tns:checkPetExistanceResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="checkPetExistance">
+    <wsdl:part element="tns:checkPetExistance" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="InstantiationException">
+    <wsdl:part element="tns:InstantiationException" name="InstantiationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="IllegalAccessException">
+    <wsdl:part element="tns:IllegalAccessException" name="IllegalAccessException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="AccessDeniedException">
+    <wsdl:part element="tns:AccessDeniedException" name="AccessDeniedException">
+    </wsdl:part>
+  </wsdl:message>
+
+  <wsdl:portType name="PetWS">
+    <wsdl:operation name="checkPetExistance">
+      <wsdl:documentation> Pet</wsdl:documentation>
+      <wsdl:input message="tns:checkPetExistance" name="checkPetExistance">
+      </wsdl:input>
+      <wsdl:output message="tns:checkPetExistanceResponse" name="checkPetExistanceResponse">
+      </wsdl:output>
+      <wsdl:fault message="tns:AccessDeniedException" name="AccessDeniedException">
+      </wsdl:fault>
+      <wsdl:fault message="tns:InstantiationException" name="InstantiationException">
+      </wsdl:fault>
+      <wsdl:fault message="tns:IllegalAccessException" name="IllegalAccessException">
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PetWSSoapBinding" type="tns:PetWS">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="checkPetExistance">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="checkPetExistance">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="checkPetExistanceResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="AccessDeniedException">
+        <soap:fault name="AccessDeniedException" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="InstantiationException">
+        <soap:fault name="InstantiationException" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="IllegalAccessException">
+        <soap:fault name="IllegalAccessException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="serviceManyFaults">
+    <wsdl:port binding="tns:PetWSSoapBinding" name="PetWSPort">
+      <soap:address location="https://{{url2}}/services/Pet/v7.8"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/test/unit/WsdlInformationService11.test.js
+++ b/test/unit/WsdlInformationService11.test.js
@@ -1292,7 +1292,6 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
         soap12Namespace,
         httpNamespace
       ),
-
       operation = {};
     operation['http:operation'] = {
       '@_location': '/FahrenheitToCelsius'
@@ -1306,7 +1305,7 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
     }
   });
 
-  it('should throw an error when called with operation as empty object', function () {
+  it('should return empty style when called with operation as empty object', function () {
 
     const simpleInput = `<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
     xmlns:tns="http://tempuri.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
@@ -1394,14 +1393,9 @@ describe('WSDL 1.1 parser getStyleFromBindingOperation', function () {
         soapNamespace,
         soap12Namespace,
         httpNamespace
-      );
-    try {
-      informationService.getStyleFromBindingOperation({}, bindingInfo);
-      assert.fail('we expected an error');
-    }
-    catch (error) {
-      expect(error.message).to.equal('Cannot get style info from binding operation');
-    }
+      ),
+      style = informationService.getStyleFromBindingOperation({}, bindingInfo);
+    expect(style).to.equal('');
   });
 });
 

--- a/test/unit/messageWithSchemaValidation.test.js
+++ b/test/unit/messageWithSchemaValidation.test.js
@@ -333,7 +333,7 @@ describe('Tools from messageWithSchemaValidation', function () {
                   Limited to quadrillions.`,
           'style': 'document',
           'url': 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-          'input': {
+          'input': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -348,8 +348,8 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
-          'output': {
+          }],
+          'output': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -364,7 +364,7 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
+          }],
           'fault': null,
           'portName': 'NumberConversionSoap',
           'serviceName': 'NumberConversion',
@@ -375,7 +375,7 @@ describe('Tools from messageWithSchemaValidation', function () {
           'description': 'Returns the non-zero dollar amount of the passed number.',
           'style': 'document',
           'url': 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-          'input': {
+          'input': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -390,8 +390,8 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
-          'output': {
+          }],
+          'output': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -406,7 +406,7 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
+          }],
           'fault': null,
           'portName': 'NumberConversionSoap',
           'serviceName': 'NumberConversion',
@@ -418,7 +418,7 @@ describe('Tools from messageWithSchemaValidation', function () {
                   Limited to quadrillions.`,
           'style': 'document',
           'url': 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-          'input': {
+          'input': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -433,8 +433,8 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
-          'output': {
+          }],
+          'output': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -449,7 +449,7 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
+          }],
           'fault': null,
           'portName': 'NumberConversionSoap12',
           'serviceName': 'NumberConversion',
@@ -460,7 +460,7 @@ describe('Tools from messageWithSchemaValidation', function () {
           'description': 'Returns the non-zero dollar amount of the passed number.',
           'style': 'document',
           'url': 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
-          'input': {
+          'input': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -475,8 +475,8 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
-          'output': {
+          }],
+          'output': [{
             'children': [{
               'children': [],
               'minOccurs': '1',
@@ -491,7 +491,7 @@ describe('Tools from messageWithSchemaValidation', function () {
             'type': 'complex',
             'isComplex': true,
             'namespace': 'http://www.dataaccess.com/webservicesserver/'
-          },
+          }],
           'fault': null,
           'portName': 'NumberConversionSoap12',
           'serviceName': 'NumberConversion',

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -759,9 +759,9 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'NumberConversionSoap',
         serviceName: 'NumberConversion'
       });
-    expect(wsdlObject.operationsArray[0].input).to.be.an('object');
-    expect(wsdlObject.operationsArray[0].output).to.be.an('object');
-    expect(wsdlObject.operationsArray[0].fault).to.be.an('object');
+    expect(wsdlObject.operationsArray[0].input).to.be.an('Array');
+    expect(wsdlObject.operationsArray[0].output).to.be.an('Array');
+    expect(wsdlObject.operationsArray[0].fault).to.be.an('Array');
 
     expect(wsdlObject.operationsArray[0].description.replace(/[\r\n\s]+/g, '')).to.equal(
       ('Returns the word corresponding to the positive number ' +
@@ -777,8 +777,8 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'NumberConversionSoap',
         serviceName: 'NumberConversion'
       });
-    expect(wsdlObject.operationsArray[1].input).to.be.an('object');
-    expect(wsdlObject.operationsArray[1].output).to.be.an('object');
+    expect(wsdlObject.operationsArray[1].input).to.be.an('Array');
+    expect(wsdlObject.operationsArray[1].output).to.be.an('Array');
     expect(wsdlObject.operationsArray[1].fault).to.be.null;
 
     expect(wsdlObject.operationsArray[2]).to.be.an('object')


### PR DESCRIPTION
Add support in conversion and validation for files that have more than one fault in operation

e.g.
<wsdl:operation name=""createPet"">
    <wsdl:input message=""tns:createPet"" name=""createPet"">
    </wsdl:input>
    <wsdl:output message=""tns:createPetResponse"" name=""createPetResponse"">
    </wsdl:output>
    <wsdl:fault message=""tns:AccessDeniedException"" name=""AccessDeniedException"">
    </wsdl:fault>
    <wsdl:fault message=""tns:OtherException"" name=""OtherException"">
    </wsdl:fault>
</wsdl:operation>
we used to generate only one output and one fault for every request. Due that this file has 2 faults
instead of having one object we have an array, trying to access a property of it returned undefined then the replace operation failed
Now we handle outputs and faults always as an array so if you have one or more we handle it correctly and generate all the responses
in the request. Also the name of the fault was added in the name of the response for easier identification
e.g ""createPet fault - AccesDeniedException"" and ""createPet fault - OtherException"" will be added as the name of the responses"

Validation flow also was changed to validate correctly al the responses