### PR TITLE
Separate validators

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -7,6 +7,9 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
   {
     HeadersValidator
   } = require('./transactionValidator/HeadersValidator'),
+  {
+    MethodValidator
+  } = require('./transactionValidator/MethodValidator'),
   Ajv = require('ajv'),
   {
     getCleanSchema,
@@ -21,12 +24,10 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
   MISSING_ENDPOINT_REASON_CODE = 'MISSING_ENDPOINT',
   INVALID_BODY_REASON_CODE = 'INVALID_BODY',
   INVALID_RESPONSE_BODY_REASON_CODE = 'INVALID_RESPONSE_BODY',
-  INVALID_SOAP_METHOD_REASON_CODE = 'INVALID_SOAP_METHOD',
   RESPONSE_BODY_PROPERTY = 'RESPONSE_BODY',
   BODY_PROPERTY = 'BODY',
   RESPONSE_BODY_NOT_PROVIDED_MSG = 'Response body not provided',
   REQUEST_BODY_NOT_PROVIDED_MSG = 'Request body not provided',
-  SOAP_METHOD_PROPERTY = 'SOAP_METHOD',
   MISSING_SCHEMA_ERROR_PART = 'This element is not expected',
   {
     SOAP_ENVELOPE_NS_URL,
@@ -282,23 +283,8 @@ class TransactionValidator {
    * @returns {Array} mismatches array
    */
   validateSoapMethod(protocol, method, operationFromWSDL, validationPropertiesToIgnore) {
-    const postProtocols = [SOAP_PROTOCOL, SOAP12_PROTOCOL];
-    let mismatches = [];
-    if (validationPropertiesToIgnore && validationPropertiesToIgnore.includes(SOAP_METHOD_PROPERTY)) {
-      return mismatches;
-    }
-    if (postProtocols.includes(protocol.toLowerCase()) && method.toLowerCase() !== 'post') {
-      mismatches = [
-        {
-          property: SOAP_METHOD_PROPERTY,
-          transactionJsonPath: '$.request.method',
-          schemaJsonPath: operationFromWSDL.xpathInfo.xpath,
-          reasonCode: INVALID_SOAP_METHOD_REASON_CODE,
-          reason: 'Soap requests must use POST method.'
-        }
-      ];
-    }
-    return mismatches;
+    const validator = new MethodValidator();
+    return validator.validate(protocol, method, operationFromWSDL, validationPropertiesToIgnore);
   }
 
   /**
@@ -653,8 +639,8 @@ class TransactionValidator {
    * @returns {Array} missmatchs array
    */
   validateHeaders(requestHeaders, entityId, validateHeadersOption, isResponse, options) {
-    const transactionValidator = new HeadersValidator();
-    return transactionValidator.validate(requestHeaders, entityId, validateHeadersOption, isResponse, options);
+    const validator = new HeadersValidator();
+    return validator.validate(requestHeaders, entityId, validateHeadersOption, isResponse, options);
   }
 
   /**

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -4,6 +4,9 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
   {
     QueryParamsValidator
   } = require('./transactionValidator/QueryParamsValidator'),
+  {
+    HeadersValidator
+  } = require('./transactionValidator/HeadersValidator'),
   Ajv = require('ajv'),
   {
     getCleanSchema,
@@ -14,12 +17,8 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
   } = require('./utils/messageWithSchemaValidation'),
   transactionSchema = require('./constants/transactionSchema'),
   { parseFromXmlToObject, getNamespaceByURL } = require('./WsdlParserCommon'),
-  HEADER_PROPERTY = 'HEADER',
   ENDPOINT_PROPERTY = 'ENDPOINT',
-  MISSING_IN_REQUEST_REASON_CODE = 'MISSING_IN_REQUEST',
-  INVALID_TYPE_REASON_CODE = 'INVALID_TYPE',
   MISSING_ENDPOINT_REASON_CODE = 'MISSING_ENDPOINT',
-  CONTENT_TYPE_HEADER_KEY = 'Content-Type',
   INVALID_BODY_REASON_CODE = 'INVALID_BODY',
   INVALID_RESPONSE_BODY_REASON_CODE = 'INVALID_RESPONSE_BODY',
   INVALID_SOAP_METHOD_REASON_CODE = 'INVALID_SOAP_METHOD',
@@ -654,52 +653,8 @@ class TransactionValidator {
    * @returns {Array} missmatchs array
    */
   validateHeaders(requestHeaders, entityId, validateHeadersOption, isResponse, options) {
-    let missmatches = [],
-      contentTypeMissmatch;
-    if (validateHeadersOption) {
-      contentTypeMissmatch = this.validateContentTypeHeader(requestHeaders, entityId, isResponse, options);
-    }
-    if (contentTypeMissmatch) {
-      missmatches.push(contentTypeMissmatch);
-    }
-    return missmatches;
-  }
-
-  /**
-   *
-   * @description validates if the content type header is pressent and if has value of text/xml
-   * @param {object} headers headers list
-   * @param {string} entityId request or response id
-   * @param {boolean} isResponse true if the entity is response false if not
-   * @param {object} options options validation process
-   * @returns {object} missmatch object if the case
-   */
-  validateContentTypeHeader(headers, entityId, isResponse, options) {
-    let index = headers.findIndex((header) => { return header.key === CONTENT_TYPE_HEADER_KEY; }),
-      contentTypeHeader = headers[index];
-    const { ignoreUnresolvedVariables } = options;
-    if (!contentTypeHeader) {
-      return {
-        property: HEADER_PROPERTY,
-        transactionJsonPath: isResponse ? `$.responses[${entityId}].header` : '$.request.header',
-        schemaJsonPath: 'schemaPathPrefix',
-        reasonCode: MISSING_IN_REQUEST_REASON_CODE,
-        reason: 'The header "Content-Type" was not found in the transaction'
-      };
-    }
-    if (ignoreUnresolvedVariables && isPmVariable(contentTypeHeader.value)) {
-      return;
-    }
-    if (!contentTypeHeader.value.includes('text/xml')) {
-      return {
-        property: HEADER_PROPERTY,
-        transactionJsonPath: isResponse ? `$.responses[${entityId}].header[${index}].value` :
-          `$.request.header[${index}].value`,
-        schemaJsonPath: 'schemaPathPrefix',
-        reasonCode: INVALID_TYPE_REASON_CODE,
-        reason: `The header "Content-Type" needs to be "text/xml" but we found "${contentTypeHeader.value}" instead`
-      };
-    }
+    const transactionValidator = new HeadersValidator();
+    return transactionValidator.validate(requestHeaders, entityId, validateHeadersOption, isResponse, options);
   }
 
   /**

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -340,7 +340,7 @@ class TransactionValidator {
    * @param {object} requestUrl Request url postman object
    * @returns {string} the last segment in path
    */
-  getURLPathLast(requestUrl) {
+  getLastURLPath(requestUrl) {
     if (typeof requestUrl === 'object') {
       if (requestUrl.path) {
         return requestUrl.path[requestUrl.path.length - 1];
@@ -478,7 +478,7 @@ class TransactionValidator {
     }
 
     if (itemRequest.method && itemRequest.method === GET_METHOD && methodName === '') {
-      methodName = this.getURLPathLast(itemRequest.url);
+      methodName = this.getLastURLPath(itemRequest.url);
       protocol = HTTP_PROTOCOL;
       return { methodName, protocol };
     }
@@ -585,7 +585,7 @@ class TransactionValidator {
 
   /**
    *
-   * @description  function to filter operations by url name protocol method
+   * @description  function to filter operations by element name
    * @param {object} operation operation
    * @returns {Function} filter function
    */

--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -1,6 +1,4 @@
-const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/mismatchUtils'),
-  { SOAPMessageHelper } = require('./utils/SOAPMessageHelper'),
-  sdk = require('postman-collection'),
+const sdk = require('postman-collection'),
   {
     QueryParamsValidator
   } = require('./transactionValidator/QueryParamsValidator'),
@@ -10,25 +8,17 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
   {
     MethodValidator
   } = require('./transactionValidator/MethodValidator'),
-  Ajv = require('ajv'),
   {
-    getCleanSchema,
-    validateMessageWithSchema,
-    unwrapAndCleanBody,
-    getMessagePayload,
-    getMessageNamespace
-  } = require('./utils/messageWithSchemaValidation'),
+    BodyValidator
+  } = require('./transactionValidator/BodyValidator'),
+  Ajv = require('ajv'),
   transactionSchema = require('./constants/transactionSchema'),
   { parseFromXmlToObject, getNamespaceByURL } = require('./WsdlParserCommon'),
   ENDPOINT_PROPERTY = 'ENDPOINT',
   MISSING_ENDPOINT_REASON_CODE = 'MISSING_ENDPOINT',
-  INVALID_BODY_REASON_CODE = 'INVALID_BODY',
   INVALID_RESPONSE_BODY_REASON_CODE = 'INVALID_RESPONSE_BODY',
   RESPONSE_BODY_PROPERTY = 'RESPONSE_BODY',
-  BODY_PROPERTY = 'BODY',
   RESPONSE_BODY_NOT_PROVIDED_MSG = 'Response body not provided',
-  REQUEST_BODY_NOT_PROVIDED_MSG = 'Request body not provided',
-  MISSING_SCHEMA_ERROR_PART = 'This element is not expected',
   {
     SOAP_ENVELOPE_NS_URL,
     SOAP_12_ENVELOPE_NS_URL,
@@ -39,7 +29,6 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
     HTTP_PROTOCOL
   } = require('./constants/processConstants'),
   {
-    isPmVariable,
     getLastSegmentURL
   } = require('./utils/textUtils'),
   {
@@ -51,7 +40,6 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('./utils/
   {
     WsdlToPostmanCollectionMapper
   } = require('./WsdlToPostmanCollectionMapper');
-
 class TransactionValidator {
   /**
    *
@@ -288,41 +276,6 @@ class TransactionValidator {
   }
 
   /**
-   * generate a correct body from the wsdl schema
-   * @param {object} wsdlObject the wsdlObject from the wsdl file
-   * @param {object} operationFromWsdl the current operation object
-   * @param {object} elementFromWSDLMessage the wsdl element for creating the message
-   * @param {object} xmlParser injects the parse that will be used
-   * @param {boolean} detailed defines if generated body will contain all namespaces and envelope tags or not
-   * @returns {string} the correct body from the wsdl document schema
-   */
-  getBodyFromSchema(wsdlObject, operationFromWsdl, elementFromWSDLMessage, xmlParser, detailed) {
-    const messageHelper = new SOAPMessageHelper();
-    let message = messageHelper.convertInputToMessage(elementFromWSDLMessage,
-      wsdlObject.securityPolicyArray,
-      operationFromWsdl.protocol,
-      xmlParser
-    );
-    if (detailed) {
-      message = unwrapAndCleanBody(message, elementFromWSDLMessage.name);
-    }
-    return message;
-  }
-
-  /**
-   * filter errors depending on detailedBlobValidation option
-   * @param {array} errors the array of errors to report
-   * @param {boolean} detailedBlobValidation option to define if error will be reported with detail or not
-   * @returns {array} an array with errors depending on detailedBlobValidation option
-   */
-  handleDetailedBlobValidation(errors, detailedBlobValidation) {
-    if (!detailedBlobValidation && errors.length > 0) {
-      return [errors[0]];
-    }
-    return errors;
-  }
-
-  /**
    * Validate body string and return mismatches
    * @param {String} body Message in body
    * @param {Object} wsdlObject Object generated from wsdl document
@@ -335,106 +288,9 @@ class TransactionValidator {
    */
   validateBody(body, wsdlObject, operationFromWSDL, isResponse, options, xmlParser,
     elementFromWSDLMessage) {
-    let mismatches = [],
-      filteredErrors,
-      errors,
-      namespaceURL,
-      rawXmlMessage;
-    const {
-        validationPropertiesToIgnore,
-        suggestAvailableFixes,
-        detailedBlobValidation
-      } = options,
-      mismatchProperty = isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY;
-
-    if (validationPropertiesToIgnore && validationPropertiesToIgnore.includes(mismatchProperty)) {
-      return mismatches;
-    }
-
-    if (body) {
-      const parsedXml = wsdlObject.xmlParsed;
-      namespaceURL = getMessageNamespace(body, elementFromWSDLMessage.name);
-      let { cleanSchema, isSchemaXSDDefault } = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version,
-        xmlParser, namespaceURL);
-      if (!isSchemaXSDDefault) {
-        rawXmlMessage = unwrapAndCleanBody(body, elementFromWSDLMessage.name);
-      }
-      else {
-        rawXmlMessage = getMessagePayload(body, elementFromWSDLMessage.name);
-      }
-      errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
-      if (errors.length > 0) {
-        filteredErrors = this.filterSchemaValidationErrors(errors, options);
-        filteredErrors = this.handleDetailedBlobValidation(filteredErrors, detailedBlobValidation);
-        mismatches = filteredErrors.map((error) => {
-          let mismatch = getBodyMismatchObject(operationFromWSDL, error, isResponse, options);
-          if (suggestAvailableFixes) {
-            const currentBody = detailedBlobValidation ? rawXmlMessage : body,
-              expectedBody = this.getBodyFromSchema(
-                wsdlObject,
-                operationFromWSDL,
-                elementFromWSDLMessage,
-                xmlParser,
-                detailedBlobValidation
-              );
-            mismatch = getMismatchWithSuggestedFix(
-              mismatch,
-              currentBody,
-              expectedBody,
-              detailedBlobValidation,
-              cleanSchema
-            );
-          }
-          return mismatch;
-        });
-      }
-    }
-    else if (operationFromWSDL.method !== GET_METHOD) {
-      mismatches = [
-        {
-          property: isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY,
-          transactionJsonPath: isResponse ? '$.response.body' : '$.request.body',
-          schemaJsonPath: operationFromWSDL.xpathInfo.xpath,
-          reasonCode: isResponse ? INVALID_RESPONSE_BODY_REASON_CODE : INVALID_BODY_REASON_CODE,
-          reason: isResponse ? RESPONSE_BODY_NOT_PROVIDED_MSG : REQUEST_BODY_NOT_PROVIDED_MSG
-        }
-      ];
-    }
-    return mismatches;
-  }
-
-  /**
-   * @description Filter the obtained schema validation errors
-   * according to the sent options
-   * @param {Array} errors schema validation errors
-   * @param {object} options options validation process
-   * @returns {Array} filtered validation errors
-   */
-  filterSchemaValidationErrors(errors, options) {
-    let filteredErrors = errors;
-    const {
-      ignoreUnresolvedVariables,
-      showMissingInSchemaErrors
-    } = options;
-    if (ignoreUnresolvedVariables) {
-      filteredErrors = errors.filter((error) => {
-        if (error.code !== 1824) {
-          return true;
-        }
-        return error.code === 1824 && !isPmVariable(error.str1);
-      });
-    }
-
-    if (showMissingInSchemaErrors !== undefined && showMissingInSchemaErrors === false) {
-      filteredErrors = filteredErrors.filter((error) => {
-        const isMissingInSchemaError = (
-          error.code === 1871 &&
-          error.message.includes(MISSING_SCHEMA_ERROR_PART)
-        );
-        return !isMissingInSchemaError;
-      });
-    }
-    return filteredErrors;
+    const validator = new BodyValidator();
+    return validator.validate(body, wsdlObject, operationFromWSDL, isResponse,
+      options, xmlParser, elementFromWSDLMessage);
   }
 
   /**

--- a/lib/transactionValidator/BodyValidator.js
+++ b/lib/transactionValidator/BodyValidator.js
@@ -1,0 +1,184 @@
+const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('../utils/mismatchUtils'),
+  { SOAPMessageHelper } = require('../utils/SOAPMessageHelper'),
+  {
+    getCleanSchema,
+    validateMessageWithSchema,
+    unwrapAndCleanBody,
+    getMessagePayload,
+    getMessageNamespace
+  } = require('../utils/messageWithSchemaValidation'),
+  INVALID_BODY_REASON_CODE = 'INVALID_BODY',
+  INVALID_RESPONSE_BODY_REASON_CODE = 'INVALID_RESPONSE_BODY',
+  RESPONSE_BODY_PROPERTY = 'RESPONSE_BODY',
+  BODY_PROPERTY = 'BODY',
+  RESPONSE_BODY_NOT_PROVIDED_MSG = 'Response body not provided',
+  REQUEST_BODY_NOT_PROVIDED_MSG = 'Request body not provided',
+  MISSING_SCHEMA_ERROR_PART = 'This element is not expected',
+  {
+    isPmVariable
+  } = require('../utils/textUtils'),
+  {
+    GET_METHOD
+  } = require('../utils/httpUtils');
+
+/**
+ * Class to validate XML against an XSD schema.
+ * Facade to xmllint package
+ */
+class BodyValidator {
+
+  /**
+   * Validate body string and return mismatches
+   * @param {String} body Message in body
+   * @param {Object} wsdlObject Object generated from wsdl document
+   * @param {Object} operationFromWSDL wsdlObject operation's
+   * @param {Boolean} isResponse True if provided message is in a response, False if is in a request
+   * @param {object} options options validation process
+   * @param {object} xmlParser the parser class to parse xml to object or vice versa
+   * @param {object} elementFromWSDLMessage the element from message
+   * @returns {Array} List of mismatches found
+   */
+  validate(body, wsdlObject, operationFromWSDL, isResponse, options, xmlParser,
+    elementFromWSDLMessage) {
+    let mismatches = [],
+      filteredErrors,
+      errors,
+      namespaceURL,
+      rawXmlMessage;
+    const {
+        validationPropertiesToIgnore,
+        suggestAvailableFixes,
+        detailedBlobValidation
+      } = options,
+      mismatchProperty = isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY;
+
+    if (validationPropertiesToIgnore && validationPropertiesToIgnore.includes(mismatchProperty)) {
+      return mismatches;
+    }
+
+    if (body) {
+      const parsedXml = wsdlObject.xmlParsed;
+      namespaceURL = getMessageNamespace(body, elementFromWSDLMessage.name);
+      let { cleanSchema, isSchemaXSDDefault } = getCleanSchema(parsedXml, wsdlObject, wsdlObject.version,
+        xmlParser, namespaceURL);
+      if (!isSchemaXSDDefault) {
+        rawXmlMessage = unwrapAndCleanBody(body, elementFromWSDLMessage.name);
+      }
+      else {
+        rawXmlMessage = getMessagePayload(body, elementFromWSDLMessage.name);
+      }
+      errors = validateMessageWithSchema(rawXmlMessage, cleanSchema);
+      if (errors.length > 0) {
+        filteredErrors = this.filterSchemaValidationErrors(errors, options);
+        filteredErrors = this.handleDetailedBlobValidation(filteredErrors, detailedBlobValidation);
+        mismatches = filteredErrors.map((error) => {
+          let mismatch = getBodyMismatchObject(operationFromWSDL, error, isResponse, options);
+          if (suggestAvailableFixes) {
+            const currentBody = detailedBlobValidation ? rawXmlMessage : body,
+              expectedBody = this.getBodyFromSchema(
+                wsdlObject,
+                operationFromWSDL,
+                elementFromWSDLMessage,
+                xmlParser,
+                detailedBlobValidation
+              );
+            mismatch = getMismatchWithSuggestedFix(
+              mismatch,
+              currentBody,
+              expectedBody,
+              detailedBlobValidation,
+              cleanSchema
+            );
+          }
+          return mismatch;
+        });
+      }
+    }
+    else if (operationFromWSDL.method !== GET_METHOD) {
+      mismatches = [
+        {
+          property: isResponse ? RESPONSE_BODY_PROPERTY : BODY_PROPERTY,
+          transactionJsonPath: isResponse ? '$.response.body' : '$.request.body',
+          schemaJsonPath: operationFromWSDL.xpathInfo.xpath,
+          reasonCode: isResponse ? INVALID_RESPONSE_BODY_REASON_CODE : INVALID_BODY_REASON_CODE,
+          reason: isResponse ? RESPONSE_BODY_NOT_PROVIDED_MSG : REQUEST_BODY_NOT_PROVIDED_MSG
+        }
+      ];
+    }
+    return mismatches;
+  }
+
+  /**
+   * @description Filter the obtained schema validation errors
+   * according to the sent options
+   * @param {Array} errors schema validation errors
+   * @param {object} options options validation process
+   * @returns {Array} filtered validation errors
+   */
+  filterSchemaValidationErrors(errors, options) {
+    let filteredErrors = errors;
+    const {
+      ignoreUnresolvedVariables,
+      showMissingInSchemaErrors
+    } = options;
+    if (ignoreUnresolvedVariables) {
+      filteredErrors = errors.filter((error) => {
+        if (error.code !== 1824) {
+          return true;
+        }
+        return error.code === 1824 && !isPmVariable(error.str1);
+      });
+    }
+
+    if (showMissingInSchemaErrors !== undefined && showMissingInSchemaErrors === false) {
+      filteredErrors = filteredErrors.filter((error) => {
+        const isMissingInSchemaError = (
+          error.code === 1871 &&
+          error.message.includes(MISSING_SCHEMA_ERROR_PART)
+        );
+        return !isMissingInSchemaError;
+      });
+    }
+    return filteredErrors;
+  }
+
+  /**
+ * filter errors depending on detailedBlobValidation option
+ * @param {array} errors the array of errors to report
+ * @param {boolean} detailedBlobValidation option to define if error will be reported with detail or not
+ * @returns {array} an array with errors depending on detailedBlobValidation option
+ */
+  handleDetailedBlobValidation(errors, detailedBlobValidation) {
+    if (!detailedBlobValidation && errors.length > 0) {
+      return [errors[0]];
+    }
+    return errors;
+  }
+
+  /**
+   * generate a correct body from the wsdl schema
+   * @param {object} wsdlObject the wsdlObject from the wsdl file
+   * @param {object} operationFromWsdl the current operation object
+   * @param {object} elementFromWSDLMessage the wsdl element for creating the message
+   * @param {object} xmlParser injects the parse that will be used
+   * @param {boolean} detailed defines if generated body will contain all namespaces and envelope tags or not
+   * @returns {string} the correct body from the wsdl document schema
+   */
+  getBodyFromSchema(wsdlObject, operationFromWsdl, elementFromWSDLMessage, xmlParser, detailed) {
+    const messageHelper = new SOAPMessageHelper();
+    let message = messageHelper.convertInputToMessage(elementFromWSDLMessage,
+      wsdlObject.securityPolicyArray,
+      operationFromWsdl.protocol,
+      xmlParser
+    );
+    if (detailed) {
+      message = unwrapAndCleanBody(message, elementFromWSDLMessage.name);
+    }
+    return message;
+  }
+
+}
+
+module.exports = {
+  BodyValidator
+};

--- a/lib/transactionValidator/BodyValidator.js
+++ b/lib/transactionValidator/BodyValidator.js
@@ -22,8 +22,7 @@ const { getBodyMismatchObject, getMismatchWithSuggestedFix } = require('../utils
   } = require('../utils/httpUtils');
 
 /**
- * Class to validate XML against an XSD schema.
- * Facade to xmllint package
+ * Class to validate a postman request body
  */
 class BodyValidator {
 

--- a/lib/transactionValidator/HeadersValidator.js
+++ b/lib/transactionValidator/HeadersValidator.js
@@ -4,8 +4,7 @@ const MISSING_IN_REQUEST_REASON_CODE = 'MISSING_IN_REQUEST',
   HEADER_PROPERTY = 'HEADER';
 
 /**
- * Class to validate XML against an XSD schema.
- * Facade to xmllint package
+ * Class to validate postman request headers
  */
 class HeadersValidator {
 

--- a/lib/transactionValidator/HeadersValidator.js
+++ b/lib/transactionValidator/HeadersValidator.js
@@ -1,0 +1,76 @@
+const MISSING_IN_REQUEST_REASON_CODE = 'MISSING_IN_REQUEST',
+  INVALID_TYPE_REASON_CODE = 'INVALID_TYPE',
+  CONTENT_TYPE_HEADER_KEY = 'Content-Type',
+  HEADER_PROPERTY = 'HEADER';
+
+/**
+ * Class to validate XML against an XSD schema.
+ * Facade to xmllint package
+ */
+class HeadersValidator {
+
+  /**
+   *
+   * @description validates request or response headers
+   * @param {object} requestHeaders headers list
+   * @param {string} entityId request or response id
+   * @param {boolean} validateHeadersOption if validateHeadersOption option value, False by default
+   * @param {boolean} isResponse true if the entity is response false if not
+   * @param {object} options options validation process
+   * @returns {Array} missmatchs array
+   */
+  validate(requestHeaders, entityId, validateHeadersOption, isResponse, options) {
+    let missmatches = [],
+      contentTypeMissmatch;
+    if (validateHeadersOption) {
+      contentTypeMissmatch = this.validateContentTypeHeader(requestHeaders, entityId, isResponse, options);
+    }
+    if (contentTypeMissmatch) {
+      missmatches.push(contentTypeMissmatch);
+    }
+    return missmatches;
+  }
+
+  /**
+   *
+   * @description validates if the content type header is pressent and if has value of text/xml
+   * @param {object} headers headers list
+   * @param {string} entityId request or response id
+   * @param {boolean} isResponse true if the entity is response false if not
+   * @param {object} options options validation process
+   * @returns {object} missmatch object if the case
+   */
+  validateContentTypeHeader(headers, entityId, isResponse, options) {
+    let index = headers.findIndex((header) => { return header.key === CONTENT_TYPE_HEADER_KEY; }),
+      contentTypeHeader = headers[index];
+    const { ignoreUnresolvedVariables } = options;
+    if (!contentTypeHeader) {
+      return {
+        property: HEADER_PROPERTY,
+        transactionJsonPath: isResponse ? `$.responses[${entityId}].header` : '$.request.header',
+        schemaJsonPath: 'schemaPathPrefix',
+        reasonCode: MISSING_IN_REQUEST_REASON_CODE,
+        reason: 'The header "Content-Type" was not found in the transaction'
+      };
+    }
+    if (ignoreUnresolvedVariables && isPmVariable(contentTypeHeader.value)) {
+      return;
+    }
+    if (!contentTypeHeader.value.includes('text/xml')) {
+      return {
+        property: HEADER_PROPERTY,
+        transactionJsonPath: isResponse ? `$.responses[${entityId}].header[${index}].value` :
+          `$.request.header[${index}].value`,
+        schemaJsonPath: 'schemaPathPrefix',
+        reasonCode: INVALID_TYPE_REASON_CODE,
+        reason: `The header "Content-Type" needs to be "text/xml" but we found "${contentTypeHeader.value}" instead`
+      };
+    }
+  }
+
+
+}
+
+module.exports = {
+  HeadersValidator
+};

--- a/lib/transactionValidator/HeadersValidator.js
+++ b/lib/transactionValidator/HeadersValidator.js
@@ -1,6 +1,7 @@
 const MISSING_IN_REQUEST_REASON_CODE = 'MISSING_IN_REQUEST',
   INVALID_TYPE_REASON_CODE = 'INVALID_TYPE',
   CONTENT_TYPE_HEADER_KEY = 'Content-Type',
+  VALID_CONTENT_TYPES = ['text/xml', 'application/soap+xml'],
   HEADER_PROPERTY = 'HEADER';
 
 /**
@@ -41,6 +42,7 @@ class HeadersValidator {
    */
   validateContentTypeHeader(headers, entityId, isResponse, options) {
     let index = headers.findIndex((header) => { return header.key === CONTENT_TYPE_HEADER_KEY; }),
+      foundHeader,
       contentTypeHeader = headers[index];
     const { ignoreUnresolvedVariables } = options;
     if (!contentTypeHeader) {
@@ -55,18 +57,21 @@ class HeadersValidator {
     if (ignoreUnresolvedVariables && isPmVariable(contentTypeHeader.value)) {
       return;
     }
-    if (!contentTypeHeader.value.includes('text/xml')) {
+    foundHeader = VALID_CONTENT_TYPES.find((validContent) => {
+      return contentTypeHeader.value.includes(validContent);
+    });
+    if (!foundHeader) {
       return {
         property: HEADER_PROPERTY,
         transactionJsonPath: isResponse ? `$.responses[${entityId}].header[${index}].value` :
           `$.request.header[${index}].value`,
         schemaJsonPath: 'schemaPathPrefix',
         reasonCode: INVALID_TYPE_REASON_CODE,
-        reason: `The header "Content-Type" needs to be "text/xml" but we found "${contentTypeHeader.value}" instead`
+        reason: `The header "Content-Type" needs to be "${VALID_CONTENT_TYPES[0]}" or "${VALID_CONTENT_TYPES[1]}" ` +
+        `but we found "${contentTypeHeader.value}" instead`
       };
     }
   }
-
 
 }
 

--- a/lib/transactionValidator/MethodValidator.js
+++ b/lib/transactionValidator/MethodValidator.js
@@ -1,0 +1,45 @@
+const {
+  SOAP_PROTOCOL,
+  SOAP12_PROTOCOL,
+  SOAP_METHOD_PROPERTY = 'SOAP_METHOD',
+  INVALID_SOAP_METHOD_REASON_CODE = 'INVALID_SOAP_METHOD'
+} = require('../constants/processConstants');
+
+/**
+ * Class to validate XML against an XSD schema.
+ * Facade to xmllint package
+ */
+class MethodValidator {
+
+  /**
+   * Validate that the request uses POST method due that is the used for SOAP Protocol
+   * @param {Array} protocol the WSDL operation protocol
+   * @param {Object} method The Request Http Method
+   * @param {Object} operationFromWSDL The wsdlObject operation's
+   * @param {Object} validationPropertiesToIgnore option for ignoring properties in validation
+   * @returns {Array} mismatches array
+   */
+  validate(protocol, method, operationFromWSDL, validationPropertiesToIgnore) {
+    const postProtocols = [SOAP_PROTOCOL, SOAP12_PROTOCOL];
+    let mismatches = [];
+    if (validationPropertiesToIgnore && validationPropertiesToIgnore.includes(SOAP_METHOD_PROPERTY)) {
+      return mismatches;
+    }
+    if (postProtocols.includes(protocol.toLowerCase()) && method.toLowerCase() !== 'post') {
+      mismatches = [
+        {
+          property: SOAP_METHOD_PROPERTY,
+          transactionJsonPath: '$.request.method',
+          schemaJsonPath: operationFromWSDL.xpathInfo.xpath,
+          reasonCode: INVALID_SOAP_METHOD_REASON_CODE,
+          reason: 'Soap requests must use POST method.'
+        }
+      ];
+    }
+    return mismatches;
+  }
+}
+
+module.exports = {
+  MethodValidator
+};

--- a/lib/transactionValidator/MethodValidator.js
+++ b/lib/transactionValidator/MethodValidator.js
@@ -6,8 +6,7 @@ const {
 } = require('../constants/processConstants');
 
 /**
- * Class to validate XML against an XSD schema.
- * Facade to xmllint package
+ * Class to validate a postman request http method
  */
 class MethodValidator {
 

--- a/lib/transactionValidator/QueryParamsValidator.js
+++ b/lib/transactionValidator/QueryParamsValidator.js
@@ -15,8 +15,7 @@ const QUERYPARAM_PROPERTY = 'QUERYPARAM',
   MISSING_IN_SCHEMA_REASON_CODE = 'MISSING_IN_SCHEMA';
 
 /**
- * Class to validate XML against an XSD schema.
- * Facade to xmllint package
+ * Class to validate a postman query params
  */
 class QueryParamsValidator {
 

--- a/test/convert-validation/validateTransactions.test.js
+++ b/test/convert-validation/validateTransactions.test.js
@@ -204,7 +204,7 @@ describe('Test validate Transactions method in SchemaPack', function () {
                 transactionJsonPath: '$.request.header[0].value',
                 schemaJsonPath: 'schemaPathPrefix',
                 reasonCode: 'INVALID_TYPE',
-                reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we ' +
+                reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we ' +
                   'found \"text/plain; charset=utf-8\" instead'
               }],
               responses: {
@@ -216,7 +216,7 @@ describe('Test validate Transactions method in SchemaPack', function () {
                     transactionJsonPath: '$.responses[d36c56cf-0cf6-4273-a34d-973e842bf80f].header[0].value',
                     schemaJsonPath: 'schemaPathPrefix',
                     reasonCode: 'INVALID_TYPE',
-                    reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we' +
+                    reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we' +
                       ' found \"text/plain; charset=utf-8\" instead'
                   }]
                 }

--- a/test/unit/TransactionValidator.options.test.js
+++ b/test/unit/TransactionValidator.options.test.js
@@ -1135,7 +1135,7 @@ describe('Validate Headers with options', function () {
               transactionJsonPath: '$.request.header[0].value',
               schemaJsonPath: 'schemaPathPrefix',
               reasonCode: 'INVALID_TYPE',
-              reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we ' +
+              reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we ' +
                 'found \"{{unresolvedVariable}}\" instead'
             }],
             responses: {
@@ -1147,7 +1147,7 @@ describe('Validate Headers with options', function () {
                   transactionJsonPath: '$.responses[d36c56cf-0cf6-4273-a34d-973e842bf80f].header[0].value',
                   schemaJsonPath: 'schemaPathPrefix',
                   reasonCode: 'INVALID_TYPE',
-                  reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we' +
+                  reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we' +
                     ' found \"{{unresolvedVariable}}\" instead'
                 }]
               }

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -492,7 +492,7 @@ describe('Validate Headers', function() {
               transactionJsonPath: '$.request.header[0].value',
               schemaJsonPath: 'schemaPathPrefix',
               reasonCode: 'INVALID_TYPE',
-              reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we ' +
+              reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we ' +
                 'found \"text/plain; charset=utf-8\" instead'
             }],
             responses: {
@@ -504,7 +504,7 @@ describe('Validate Headers', function() {
                   transactionJsonPath: '$.responses[d36c56cf-0cf6-4273-a34d-973e842bf80f].header[0].value',
                   schemaJsonPath: 'schemaPathPrefix',
                   reasonCode: 'INVALID_TYPE',
-                  reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we' +
+                  reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we' +
                     ' found \"text/plain; charset=utf-8\" instead'
                 }]
               }

--- a/test/unit/transactionValidator/BodyValidator.test.js
+++ b/test/unit/transactionValidator/BodyValidator.test.js
@@ -37,7 +37,7 @@ const {
         name: 'NumberToWords',
         isComplex: true,
         type: 'complex',
-        namespace: 'http://www.dataaccess.com/webservicesserver/',
+        namespace: 'http://www.dataaccess.com/webservicesserver/'
       }
     ],
     output: [
@@ -65,14 +65,14 @@ const {
             ],
             name: 'faultcode',
             isComplex: false,
-            type: 'string',
-          },
+            type: 'string'
+          }
         ],
         name: 'fault',
         isComplex: true,
         type: 'complex',
-        namespace: '',
-      },
+        namespace: ''
+      }
     ],
     portName: 'NumberConversionSoap',
     serviceName: 'NumberConversion',

--- a/test/unit/transactionValidator/BodyValidator.test.js
+++ b/test/unit/transactionValidator/BodyValidator.test.js
@@ -1,0 +1,145 @@
+const {
+    expect
+  } = require('chai'),
+  {
+    BodyValidator
+  } = require('../../../lib/transactionValidator/BodyValidator'),
+  {
+    XMLParser
+  } = require('../../../lib/XMLParser'),
+  numberToWordsWSDLObject = require('../../data/transactionsValidation/wsdlObjects/numberToWords'),
+  VALID_BODY = '<?xml version=\"1.0\" encoding=\'utf-8\'?>\n<soap:Envelope' +
+    ' xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n' +
+    '<NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n' +
+    '<ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n</soap:Envelope>\n',
+  INVALID_BODY_TYPE = '<?xml version=\"1.0\" encoding=\'utf-8\'?>\n<soap:Envelope' +
+    ' xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n' +
+    '<NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n' +
+    '<ubiNum>WRONG TYPE</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n</soap:Envelope>\n',
+  OPERATION = {
+    name: 'NumberToWords',
+    description: 'Returns the word corresponding to the positive number passed as parameter.',
+    style: 'document',
+    url: 'https://www.dataaccess.com/webservicesserver/NumberConversion.wso',
+    input: [
+      {
+        children: [
+          {
+            children: [
+            ],
+            name: 'ubiNum',
+            isComplex: false,
+            type: 'integer',
+            maximum: 2147483647,
+            minimum: -2147483648
+          }
+        ],
+        name: 'NumberToWords',
+        isComplex: true,
+        type: 'complex',
+        namespace: 'http://www.dataaccess.com/webservicesserver/',
+      }
+    ],
+    output: [
+      {
+        children: [
+          {
+            children: [
+            ],
+            name: 'NumberToWordsResult',
+            isComplex: false,
+            type: 'string'
+          }
+        ],
+        name: 'NumberToWordsResponse',
+        isComplex: true,
+        type: 'complex',
+        namespace: 'http://www.dataaccess.com/webservicesserver/'
+      }
+    ],
+    fault: [
+      {
+        children: [
+          {
+            children: [
+            ],
+            name: 'faultcode',
+            isComplex: false,
+            type: 'string',
+          },
+        ],
+        name: 'fault',
+        isComplex: true,
+        type: 'complex',
+        namespace: '',
+      },
+    ],
+    portName: 'NumberConversionSoap',
+    serviceName: 'NumberConversion',
+    method: 'POST',
+    protocol: 'soap',
+    xpathInfo: {
+      xpath: '//definitions//binding[@name=\'NumberConversionSoapBinding\']//operation[@name=\'NumberToWords\']',
+      wsdlNamespaceUrl: 'http://schemas.xmlsoap.org/wsdl/'
+    },
+    soapActionSegment: 'NumberToWords',
+    soapAction: 'http://www.dataaccess.com/webservicesserver/NumberToWords'
+  },
+  OPERATION_ELEMENT = {
+    children: [
+      {
+        children: [
+        ],
+        name: 'ubiNum',
+        isComplex: false,
+        type: 'integer',
+        maximum: 2147483647,
+        minimum: -2147483648
+      }
+    ],
+    name: 'NumberToWords',
+    isComplex: true,
+    type: 'complex',
+    namespace: 'http://www.dataaccess.com/webservicesserver/'
+  };
+
+describe('BodyValidator', function () {
+  it('Should return an empty array when request and response bodies are valid', function() {
+    const validator = new BodyValidator(),
+      result = validator.validate(VALID_BODY, numberToWordsWSDLObject, OPERATION, false,
+        {}, new XMLParser(), OPERATION_ELEMENT);
+    expect(result).to.be.an('Array');
+    expect(result.length).to.equal(0);
+  });
+
+  it('Should have a mismatch INVALID_BODY when a request endpoint has a type error in body', function() {
+    const validator = new BodyValidator(),
+      result = validator.validate(INVALID_BODY_TYPE, numberToWordsWSDLObject, OPERATION, false,
+        {}, new XMLParser(), OPERATION_ELEMENT);
+    expect(result).to.be.an('Array');
+    expect(result[0]).to.be.an('object').and.to.deep.include({
+      'property': 'BODY',
+      'reason': 'The request body didn\'t match the specified schema',
+      'reasonCode': 'INVALID_BODY',
+      'schemaJsonPath':
+       '//definitions//binding[@name=\'NumberConversionSoapBinding\']//operation[@name=\'NumberToWords\']',
+      'transactionJsonPath': '$.request.body'
+    });
+  });
+
+  it('Should have a mismatch INVALID_TYPE when a request endpoint has a type error in body option detailed true',
+    function() {
+      const validator = new BodyValidator(),
+        result = validator.validate(INVALID_BODY_TYPE, numberToWordsWSDLObject, OPERATION, false,
+          { detailedBlobValidation: true }, new XMLParser(), OPERATION_ELEMENT);
+      expect(result).to.be.an('Array');
+      expect(result[0]).to.be.an('object').and.to.deep.include({
+        'property': 'BODY',
+        'reason': 'Element \'ubiNum\': \'WRONG TYPE\' is not a valid value of the atomic type \'xs:unsignedLong\'.\n',
+        'reasonCode': 'INVALID_TYPE',
+        'schemaJsonPath':
+        '//definitions//binding[@name=\'NumberConversionSoapBinding\']//operation[@name=\'NumberToWords\']',
+        'transactionJsonPath': '$.request.body'
+      });
+    });
+});

--- a/test/unit/transactionValidator/HeadersValidator.test.js
+++ b/test/unit/transactionValidator/HeadersValidator.test.js
@@ -51,7 +51,7 @@ describe('HeadersValidator', function () {
       transactionJsonPath: '$.request.header[0].value',
       schemaJsonPath: 'schemaPathPrefix',
       reasonCode: 'INVALID_TYPE',
-      reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we ' +
+      reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we ' +
         'found \"text/plain; charset=utf-8\" instead'
     });
   });
@@ -75,6 +75,42 @@ describe('HeadersValidator', function () {
       }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', false, false, {});
     expect(result).to.be.an('array');
     expect(result.length).to.eq(0);
+  });
+
+  it('Should not return missmatch when header is text/xml and validateHeader option is true', function () {
+    const options = getOptions({
+        usage: ['VALIDATION']
+      }),
+      validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
+    let optionFromOptions = {},
+      validator,
+      result;
+    optionFromOptions[`${validateHeaderOption.id}`] = true;
+    validator = new HeadersValidator();
+    result = validator.validate([{
+      'key': 'Content-Type',
+      'value': 'text/xml'
+    }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
+    expect(result).to.be.an('Array');
+    expect(result.length).to.equal(0);
+  });
+
+  it('Should not return missmatch when header is application/soap+xml and validateHeader option is true', function () {
+    const options = getOptions({
+        usage: ['VALIDATION']
+      }),
+      validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
+    let optionFromOptions = {},
+      validator,
+      result;
+    optionFromOptions[`${validateHeaderOption.id}`] = true;
+    validator = new HeadersValidator();
+    result = validator.validate([{
+      'key': 'Content-Type',
+      'value': 'application/soap+xml'
+    }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
+    expect(result).to.be.an('Array');
+    expect(result.length).to.equal(0);
   });
 
 });

--- a/test/unit/transactionValidator/HeadersValidator.test.js
+++ b/test/unit/transactionValidator/HeadersValidator.test.js
@@ -14,11 +14,11 @@ describe('HeadersValidator', function () {
       }),
       validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
     let optionFromOptions = {},
-      transactionValidator,
+      validator,
       result;
     optionFromOptions[`${validateHeaderOption.id}`] = true;
-    transactionValidator = new HeadersValidator();
-    result = transactionValidator.validate([], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
+    validator = new HeadersValidator();
+    result = validator.validate([], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
     expect(result).to.be.an('Array');
     expect(result[0]).to.be.an('object').and.to.deep.include({
       property: 'HEADER',
@@ -37,11 +37,11 @@ describe('HeadersValidator', function () {
       }),
       validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
     let optionFromOptions = {},
-      transactionValidator,
+      validator,
       result;
     optionFromOptions[`${validateHeaderOption.id}`] = true;
-    transactionValidator = new HeadersValidator();
-    result = transactionValidator.validate([{
+    validator = new HeadersValidator();
+    result = validator.validate([{
       'key': 'Content-Type',
       'value': 'text/plain; charset=utf-8'
     }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
@@ -59,8 +59,8 @@ describe('HeadersValidator', function () {
   it('Should not return missing header when validateHeader option is not provided' +
   ' and not content-type header is present',
   function () {
-    const transactionValidator = new HeadersValidator(),
-      result = transactionValidator.validate([], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', false, false, {});
+    const validator = new HeadersValidator(),
+      result = validator.validate([], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', false, false, {});
     expect(result).to.be.an('array');
     expect(result.length).to.eq(0);
   });
@@ -68,8 +68,8 @@ describe('HeadersValidator', function () {
   it('Should not return bad header mismatch when validateHeader option' +
   ' is false and content-type header is not text/xml',
   function () {
-    const transactionValidator = new HeadersValidator(),
-      result = transactionValidator.validate([{
+    const validator = new HeadersValidator(),
+      result = validator.validate([{
         'key': 'Content-Type',
         'value': 'text/plain; charset=utf-8'
       }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', false, false, {});

--- a/test/unit/transactionValidator/HeadersValidator.test.js
+++ b/test/unit/transactionValidator/HeadersValidator.test.js
@@ -1,0 +1,80 @@
+const {
+    expect
+  } = require('chai'),
+  {
+    HeadersValidator
+  } = require('../../../lib/transactionValidator/HeadersValidator'),
+  getOptions = require('../../../lib/utils/options').getOptions;
+
+describe('HeadersValidator', function () {
+  it('Should return missing header when validateHeader option is on true' +
+    ' and not content-type header is present', function () {
+    const options = getOptions({
+        usage: ['VALIDATION']
+      }),
+      validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
+    let optionFromOptions = {},
+      transactionValidator,
+      result;
+    optionFromOptions[`${validateHeaderOption.id}`] = true;
+    transactionValidator = new HeadersValidator();
+    result = transactionValidator.validate([], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
+    expect(result).to.be.an('Array');
+    expect(result[0]).to.be.an('object').and.to.deep.include({
+      property: 'HEADER',
+      transactionJsonPath: '$.request.header',
+      schemaJsonPath: 'schemaPathPrefix',
+      reasonCode: 'MISSING_IN_REQUEST',
+      reason: 'The header "Content-Type" was not found in the transaction'
+    });
+  });
+
+  it('Should return bad header mismatch when validateHeader option' +
+  ' is true and content-type header is not text/xml',
+  function () {
+    const options = getOptions({
+        usage: ['VALIDATION']
+      }),
+      validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
+    let optionFromOptions = {},
+      transactionValidator,
+      result;
+    optionFromOptions[`${validateHeaderOption.id}`] = true;
+    transactionValidator = new HeadersValidator();
+    result = transactionValidator.validate([{
+      'key': 'Content-Type',
+      'value': 'text/plain; charset=utf-8'
+    }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', true, false, optionFromOptions);
+    expect(result).to.be.an('Array');
+    expect(result[0]).to.be.an('object').and.to.deep.include({
+      property: 'HEADER',
+      transactionJsonPath: '$.request.header[0].value',
+      schemaJsonPath: 'schemaPathPrefix',
+      reasonCode: 'INVALID_TYPE',
+      reason: 'The header \"Content-Type\" needs to be \"text/xml\" but we ' +
+        'found \"text/plain; charset=utf-8\" instead'
+    });
+  });
+
+  it('Should not return missing header when validateHeader option is not provided' +
+  ' and not content-type header is present',
+  function () {
+    const transactionValidator = new HeadersValidator(),
+      result = transactionValidator.validate([], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', false, false, {});
+    expect(result).to.be.an('array');
+    expect(result.length).to.eq(0);
+  });
+
+  it('Should not return bad header mismatch when validateHeader option' +
+  ' is false and content-type header is not text/xml',
+  function () {
+    const transactionValidator = new HeadersValidator(),
+      result = transactionValidator.validate([{
+        'key': 'Content-Type',
+        'value': 'text/plain; charset=utf-8'
+      }], 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0', false, false, {});
+    expect(result).to.be.an('array');
+    expect(result.length).to.eq(0);
+  });
+
+});

--- a/test/unit/transactionValidator/MethodValidator.test.js
+++ b/test/unit/transactionValidator/MethodValidator.test.js
@@ -1,0 +1,30 @@
+const {
+    expect
+  } = require('chai'),
+  {
+    MethodValidator
+  } = require('../../../lib/transactionValidator/MethodValidator');
+
+describe('Method validator', function() {
+  it('Should have a mismatch when item request has a different method than POST in a /soap12 request', function() {
+    const transactionValidator = new MethodValidator(),
+      result = transactionValidator.validate('soap12', 'GET', { xpathInfo: { xpath: 'xpath' } });
+    expect(result[0]).to.be.an('object').and.to.deep.include({
+      'property': 'SOAP_METHOD',
+      'reason': 'Soap requests must use POST method.',
+      'reasonCode': 'INVALID_SOAP_METHOD',
+      'schemaJsonPath': 'xpath',
+      'transactionJsonPath': '$.request.method'
+    });
+  });
+
+  it('Shouldn\'t  have a mismatch when item request has a different method than POST in a /soap12 request' +
+      ' and option validationPropertiesToIgnore has "HTTP_METHOD"', function() {
+    const transactionValidator = new MethodValidator(),
+      result = transactionValidator.validate('soap12', 'GET', { xpathInfo: { xpath: 'xpath' } },
+        ['SOAP_METHOD']
+      );
+    expect(result).to.be.an('Array');
+    expect(result.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Separate the transactionValidator into a more semantic classes with single responsibility

added also support for application/soap+xml content type header