### PR TITLE
Issue/10160

### DIFF
--- a/lib/XSDToJsonSchemaParser.js
+++ b/lib/XSDToJsonSchemaParser.js
@@ -45,10 +45,9 @@ class XSDToJsonSchemaParser {
       convertedSchemas,
       jsonSchemas = [];
     const xs2js = new Xsd2JsonSchema();
-    for (let index = 0; index < schemas.length; index++) {
-      const schema = schemas[index];
+    schemas.forEach((schema, index) => {
       schemasToParse[`schema_${index}.xsd`] = schema;
-    }
+    });
     try {
       convertedSchemas = xs2js.processAllSchemas({ schemas: schemasToParse });
       for (let index = 0; index < schemas.length; index++) {

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -96,7 +96,8 @@ class SchemaBuilderXSD {
         schemaStrings = [];
       schemaTags = this.getSchemasInformation(type, wsdlObject, parserPlaceholder);
 
-      const orderedSchemas = orderSchemasAccordingToDependencies(schemaTags, parserPlaceholder);
+      const orderedSchemas = orderSchemasAccordingToDependencies(schemaTags, parserPlaceholder,
+        wsdlObject.allNameSpaces);
 
       orderedSchemas.forEach((schemaTag) => {
 
@@ -1034,7 +1035,8 @@ class SchemaBuilderXSD {
       property.properties = complexType;
       property.type = 'complex';
       property.complexName = complexType.name;
-      if (property.name !== property.properties.name) {
+      if (property.name !== property.properties.name &&
+              !this.isSelfReferenceElement(property.properties, type)) {
         this.searchAndAssignComplex(property.properties, complexTypes, simpleTypes,
           elements);
       }
@@ -1053,6 +1055,31 @@ class SchemaBuilderXSD {
         this.processSimpleTypeSchema(type, simpleTypes, property, complexTypes, elements);
       }
     }
+  }
+
+  /**
+   * Identifies if an element has a reference to itself to avoid infinit loop
+   * @param {object} elementProperties the properties of the root parent
+   * @param {string} complexTypeName the name of the type
+   * @returns {Boolean} true if the element has a reference to itself otherwise false
+   */
+  isSelfReferenceElement(elementProperties, complexTypeName) {
+    let isSelfReference = false;
+    traverseUtility(elementProperties).forEach((property) => {
+      if (property) {
+        let hasReferenceTypeKey;
+        hasReferenceTypeKey = Object.keys(property)
+          .find(
+            (key) => {
+              return key === '$ref' && property[key] !== undefined;
+            }
+          );
+        if (hasReferenceTypeKey && property.$ref !== null && property.$ref === complexTypeName) {
+          isSelfReference = true;
+        }
+      }
+    });
+    return isSelfReference;
   }
 
   /**

--- a/lib/utils/knownTypes.js
+++ b/lib/utils/knownTypes.js
@@ -322,7 +322,7 @@ let knownTypes = {
  * @returns {boolean} wether is a known type or not
  */
 function isKnownType(type) {
-  if (!type) {
+  if (!type || typeof type === 'object') {
     return false;
   }
   let filterType = type.includes(XML_NAMESPACE_SEPARATOR) ? type.split(XML_NAMESPACE_SEPARATOR)[1] : type;

--- a/lib/utils/orderSchemasByDependency.js
+++ b/lib/utils/orderSchemasByDependency.js
@@ -67,7 +67,7 @@ function pushIndependent(
 * @returns {object} the found namespace
 */
 function getNotCommonNamespaces(allNameSpaces) {
-  let commonNamespaces = ['targetNamespace', 'xmlns', 'soap', 'xsd', 'tns'];
+  let commonNamespaces = ['targetNamespace', 'xmlns', 'soap', 'xsd', 'tns', 'soap12'];
   if (allNameSpaces) {
     return allNameSpaces.filter((namespace) => { return !commonNamespaces.includes(namespace.key); });
   }
@@ -82,11 +82,12 @@ function getNotCommonNamespaces(allNameSpaces) {
 *
 * @param {Array} schemaAndInformation array of elements from the xsd2json
 * @param {Array} namespacesFromWSDL schemas with no imports to fill
+* @param {string} attributePlaceHolder parser character for attributes
 * @returns {undefined} nothing
 */
-function assignNamespacesToSchema(schemaAndInformation, namespacesFromWSDL) {
+function assignNamespacesToSchema(schemaAndInformation, namespacesFromWSDL, attributePlaceHolder) {
   namespacesFromWSDL.forEach((namespace) => {
-    schemaAndInformation.foundSchemaTag[`@_xmlns:${namespace.key}`] = namespace.url;
+    schemaAndInformation.foundSchemaTag[`${attributePlaceHolder}_xmlns:${namespace.key}`] = namespace.url;
   });
 }
 
@@ -128,7 +129,7 @@ function processSchema(schemaAndInformation, independent, attributePlaceHolder, 
         });
       schemaAndInformation.dependencies.add(
         getXMLAttributeByName(importElement, attributePlaceHolder, 'namespace'));
-      assignNamespacesToSchema(schemaAndInformation, namespacesFromWSDL);
+      assignNamespacesToSchema(schemaAndInformation, namespacesFromWSDL, attributePlaceHolder);
       if (toProcess && parentTargetNamespace !== importedName) {
         processSchema(toProcess, independent, attributePlaceHolder, dependent, schemasToOrderInformation,
           schemaAndInformation.targetNamespace, allNameSpaces);

--- a/lib/utils/orderSchemasByDependency.js
+++ b/lib/utils/orderSchemasByDependency.js
@@ -68,7 +68,10 @@ function pushIndependent(
 */
 function getNotCommonNamespaces(allNameSpaces) {
   let commonNamespaces = ['targetNamespace', 'xmlns', 'soap', 'xsd', 'tns'];
-  return allNameSpaces.filter((namespace) => { return !commonNamespaces.includes(namespace.key); });
+  if (allNameSpaces) {
+    return allNameSpaces.filter((namespace) => { return !commonNamespaces.includes(namespace.key); });
+  }
+  return [];
 }
 
 /**

--- a/lib/utils/orderSchemasByDependency.js
+++ b/lib/utils/orderSchemasByDependency.js
@@ -60,6 +60,35 @@ function pushIndependent(
 
 /**
 *
+* @description returns the namespace from the WSDL
+*
+* @param {Array} allNameSpaces array of all the namespaces in wsdl definition
+* @param {string} url the url to search the namespace
+* @returns {object} the found namespace
+*/
+function getNotCommonNamespaces(allNameSpaces) {
+  let commonNamespaces = ['targetNamespace', 'xmlns', 'soap', 'xsd', 'tns'];
+  return allNameSpaces.filter((namespace) => { return !commonNamespaces.includes(namespace.key); });
+}
+
+/**
+*
+* @description takes an schema element
+* from xsd2json and determines if has imports or not
+* if has imports call again with dependencies
+*
+* @param {Array} schemaAndInformation array of elements from the xsd2json
+* @param {Array} namespacesFromWSDL schemas with no imports to fill
+* @returns {undefined} nothing
+*/
+function assignNamespacesToSchema(schemaAndInformation, namespacesFromWSDL) {
+  namespacesFromWSDL.forEach((namespace) => {
+    schemaAndInformation.foundSchemaTag[`@_xmlns:${namespace.key}`] = namespace.url;
+  });
+}
+
+/**
+*
 * @description takes an schema element
 * from xsd2json and determines if has imports or not
 * if has imports call again with dependencies
@@ -69,9 +98,12 @@ function pushIndependent(
 * @param {string} attributePlaceHolder parser character for attributes
 * @param {Array} dependent array of schemas with imports
 * @param {Array} schemasToOrderInformation all the schemas to order
+* @param {string} parentTargetNamespace the target namespace of the schema that depends of the current schema
+* @param {Array} allNameSpaces array of all the namespaces in wsdl definition
 * @returns {undefined} nothing
 */
-function processSchema(schemaAndInformation, independent, attributePlaceHolder, dependent, schemasToOrderInformation) {
+function processSchema(schemaAndInformation, independent, attributePlaceHolder, dependent, schemasToOrderInformation,
+  parentTargetNamespace, allNameSpaces) {
   let imports,
     schema = schemaAndInformation.foundSchemaTag,
     namespace = schemaAndInformation.foundLocalSchemaNamespace;
@@ -87,13 +119,16 @@ function processSchema(schemaAndInformation, independent, attributePlaceHolder, 
   if (imports && imports.length > 0) {
     imports.forEach((importElement) => {
       let importedName = getXMLAttributeByName(importElement, attributePlaceHolder, 'namespace'),
+        namespacesFromWSDL = getNotCommonNamespaces(allNameSpaces, importedName),
         toProcess = schemasToOrderInformation.find((schema) => {
           return schema.targetNamespace === importedName;
         });
       schemaAndInformation.dependencies.add(
         getXMLAttributeByName(importElement, attributePlaceHolder, 'namespace'));
-      if (toProcess) {
-        processSchema(toProcess, independent, attributePlaceHolder, dependent, schemasToOrderInformation);
+      assignNamespacesToSchema(schemaAndInformation, namespacesFromWSDL);
+      if (toProcess && parentTargetNamespace !== importedName) {
+        processSchema(toProcess, independent, attributePlaceHolder, dependent, schemasToOrderInformation,
+          schemaAndInformation.targetNamespace, allNameSpaces);
       }
     });
     pushDependentInOrder({
@@ -111,17 +146,19 @@ function processSchema(schemaAndInformation, independent, attributePlaceHolder, 
 *
 * @param {Array} schemasToOrderInformation array of elements from the xsd2json
 * @param {string} attributePlaceHolder parser character for attributes
+* @param {Array} allNameSpaces array of all the namespaces in wsdl definition
 * @returns {string} validation
 */
-function orderSchemasAccordingToDependencies(schemasToOrderInformation, attributePlaceHolder) {
+function orderSchemasAccordingToDependencies(schemasToOrderInformation, attributePlaceHolder,
+  allNameSpaces) {
   let independent = [],
     dependent = [];
   schemasToOrderInformation.forEach((schemaAndInformation) => {
-    processSchema(schemaAndInformation, independent, attributePlaceHolder, dependent, schemasToOrderInformation);
+    processSchema(schemaAndInformation, independent, attributePlaceHolder, dependent,
+      schemasToOrderInformation, undefined, allNameSpaces);
   });
   return independent.concat(dependent);
 }
-
 
 module.exports = {
   orderSchemasAccordingToDependencies


### PR DESCRIPTION
Refer to the issue: https://github.com/postmanlabs/postman-app-support/issues/10160

This file has the next characteristics

1. Has an schema with an import, and the imported schema has an import of the first schema, this ended up in an infinite loop.
  Schema 1 imports schema 2 and schema 2 imports schema 1.
Modified the cicle to prevent the application to fail

2. Schemas that import other schemas does not have the corresponding namespace of the imported schema
  e.g. 
```
<definitions targetNamespace="some:uri:ns"
             xmlns:eons="some:uri">
    <types>
        <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="some:uri:ns">**// missing  xmlns:eons="some:uri"**
            <import namespace="some:uri"/>
            <complexType name="Type">
                <complexContent>
                    <extension base="**ons:**base">
....
```

When you do not have the namespace definition locally the xsd2json library can't locate the type so now we add al namespaces definitions into the schemas to prevent the error.

3. This file has an element with a self reference
```
<complexType name="SomeType">
                <sequence>
                    <element name="children" type="SomeType" minOccurs="0" maxOccurs="unbounded"/>
                    <element name="label"           type="xsd:string"/>
                </sequence>
            </complexType>
```
this was leading us to a infinite loop
Added a stop condition to prevent this scenario.