### PR TITLE
Import same namespace

### DIFF
--- a/lib/WSDLParserFactory.js
+++ b/lib/WSDLParserFactory.js
@@ -13,6 +13,16 @@ const V11 = '1.1',
  * depending on the input file
  */
 class WSDLParserFactory {
+
+  /**
+   * Creates a concrete implementation of the parser
+   * depending on the input file
+   * definitions for v 1.1
+   * description for v 2.0
+   * @param {string} xmlDocumentContent the content file in string
+   * @returns {object} the concrete parser for each case throws error
+   * if not found
+   */
   getParser(xmlDocumentContent) {
     let version = this.getWsdlVersion(xmlDocumentContent);
     if (version === V11) {
@@ -26,8 +36,21 @@ class WSDLParserFactory {
    * depending on the input file
    * definitions for v 1.1
    * description for v 2.0
-   * @param {string} xmlDocumentContent the content file in string
+   * @param {string} version the document version
    * @returns {object} the concrete parser for each case throws error
+   * if not found
+   */
+  getParserByVersion(version) {
+    if (version === V11) {
+      return new WsdlParser(new WsdlInformationService11());
+    }
+    return new WsdlParser(new WsdlInformationService20());
+  }
+
+  /**
+   * Gets the WSDL Version
+   * @param {string} xmlDocumentContent the content file in string
+   * @returns {string} the version of the WSDL
    * if not found
    */
   getWsdlVersion(xmlDocumentContent) {
@@ -43,6 +66,12 @@ class WSDLParserFactory {
     throw new WsdlError('Not WSDL Specification found in your document');
   }
 
+  /**
+   * Gets the WSDL Version
+   * @param {string} xmlDocumentContent the content file in string
+   * @returns {string} the version of the WSDL
+   * if not found
+   */
   getSafeWsdlVersion(xmlDocumentContent) {
     if (!xmlDocumentContent) {
       throw new WsdlError('Empty input was proportionated');

--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -49,7 +49,8 @@ const
     getAttributeByName,
     THIS_NS_PREFIX,
     getDocumentationStringFromNode,
-    excludeSeparatorFromName
+    excludeSeparatorFromName,
+    SERVICE_TAG
   } = require('./WsdlParserCommon'),
   {
     getQNamePrefixFilter,
@@ -95,6 +96,9 @@ class WsdlInformationService11 {
     this.THISNamespaceKey = TNS_NS_KEY;
     this.TargetNamespaceKey = TARGETNAMESPACE_KEY;
     this.XMLPolicyURL = XML_POLICY;
+    this.AbstractInterfaceTag = PORT_TYPE_TAG;
+    this.ConcreteInterfaceTag = BINDING_TAG;
+    this.ConcreteServiceTag = SERVICE_TAG;
   }
 
   /**

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -3,7 +3,8 @@ const
     getNodeByName,
     getAttributeByName,
     THIS_NS_PREFIX,
-    getDocumentationStringFromNode
+    getDocumentationStringFromNode,
+    SERVICE_TAG
   } = require('./WsdlParserCommon'),
   {
     getArrayFrom
@@ -79,6 +80,9 @@ class WsdlInformationService20 {
     this.THISNamespaceKey = TNS_NS_KEY;
     this.TargetNamespaceKey = TARGETNAMESPACE_KEY;
     this.XMLPolicyURL = XML_POLICY;
+    this.AbstractInterfaceTag = INTERFACE_TAG;
+    this.ConcreteInterfaceTag = BINDING_TAG;
+    this.ConcreteServiceTag = SERVICE_TAG;
 
   }
 

--- a/lib/constants/XSDConstants.js
+++ b/lib/constants/XSDConstants.js
@@ -1,0 +1,11 @@
+const COMPLEX_TYPE_TAG = 'complexType',
+  GROUP_TAG = 'group',
+  SIMPLE_TYPE_TAG = 'simpleType',
+  ATTRIBUTE_ELEMENT = 'element';
+
+module.exports = {
+  COMPLEX_TYPE_TAG,
+  GROUP_TAG,
+  SIMPLE_TYPE_TAG,
+  ATTRIBUTE_ELEMENT
+};

--- a/lib/constants/messageConstants.js
+++ b/lib/constants/messageConstants.js
@@ -7,7 +7,8 @@ const DOC_HAS_NO_SERVICE_MESSAGE = 'Could not found services in document the ite
   MULTIPLE_ROOT_FILES = 'There are multiple files with services defined.',
   NOT_WSDL_IN_FOLDER = 'There was not WSDL file in folder.',
   WSDL_DIFF_VERSION = 'All WSDLs must be the same version.',
-  MISSING_XML_PARSER = 'XMLParser should be proportionated.';
+  MISSING_XML_PARSER = 'XMLParser should be proportionated.',
+  MISSING_ROOT_FILE = 'There was not WSDL with services and imports in the folder';
 
 module.exports = {
   DOC_HAS_NO_SERVICE_MESSAGE,
@@ -19,5 +20,6 @@ module.exports = {
   MULTIPLE_ROOT_FILES,
   NOT_WSDL_IN_FOLDER,
   WSDL_DIFF_VERSION,
-  MISSING_XML_PARSER
+  MISSING_XML_PARSER,
+  MISSING_ROOT_FILE
 };

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -29,17 +29,20 @@ const Parser = require('fast-xml-parser').j2xParser,
   {
     isKnownType
   } = require('./knownTypes'),
+  {
+    COMPLEX_TYPE_TAG,
+    GROUP_TAG,
+    SIMPLE_TYPE_TAG,
+    ATTRIBUTE_ELEMENT
+  } = require('../constants/XSDConstants'),
+
   TYPES_TAG = 'types',
   ATTRIBUTE_TARGET_NAMESPACE = 'targetNamespace',
   SCHEMA_TAG = 'schema',
   MESSAGE_TAG = 'message',
-  COMPLEX_TYPE_TAG = 'complexType',
-  GROUP_TAG = 'group',
-  SIMPLE_TYPE_TAG = 'simpleType',
   ATTRIBUTE_NAME = 'name',
   ATTRIBUTE_PART = 'part',
   ATTRIBUTE_TYPE = 'type',
-  ATTRIBUTE_ELEMENT = 'element',
   traverseUtility = require('traverse'),
   IS_KNOWN_TYPE = 'knownType',
   IS_ELEMENT = 'isElement',

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -30,7 +30,13 @@ const
     NOT_WSDL_IN_FOLDER,
     WSDL_DIFF_VERSION,
     MISSING_XML_PARSER
-  } = require('../constants/messageConstants');
+  } = require('../constants/messageConstants'),
+  {
+    COMPLEX_TYPE_TAG,
+    GROUP_TAG,
+    SIMPLE_TYPE_TAG,
+    ATTRIBUTE_ELEMENT
+  } = require('../constants/XSDConstants');
 
 var path = require('path'),
   pathBrowserify = require('path-browserify');
@@ -98,9 +104,11 @@ class WSDLMerger {
    * @param {object} parsedSchemas the array of parsed xmls
    * @param {string} wsdlRoot the wsdl root according to the version
    * @param {string} attributePlaceHolder the character for attributes according the xml parser
+   * @param {object} wsdlParser the WSDL parser according to WSDL version
    * @returns {object} the root
    */
-  resolveImportsFromRootFile(WSDLRootFile, parsedWSDL, parsedSchemas, wsdlRoot, attributePlaceHolder) {
+  resolveImportsFromRootFile(WSDLRootFile, parsedWSDL, parsedSchemas, wsdlRoot, attributePlaceHolder,
+    wsdlParser) {
     let principalPrefix = getPrincipalPrefix(WSDLRootFile, wsdlRoot),
       imports = getWSDLImports(WSDLRootFile, principalPrefix, wsdlRoot);
     imports.forEach((importInformation) => {
@@ -114,7 +122,7 @@ class WSDLMerger {
       );
       if (importedFound.found) {
         this.assignImportedProperties(WSDLRootFile, importedFound, parsedWSDL, parsedSchemas, wsdlRoot,
-          principalPrefix, attributePlaceHolder);
+          principalPrefix, attributePlaceHolder, wsdlParser);
       }
     });
     return WSDLRootFile;
@@ -129,6 +137,7 @@ class WSDLMerger {
    * @param {string} wsdlRoot the wsdl root according to the version
    * @param {string} principalPrefix the wsdl principal prefix
    * @param {string} attributePlaceHolder the character for attributes according the xml parser
+   * @param {object} wsdlParser the WSDL parser according to WSDL version
    * @returns {object} the root
    */
   assignImportedPropertiesDefinitions(
@@ -138,7 +147,8 @@ class WSDLMerger {
     parsedSchemas,
     wsdlRoot,
     principalPrefix,
-    attributePlaceHolder
+    attributePlaceHolder,
+    wsdlParser
   ) {
     let definitionsProperty = importedTag[principalPrefix + wsdlRoot],
       hasImports = wsdlHasImports(importedTag, principalPrefix, wsdlRoot);
@@ -147,18 +157,17 @@ class WSDLMerger {
         attributePlaceHolder);
     }
     Object.keys(definitionsProperty).forEach((importedProperty) => {
-      let rootProperty = root[principalPrefix + wsdlRoot][importedProperty],
-        importedPropertyValue = importedTag[principalPrefix + wsdlRoot][importedProperty];
-      if (importedProperty === principalPrefix + 'portType' ||
-        importedProperty === principalPrefix + 'binding' ||
-        importedProperty === principalPrefix + 'service' ||
-        importedProperty === principalPrefix + 'types') {
+      let rootProperty = getNodeByName(root[principalPrefix + wsdlRoot], '', importedProperty),
+        importedPropertyValue = getNodeByName(importedTag[principalPrefix + wsdlRoot], '', importedProperty);
+      if (importedProperty === principalPrefix + wsdlParser.informationService.AbstractInterfaceTag ||
+        importedProperty === principalPrefix + wsdlParser.informationService.ConcreteInterfaceTag ||
+        importedProperty === principalPrefix + SERVICE_TAG ||
+        importedProperty === principalPrefix + ATTRIBUTE_TYPES) {
         this.mergeProperty(root, principalPrefix, wsdlRoot, rootProperty,
           importedProperty, importedPropertyValue);
       }
-      else if (!root[principalPrefix + wsdlRoot][importedProperty]) {
-        root[principalPrefix + wsdlRoot][importedProperty] =
-          importedTag[principalPrefix + wsdlRoot][importedProperty];
+      else if (!rootProperty) {
+        root[principalPrefix + wsdlRoot][importedProperty] = importedPropertyValue;
       }
     });
   }
@@ -211,18 +220,15 @@ class WSDLMerger {
       root[principalPrefix + wsdlRoot][principalPrefix + ATTRIBUTE_TYPES] = [];
       root[principalPrefix + wsdlRoot][principalPrefix + ATTRIBUTE_TYPES].push(importedTag);
     }
-
     else {
       let schemasInType = getArrayFrom(getNodeByQNameLocal(existingTypes[0], SCHEMA_TAG)).filter((schema) => {
         return !schema === importedTag;
       });
       schemasInType.push(schemaProperty);
-
       schemasInType.forEach((schemaInType) => {
         let typesInRoot = root[principalPrefix + wsdlRoot][principalPrefix + ATTRIBUTE_TYPES],
           targetType,
           schemasFromType;
-
         if (Array.isArray(typesInRoot)) {
           targetType = typesInRoot[0];
         }
@@ -266,44 +272,73 @@ class WSDLMerger {
     });
   }
 
-  checkAndMergeSchemas(root, imported, schemaPrefix) {
-    let willMerge = this.isSameNamspaceSchema(root, imported);
+
+  /**
+   * Gets the import information and assign it to the root
+   * @param {object} rootSchema the root file parsed
+   * @param {object} importedSchema the imported tag object
+   * @param {string} schemaPrefix the namespace prefix from the schema
+   * @returns {object} undefined
+   */
+  checkAndMergeSchemas(rootSchema, importedSchema, schemaPrefix) {
+    let willMerge = this.isSameNamespaceSchema(rootSchema, importedSchema);
     if (willMerge) {
-      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'complexType', root[schemaPrefix + 'complexType'],
-        imported[schemaPrefix + 'complexType']);
-      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'element', root[schemaPrefix + 'element'],
-        imported[schemaPrefix + 'element']);
-      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'group', root[schemaPrefix + 'group'],
-        imported[schemaPrefix + 'group']);
-      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'simpleType', root[schemaPrefix + 'simpleType'],
-        imported[schemaPrefix + 'simpleType']);
-      this.mergePropertiesFromImportedToRootSchema(root, imported);
+      this.mergeTypesFromImportedToRootSchema(rootSchema, schemaPrefix + COMPLEX_TYPE_TAG,
+        rootSchema[schemaPrefix + COMPLEX_TYPE_TAG], importedSchema[schemaPrefix + COMPLEX_TYPE_TAG]);
+      this.mergeTypesFromImportedToRootSchema(rootSchema, schemaPrefix + ATTRIBUTE_ELEMENT,
+        rootSchema[schemaPrefix + ATTRIBUTE_ELEMENT], importedSchema[schemaPrefix + ATTRIBUTE_ELEMENT]);
+      this.mergeTypesFromImportedToRootSchema(rootSchema, schemaPrefix + GROUP_TAG,
+        rootSchema[schemaPrefix + GROUP_TAG], importedSchema[schemaPrefix + GROUP_TAG]);
+      this.mergeTypesFromImportedToRootSchema(rootSchema, schemaPrefix + SIMPLE_TYPE_TAG,
+        rootSchema[schemaPrefix + SIMPLE_TYPE_TAG], importedSchema[schemaPrefix + SIMPLE_TYPE_TAG]);
+      this.mergePropertiesFromImportedToRootSchema(rootSchema, importedSchema);
       return true;
     }
     return false;
   }
 
-  mergePropertiesFromImportedToRootSchema(root, imported) {
-    Object.keys(imported).forEach((importedProperty) => {
-      let hasProperty = Object.keys(root).find((rootProperty) => { return rootProperty === importedProperty; });
+  /**
+   * Gets the import information and assign it to the root
+   * @param {object} rootSchema the root file parsed
+   * @param {object} importedSchema the imported tag object
+   * @param {string} schemaPrefix the namespace prefix from the schema
+   * @returns {object} undefined
+   */
+  mergePropertiesFromImportedToRootSchema(rootSchema, importedSchema) {
+    Object.keys(importedSchema).forEach((importedProperty) => {
+      let hasProperty = Object.keys(rootSchema).find((rootProperty) => { return rootProperty === importedProperty; });
       if (!hasProperty) {
-        root[importedProperty] = imported[importedProperty];
+        rootSchema[importedProperty] = importedSchema[importedProperty];
       }
     });
   }
 
-  mergeTypesFromImportedToRootSchema(root, rootPropertyFullName, rootPropertyValue, importedPropertyValue) {
+  /**
+   *  Merge the types from the imported tag to the root
+   * @param {object} rootSchema the root file parsed
+   * @param {string} rootPropertyFullName the root property name to merge with prefix
+   * @param {object} rootPropertyValue the root property value
+   * @param {object} importedPropertyValue the imported tag object value
+   * @param {string} schemaPrefix the namespace prefix from the schema
+   * @returns {object} undefined
+   */
+  mergeTypesFromImportedToRootSchema(rootSchema, rootPropertyFullName, rootPropertyValue, importedPropertyValue) {
     if (rootPropertyValue && Array.isArray(rootPropertyValue)) {
       arrayProperties.push(...importedPropertyValue);
     }
     else {
-      root[rootPropertyFullName] = importedPropertyValue;
+      rootSchema[rootPropertyFullName] = importedPropertyValue;
     }
   }
 
-
-  isSameNamspaceSchema(root, imported) {
-    let rootTargetNamespace = getAttributeByName(root, TARGET_NAMESPACE_SPEC),
+  /**
+   *  identifies if the root schema and the imported have the same target namespace
+   * @param {object} rootSchema the root file parsed
+   * @param {string} imported the imported schema
+   * @returns {object} undefined
+   */
+  isSameNamespaceSchema(rootSchema, imported) {
+    let rootTargetNamespace = getAttributeByName(rootSchema, TARGET_NAMESPACE_SPEC),
       importedtargetNamespace = getAttributeByName(imported, TARGET_NAMESPACE_SPEC);
     if (rootTargetNamespace !== '' && importedtargetNamespace !== '') {
       return rootTargetNamespace === importedtargetNamespace;
@@ -317,13 +352,14 @@ class WSDLMerger {
    * @param {object} importedTag the imported tag object
    * @param {object} parsedWSDL the array of parsed xmls
    * @param {object} parsedSchemas the array of parsed xmls
-   * @param {string} wsdlRoot the wsdl root according to the version
-   * @param {object} principalPrefix the wsdl principal prefix
+   * @param {string} wsdlRoot the WSDL root according to the version
+   * @param {object} principalPrefix the WSDL principal prefix
    * @param {string} attributePlaceHolder the character for attributes according the xml parser
+   * @param {object} wsdlParser the WSDL parser according to WSDL version
    * @returns {object} the root
    */
   assignImportedProperties(WSDLRootFile, importedTag, parsedWSDL, parsedSchemas, wsdlRoot, principalPrefix,
-    attributePlaceHolder) {
+    attributePlaceHolder, wsdlParser) {
     let isWSDLDefinition = importedTag.found[principalPrefix + wsdlRoot];
     if (isWSDLDefinition) {
       this.assignImportedPropertiesDefinitions(
@@ -333,7 +369,8 @@ class WSDLMerger {
         parsedSchemas,
         wsdlRoot,
         principalPrefix,
-        attributePlaceHolder
+        attributePlaceHolder,
+        wsdlParser
       );
     }
     else {
@@ -408,27 +445,30 @@ class WSDLMerger {
       rootFiles,
       parsedWSDL,
       wsdlVersion,
-      parsedXML,
+      parsedXMLs,
+      wsdlParser,
       wsdlRoot = '';
     if (!xmlParser) {
       throw new WsdlError(MISSING_XML_PARSER);
     }
-    parsedXML = contentFiles.map((file) => {
+    parsedXMLs = contentFiles.map((file) => {
       return xmlParser.safeParseToObject(file);
     }).filter((parsed) => {
       return parsed !== '';
     });
 
     wsdlVersion = this.getFilesVersion(contentFiles);
+    wsdlParser = this.getWSDLParser(wsdlVersion);
     wsdlRoot = wsdlVersion === V11 ? 'definitions' : 'description';
-    parsedSchemas = this.getParsedSchemasFromAllParsed(parsedXML);
-    parsedWSDL = this.getParsedWSDLFromAllParsed(parsedXML, wsdlRoot);
+    parsedSchemas = this.getParsedSchemasFromAllParsed(parsedXMLs);
+    parsedWSDL = this.getParsedWSDLFromAllParsed(parsedXMLs, wsdlRoot);
     rootFiles = this.getRoot(parsedWSDL, wsdlRoot);
     if (rootFiles && rootFiles.length > 1) {
       throw new WsdlError(MULTIPLE_ROOT_FILES);
     }
     root = rootFiles[0];
-    this.resolveImportsFromRootFile(root, parsedWSDL, parsedSchemas, wsdlRoot, xmlParser.attributePlaceHolder);
+    this.resolveImportsFromRootFile(root, parsedWSDL, parsedSchemas, wsdlRoot, xmlParser.attributePlaceHolder,
+      wsdlParser);
     return xmlParser.parseObjectToXML(root);
   }
 
@@ -495,6 +535,16 @@ class WSDLMerger {
       }
       return filtered[0];
     }
+  }
+
+  /**
+   * Gets the wsdl parser accordint to the version
+   * @param {string} version the files content in strings array
+   * @returns {object} the WSDL Parser
+   */
+  getWSDLParser(version) {
+    let parserFactory = new WSDLParserFactory();
+    return parserFactory.getParserByVersion(version);
   }
 
   /** Read File asynchronously

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -150,9 +150,9 @@ class WSDLMerger {
       let rootProperty = root[principalPrefix + wsdlRoot][importedProperty],
         importedPropertyValue = importedTag[principalPrefix + wsdlRoot][importedProperty];
       if (importedProperty === principalPrefix + 'portType' ||
-          importedProperty === principalPrefix + 'binding' ||
-          importedProperty === principalPrefix + 'service' ||
-          importedProperty === principalPrefix + 'types') {
+        importedProperty === principalPrefix + 'binding' ||
+        importedProperty === principalPrefix + 'service' ||
+        importedProperty === principalPrefix + 'types') {
         this.mergeProperty(root, principalPrefix, wsdlRoot, rootProperty,
           importedProperty, importedPropertyValue);
       }
@@ -180,7 +180,7 @@ class WSDLMerger {
     }
     let arrayProperties = [rootProperty];
     if (Array.isArray(importedPropertyValue)) {
-      arrayProperties.push(... importedPropertyValue);
+      arrayProperties.push(...importedPropertyValue);
     }
     else {
       arrayProperties.push(importedPropertyValue);
@@ -232,11 +232,26 @@ class WSDLMerger {
         schemasFromType = targetType[schemaPrefix + SCHEMA_TAG];
         if (schemasFromType &&
           Array.isArray(schemasFromType)) {
-          schemasFromType.push(schemaInType);
+          let schemasToPush = [];
+          schemasFromType.forEach((existingSchema) => {
+            let wasMerged = this.checkAndMergeSchemas(existingSchema, schemaInType, schemaPrefix, targetType);
+            if (!wasMerged) {
+              let alreadyAdded = schemasToPush.find((added) => {
+                return added === schemaInType;
+              });
+              if (!alreadyAdded) {
+                schemasToPush.push(schemaInType);
+              }
+            }
+          });
+          schemasFromType.push(...schemasToPush);
         }
         else if (schemasFromType) {
-          let arraySchemas = [schemasFromType, schemaInType];
-          targetType[schemaPrefix + SCHEMA_TAG] = arraySchemas;
+          let wasMerged = this.checkAndMergeSchemas(schemasFromType, schemaInType, schemaPrefix, targetType);
+          if (!wasMerged) {
+            let arraySchemas = [schemasFromType, schemaInType];
+            targetType[schemaPrefix + SCHEMA_TAG] = arraySchemas;
+          }
         }
         else {
           targetType[schemaPrefix + SCHEMA_TAG] = schemaInType;
@@ -249,6 +264,51 @@ class WSDLMerger {
         this.resolveImportsFromRootFile(importedTag, parsedWSDL, parsedSchemas, principalPrefix, attributePlaceHolder);
       }
     });
+  }
+
+  checkAndMergeSchemas(root, imported, schemaPrefix) {
+    let willMerge = this.isSameNamspaceSchema(root, imported);
+    if (willMerge) {
+      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'complexType', root[schemaPrefix + 'complexType'],
+        imported[schemaPrefix + 'complexType']);
+      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'element', root[schemaPrefix + 'element'],
+        imported[schemaPrefix + 'element']);
+      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'group', root[schemaPrefix + 'group'],
+        imported[schemaPrefix + 'group']);
+      this.mergeTypesFromImportedToRootSchema(root, schemaPrefix + 'simpleType', root[schemaPrefix + 'simpleType'],
+        imported[schemaPrefix + 'simpleType']);
+      this.mergePropertiesFromImportedToRootSchema(root, imported);
+      return true;
+    }
+    return false;
+  }
+
+  mergePropertiesFromImportedToRootSchema(root, imported) {
+    Object.keys(imported).forEach((importedProperty) => {
+      let hasProperty = Object.keys(root).find((rootProperty) => { return rootProperty === importedProperty; });
+      if (!hasProperty) {
+        root[importedProperty] = imported[importedProperty];
+      }
+    });
+  }
+
+  mergeTypesFromImportedToRootSchema(root, rootPropertyFullName, rootPropertyValue, importedPropertyValue) {
+    if (rootPropertyValue && Array.isArray(rootPropertyValue)) {
+      arrayProperties.push(...importedPropertyValue);
+    }
+    else {
+      root[rootPropertyFullName] = importedPropertyValue;
+    }
+  }
+
+
+  isSameNamspaceSchema(root, imported) {
+    let rootTargetNamespace = getAttributeByName(root, TARGET_NAMESPACE_SPEC),
+      importedtargetNamespace = getAttributeByName(imported, TARGET_NAMESPACE_SPEC);
+    if (rootTargetNamespace !== '' && importedtargetNamespace !== '') {
+      return rootTargetNamespace === importedtargetNamespace;
+    }
+    return false;
   }
 
   /**

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -10,7 +10,6 @@ const
     getAttributeByName,
     getNodeByQNameLocal,
     getSchemaPrefixFromParsedSchema,
-    SERVICE_TAG,
     IMPORT_TAG,
     SCHEMA_TAG,
     ATTRIBUTE_TYPES,
@@ -18,8 +17,7 @@ const
     ATTRIBUTE_NAMESPACE
   } = require('../WsdlParserCommon'),
   {
-    WSDLParserFactory,
-    V11
+    WSDLParserFactory
   } = require('../WSDLParserFactory'),
   {
     getArrayFrom
@@ -29,7 +27,8 @@ const
     MULTIPLE_ROOT_FILES,
     NOT_WSDL_IN_FOLDER,
     WSDL_DIFF_VERSION,
-    MISSING_XML_PARSER
+    MISSING_XML_PARSER,
+    MISSING_ROOT_FILE
   } = require('../constants/messageConstants'),
   {
     COMPLEX_TYPE_TAG,
@@ -44,16 +43,104 @@ var path = require('path'),
 class WSDLMerger {
 
   /**
+ * Merge different files to a single WSDL
+ * @param {object} input input.data contains the file paths and input.xmlFiles contains the content files
+ * @param {object} xmlParser the parser class to parse xml to object or vice versa
+ * @returns {string} the single file
+ */
+  merge(input, xmlParser) {
+    let contentFiles = [],
+      filesPathArray = input.data,
+      files = input.xmlFiles,
+      origin = input.origin || '',
+      promises = [];
+
+    // use browserified version if the input origin is a browser
+    if (origin === 'browser') {
+      path = pathBrowserify;
+    }
+
+    if (files) {
+      filesPathArray.forEach((filePath) => {
+        contentFiles.push(files[path.resolve(filePath.fileName)]);
+      });
+      return new Promise((resolve, reject) => {
+        try {
+          let res = this.processMergeFiles(contentFiles, xmlParser);
+          resolve(res);
+        }
+        catch (err) {
+          reject(err);
+        }
+      });
+    }
+
+    filesPathArray.forEach((filePath) => {
+      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION));
+    });
+    return Promise.all(promises).then((values) => {
+      contentFiles = values;
+      return this.processMergeFiles(contentFiles, xmlParser);
+    });
+
+  }
+
+  /**
+   * Merge different files to a single WSDL
+   * @param {Array} contentFiles the content of the files in string
+   * @param {object} xmlParser the parser class to parse xml to object or vice versa
+   * @returns {string} the single file
+   */
+  processMergeFiles(contentFiles, xmlParser) {
+    let parsedSchemas,
+      root,
+      rootFiles,
+      parsedWSDL,
+      wsdlVersion,
+      parsedXMLs,
+      wsdlParser,
+      wsdlRoot = '';
+    if (!xmlParser) {
+      throw new WsdlError(MISSING_XML_PARSER);
+    }
+    parsedXMLs = contentFiles.map((file) => {
+      return xmlParser.safeParseToObject(file);
+    }).filter((parsed) => {
+      return parsed !== '';
+    });
+
+    wsdlVersion = this.getFilesVersion(contentFiles);
+    wsdlParser = this.getWSDLParser(wsdlVersion);
+    wsdlRoot = wsdlParser.informationService.RootTagName;
+    parsedSchemas = this.getParsedSchemasFromAllParsed(parsedXMLs);
+    parsedWSDL = this.getParsedWSDLFromAllParsed(parsedXMLs, wsdlRoot);
+    rootFiles = this.getRoot(parsedWSDL, wsdlRoot, wsdlParser);
+    if (rootFiles && rootFiles.length > 1) {
+      throw new WsdlError(MULTIPLE_ROOT_FILES);
+    }
+    root = rootFiles[0];
+    if (!root) {
+      throw new WsdlError(MISSING_ROOT_FILE);
+    }
+    this.resolveImportsFromRootFile(root, parsedWSDL, parsedSchemas, wsdlRoot, xmlParser.attributePlaceHolder,
+      wsdlParser);
+    return xmlParser.parseObjectToXML(root);
+  }
+
+
+  /**
    * Gets the root of the files list
    * @param {object} xmlParsedArray the array of parsed xmls
    * @param {string} wsdlRoot the wsdl root according to the version
+   * @param {object} wsdlParser the WSDL parser according to WSDL version
    * @returns {object} the root
    */
-  getRoot(xmlParsedArray, wsdlRoot) {
+  getRoot(xmlParsedArray, wsdlRoot, wsdlParser) {
     let root = xmlParsedArray.filter((xmlParsed) => {
       let principalPrefix = getPrincipalPrefix(xmlParsed, wsdlRoot),
         hasImports = wsdlHasImports(xmlParsed, principalPrefix, wsdlRoot),
-        hasServices = getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, SERVICE_TAG);
+        hasServices = getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix,
+          wsdlParser.informationService.ConcreteServiceTag);
       if (hasImports && hasServices) {
         return true;
       }
@@ -161,7 +248,7 @@ class WSDLMerger {
         importedPropertyValue = getNodeByName(importedTag[principalPrefix + wsdlRoot], '', importedProperty);
       if (importedProperty === principalPrefix + wsdlParser.informationService.AbstractInterfaceTag ||
         importedProperty === principalPrefix + wsdlParser.informationService.ConcreteInterfaceTag ||
-        importedProperty === principalPrefix + SERVICE_TAG ||
+        importedProperty === principalPrefix + wsdlParser.informationService.ConcreteServiceTag ||
         importedProperty === principalPrefix + ATTRIBUTE_TYPES) {
         this.mergeProperty(root, principalPrefix, wsdlRoot, rootProperty,
           importedProperty, importedPropertyValue);
@@ -236,8 +323,7 @@ class WSDLMerger {
           targetType = typesInRoot;
         }
         schemasFromType = targetType[schemaPrefix + SCHEMA_TAG];
-        if (schemasFromType &&
-          Array.isArray(schemasFromType)) {
+        if (schemasFromType && Array.isArray(schemasFromType)) {
           let schemasToPush = [];
           schemasFromType.forEach((existingSchema) => {
             let wasMerged = this.checkAndMergeSchemas(existingSchema, schemaInType, schemaPrefix, targetType);
@@ -390,87 +476,6 @@ class WSDLMerger {
     }
   }
 
-  /**
-   * Merge different files to a single WSDL
-   * @param {object} input input.data contains the file paths and input.xmlFiles contains the content files
-   * @param {object} xmlParser the parser class to parse xml to object or vice versa
-   * @returns {string} the single file
-   */
-  merge(input, xmlParser) {
-    let contentFiles = [],
-      filesPathArray = input.data,
-      files = input.xmlFiles,
-      origin = input.origin || '',
-      promises = [];
-
-    // use browserified version if the input origin is a browser
-    if (origin === 'browser') {
-      path = pathBrowserify;
-    }
-
-    if (files) {
-      filesPathArray.forEach((filePath) => {
-        contentFiles.push(files[path.resolve(filePath.fileName)]);
-      });
-      return new Promise((resolve, reject) => {
-        try {
-          let res = this.processMergeFiles(contentFiles, xmlParser);
-          resolve(res);
-        }
-        catch (err) {
-          reject(err);
-        }
-      });
-    }
-
-    filesPathArray.forEach((filePath) => {
-      promises.push(this.readFileAsync(filePath.fileName, CODIFICATION));
-    });
-    return Promise.all(promises).then((values) => {
-      contentFiles = values;
-      return this.processMergeFiles(contentFiles, xmlParser);
-    });
-
-  }
-
-  /**
-   * Merge different files to a single WSDL
-   * @param {Array} contentFiles the content of the files in string
-   * @param {object} xmlParser the parser class to parse xml to object or vice versa
-   * @returns {string} the single file
-   */
-  processMergeFiles(contentFiles, xmlParser) {
-    let parsedSchemas,
-      root,
-      rootFiles,
-      parsedWSDL,
-      wsdlVersion,
-      parsedXMLs,
-      wsdlParser,
-      wsdlRoot = '';
-    if (!xmlParser) {
-      throw new WsdlError(MISSING_XML_PARSER);
-    }
-    parsedXMLs = contentFiles.map((file) => {
-      return xmlParser.safeParseToObject(file);
-    }).filter((parsed) => {
-      return parsed !== '';
-    });
-
-    wsdlVersion = this.getFilesVersion(contentFiles);
-    wsdlParser = this.getWSDLParser(wsdlVersion);
-    wsdlRoot = wsdlVersion === V11 ? 'definitions' : 'description';
-    parsedSchemas = this.getParsedSchemasFromAllParsed(parsedXMLs);
-    parsedWSDL = this.getParsedWSDLFromAllParsed(parsedXMLs, wsdlRoot);
-    rootFiles = this.getRoot(parsedWSDL, wsdlRoot);
-    if (rootFiles && rootFiles.length > 1) {
-      throw new WsdlError(MULTIPLE_ROOT_FILES);
-    }
-    root = rootFiles[0];
-    this.resolveImportsFromRootFile(root, parsedWSDL, parsedSchemas, wsdlRoot, xmlParser.attributePlaceHolder,
-      wsdlParser);
-    return xmlParser.parseObjectToXML(root);
-  }
 
   /**
    * Gets the parsed objects that are WSDL definitions

--- a/test/data/separatedFiles/noRootFile/Services.wsdl
+++ b/test/data/separatedFiles/noRootFile/Services.wsdl
@@ -16,9 +16,6 @@
             targetNamespace="http://namespace/2008"
             xmlns="http://namespace/2008" version="2021.0.05.1"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-            <!-- <xsd:import namespace="http://namespace/2008" schemaLocation="Types.xsd"/> -->
-            <xsd:include schemaLocation="Types.xsd" />
-
         </xsd:schema>
     </types>
 

--- a/test/data/separatedFiles/noRootFile/Services.wsdl
+++ b/test/data/separatedFiles/noRootFile/Services.wsdl
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:ns="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://namespace/2008"
+    targetNamespace="http://namespace/2008">
+
+    <!-- This starts the Types section  -->
+
+    <types>
+        <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="http://namespace/2008"
+            xmlns="http://namespace/2008" version="2021.0.05.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <!-- <xsd:import namespace="http://namespace/2008" schemaLocation="Types.xsd"/> -->
+            <xsd:include schemaLocation="Types.xsd" />
+
+        </xsd:schema>
+    </types>
+
+    <!-- This starts the Message section  -->
+
+    <message name="MessageFault">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <message name="PingInput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+    <message name="PingOutput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <!-- This starts the PortType section  -->
+
+    <portType name="LTSService">
+
+        <operation name="Ping">
+            <input message="tns:PingInput" />
+            <output message="tns:PingOutput" />
+            <fault name="Fault" message="tns:MessageFault" />
+        </operation>
+
+    </portType>
+
+    <!-- This starts the Binding section  -->
+
+    <binding name="LTSServiceSoapBinding" type="tns:LTSService">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <operation name="Ping">
+            <soap:operation soapAction="http://jackhenry.com/ws/Ping" />
+            <input>
+                <soap:body use="literal" />
+            </input>
+            <output>
+                <soap:body use="literal" />
+            </output>
+            <fault name="Fault">
+                <soap:fault name="Fault" use="literal" />
+            </fault>
+        </operation>
+    </binding>
+
+    <!-- This starts the Service section  -->
+
+    <service name="LTSService">
+        <documentation>Service Description for the LTSService Interface</documentation>
+        <port name="LTSServiceSoap" binding="tns:LTSServiceSoapBinding">
+            <soap:address location="https://{{url}}/LTS.svc" />
+        </port>
+    </service>
+</definitions>

--- a/test/data/separatedFiles/noRootFile/Types.xsd
+++ b/test/data/separatedFiles/noRootFile/Types.xsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+  xmlns="http://namespace/2008" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://namespace/2008" 
+  version="2021.0.05.1"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:element name="ElementType" type="xsd:string" />
+</xsd:schema>

--- a/test/data/separatedFiles/sameTargetnamespace/Services.wsdl
+++ b/test/data/separatedFiles/sameTargetnamespace/Services.wsdl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:ns="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://namespace/2008"
+    targetNamespace="http://namespace/2008">
+
+    <!-- This starts the Types section  -->
+
+    <types>
+        <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="http://namespace/2008"
+            xmlns="http://namespace/2008" version="2021.0.05.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:import namespace="http://namespace/2008" schemaLocation="Types.xsd"/>
+        </xsd:schema>
+    </types>
+
+    <!-- This starts the Message section  -->
+
+    <message name="MessageFault">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <message name="PingInput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+    <message name="PingOutput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <!-- This starts the PortType section  -->
+
+    <portType name="LTSService">
+
+        <operation name="Ping">
+            <input message="tns:PingInput" />
+            <output message="tns:PingOutput" />
+            <fault name="Fault" message="tns:MessageFault" />
+        </operation>
+
+    </portType>
+
+    <!-- This starts the Binding section  -->
+
+    <binding name="LTSServiceSoapBinding" type="tns:LTSService">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <operation name="Ping">
+            <soap:operation soapAction="http://jackhenry.com/ws/Ping" />
+            <input>
+                <soap:body use="literal" />
+            </input>
+            <output>
+                <soap:body use="literal" />
+            </output>
+            <fault name="Fault">
+                <soap:fault name="Fault" use="literal" />
+            </fault>
+        </operation>
+    </binding>
+
+    <!-- This starts the Service section  -->
+
+    <service name="LTSService">
+        <documentation>Service Description for the LTSService Interface</documentation>
+        <port name="LTSServiceSoap" binding="tns:LTSServiceSoapBinding">
+            <soap:address location="https://{{url}}/LTS.svc" />
+        </port>
+    </service>
+</definitions>

--- a/test/data/separatedFiles/sameTargetnamespace/Types.xsd
+++ b/test/data/separatedFiles/sameTargetnamespace/Types.xsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+  xmlns="http://namespace/2008" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://namespace/2008" 
+  version="2021.0.05.1"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:element name="ElementType" type="xsd:string" />
+</xsd:schema>


### PR DESCRIPTION
Add support for imports with the same target namespace that the WSDL root file, this is an intermediate step to support the include tag (in include tag you have to use the same namespace).

When the imported tag has the same target namespace the types will be added to the root schema.

Added also a correct handling of merging a folder without WSDL root.
Added test scenarios for both cases