### PR TITLE
Merging  - Add support for include tag

### DIFF
--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -25,7 +25,9 @@ const {
   ATTRIBUTE_TYPES = 'types',
   OPERATION_TAG = 'operation',
   IMPORT_TAG = 'import',
+  INCLUDE_TAG = 'include',
   ATTRIBUTE_NAMESPACE = 'namespace',
+  ATTRIBUTE_SCHEMALOCATION = 'schemaLocation',
   {
     DOC_HAS_NO_BINDINGS_MESSAGE,
     DOC_HAS_NO_BINDINGS_OPERATIONS_MESSAGE
@@ -489,19 +491,21 @@ function excludeSeparatorFromName(elementName) {
   return elementName ? elementName.split(XML_NAMESPACE_SEPARATOR).reverse()[0] : elementName;
 }
 
+
 /**
  * Gets the import nodes from a parsed wsdl from root or schema
  * @param {object} xmlParsed the parsed document
  * @param {string} principalPrefix principal prefix of the document
  * @param {string} wsdlRoot the root tag for the document to remove xml ns separator
+ * @param {string} tag the tag import or include
  * @returns {Array} all the import nodes
  */
-function getWSDLImports(xmlParsed, principalPrefix, wsdlRoot) {
+function getWSDLImportsOrIncludes(xmlParsed, principalPrefix, wsdlRoot, tag) {
   let types,
     globalImports = [];
 
-  if (getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, IMPORT_TAG)) {
-    globalImports.push(getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, IMPORT_TAG));
+  if (getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, tag)) {
+    globalImports.push(getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, tag));
   }
   types = getArrayFrom(getNodeByName(xmlParsed[principalPrefix + wsdlRoot], principalPrefix, ATTRIBUTE_TYPES));
   if (types && types.length > 0) {
@@ -515,7 +519,7 @@ function getWSDLImports(xmlParsed, principalPrefix, wsdlRoot) {
         });
         schemas.filter((schema) => {
           let importProperties = Object.keys(schema).filter((propertyName) => {
-            return propertyName.includes(IMPORT_TAG);
+            return propertyName.includes(tag);
           });
           if (importProperties) {
             let imports = getArrayFrom(schema[importProperties]);
@@ -532,6 +536,29 @@ function getWSDLImports(xmlParsed, principalPrefix, wsdlRoot) {
 }
 
 /**
+ * Gets the import nodes from a parsed wsdl from root or schema
+ * @param {object} xmlParsed the parsed document
+ * @param {string} principalPrefix principal prefix of the document
+ * @param {string} wsdlRoot the root tag for the document to remove xml ns separator
+ * @returns {Array} all the import nodes
+ */
+function getWSDLImports(xmlParsed, principalPrefix, wsdlRoot) {
+  return getWSDLImportsOrIncludes(xmlParsed, principalPrefix, wsdlRoot, IMPORT_TAG);
+}
+
+/**
+ * Gets the import nodes from a parsed wsdl from root or schema
+ * @param {object} xmlParsed the parsed document
+ * @param {string} principalPrefix principal prefix of the document
+ * @param {string} wsdlRoot the root tag for the document to remove xml ns separator
+ * @returns {Array} all the include nodes
+ */
+function getWSDLIncludes(xmlParsed, principalPrefix, wsdlRoot) {
+  return getWSDLImportsOrIncludes(xmlParsed, principalPrefix, wsdlRoot, INCLUDE_TAG);
+}
+
+
+/**
  * returns if document has import nodes in root or schema
  * @param {object} xmlParsed the parsed document
  * @param {string} principalPrefix principal prefix of the document
@@ -539,7 +566,8 @@ function getWSDLImports(xmlParsed, principalPrefix, wsdlRoot) {
  * @returns {boolean} if the document has imports
  */
 function wsdlHasImports(xmlParsed, principalPrefix, wsdlRoot) {
-  return getWSDLImports(xmlParsed, principalPrefix, wsdlRoot).length > 0;
+  return getWSDLImports(xmlParsed, principalPrefix, wsdlRoot).length > 0 ||
+   getWSDLIncludes(xmlParsed, principalPrefix, wsdlRoot).length > 0;
 }
 
 /**
@@ -572,6 +600,7 @@ module.exports = {
   ATTRIBUTE_TYPES,
   ATTRIBUTE_NAMESPACE,
   SCHEMA_NS_URL,
+  ATTRIBUTE_SCHEMALOCATION,
   getServices,
   getArrayFrom,
   getBindings,
@@ -590,5 +619,6 @@ module.exports = {
   wsdlHasImports,
   getNodeByQNameLocal,
   getServiceDocumentation,
-  getSchemaPrefixFromParsedSchema
+  getSchemaPrefixFromParsedSchema,
+  getWSDLIncludes
 };

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -14,7 +14,9 @@ const
     SCHEMA_TAG,
     ATTRIBUTE_TYPES,
     TARGET_NAMESPACE_SPEC,
-    ATTRIBUTE_NAMESPACE
+    ATTRIBUTE_NAMESPACE,
+    ATTRIBUTE_SCHEMALOCATION,
+    getWSDLIncludes
   } = require('../WsdlParserCommon'),
   {
     WSDLParserFactory
@@ -22,6 +24,9 @@ const
   {
     getArrayFrom
   } = require('./objectUtils'),
+  {
+    getFileNameFromPath
+  } = require('./textUtils'),
   WsdlError = require('../WsdlError'),
   {
     MULTIPLE_ROOT_FILES,
@@ -62,7 +67,9 @@ class WSDLMerger {
 
     if (files) {
       filesPathArray.forEach((filePath) => {
-        contentFiles.push(files[path.resolve(filePath.fileName)]);
+        contentFiles.push({ content: files[path.resolve(filePath.fileName)],
+          fileName: filePath.fileName });
+
       });
       return new Promise((resolve, reject) => {
         try {
@@ -79,34 +86,48 @@ class WSDLMerger {
       promises.push(this.readFileAsync(filePath.fileName, CODIFICATION));
     });
     return Promise.all(promises).then((values) => {
-      contentFiles = values;
+      values.forEach((content, index) => {
+        contentFiles.push({ content: content, fileName: filesPathArray[index].fileName });
+      });
       return this.processMergeFiles(contentFiles, xmlParser);
     });
-
   }
 
   /**
    * Merge different files to a single WSDL
-   * @param {Array} contentFiles the content of the files in string
+   * @param {Array} filesPathArray the content of the files in string and the name of the files
    * @param {object} xmlParser the parser class to parse xml to object or vice versa
    * @returns {string} the single file
    */
-  processMergeFiles(contentFiles, xmlParser) {
+  processMergeFiles(filesPathArray, xmlParser) {
     let parsedSchemas,
       root,
       rootFiles,
       parsedWSDL,
       wsdlVersion,
       parsedXMLs,
+      parsedXMLsAndFileNames,
       wsdlParser,
+      contentFiles,
       wsdlRoot = '';
     if (!xmlParser) {
       throw new WsdlError(MISSING_XML_PARSER);
     }
-    parsedXMLs = contentFiles.map((file) => {
-      return xmlParser.safeParseToObject(file);
-    }).filter((parsed) => {
-      return parsed !== '';
+
+    parsedXMLsAndFileNames = filesPathArray.map((file) => {
+      return { parsed: xmlParser.safeParseToObject(file.content),
+        fileName: file.fileName };
+    }).filter((tuple) => {
+      return tuple.parsed !== '';
+    });
+
+    parsedXMLs = parsedXMLsAndFileNames.map((tuple) => {
+      return tuple.parsed;
+    });
+
+
+    contentFiles = filesPathArray.map((filePathArray) => {
+      return filePathArray.content;
     });
 
     wsdlVersion = this.getFilesVersion(contentFiles);
@@ -123,7 +144,7 @@ class WSDLMerger {
       throw new WsdlError(MISSING_ROOT_FILE);
     }
     this.resolveImportsFromRootFile(root, parsedWSDL, parsedSchemas, wsdlRoot, xmlParser.attributePlaceHolder,
-      wsdlParser);
+      wsdlParser, parsedXMLsAndFileNames);
     return xmlParser.parseObjectToXML(root);
   }
 
@@ -186,18 +207,51 @@ class WSDLMerger {
 
   /**
    * Gets the import information and assign it to the root
+   * @param {object} parentXML the identified parent
+   * @param {object} parsedWSDL the array of parsed xmls
+   * @param {object} parsedSchemas the array of parsed xmls
+   * @param {string} schemaLocation the schema location to find
+   * @param {string} wsdlRoot the wsdl root according to the version
+   * @param {string} principalPrefix the wsdl principal prefix
+   * @param {Array} parsedXMLsAndFileNames array of content files and files names
+   * @returns {object} the root
+   */
+  getParsedWSDLOrSchemaBySchemaLocation(parentXML, parsedWSDL, parsedSchemas, schemaLocation, wsdlRoot,
+    principalPrefix, parsedXMLsAndFileNames) {
+    let schemaPrefix = '',
+      found,
+      allEllements = parsedWSDL.concat(parsedSchemas).filter((xmlParsed) => {
+        return xmlParsed !== parentXML;
+      });
+    parsedXMLsAndFileNames.forEach((tuple) => {
+      if (getFileNameFromPath(tuple.fileName) === schemaLocation) {
+        if (!tuple.parsed[principalPrefix + wsdlRoot]) {
+          schemaPrefix = getSchemaPrefixFromParsedSchema(tuple.parsed);
+        }
+        found = allEllements.find((parsedXML) => {
+          return parsedXML === tuple.parsed;
+        });
+      }
+    });
+    return { found, schemaPrefix };
+  }
+
+  /**
+   * Gets the import information and assign it to the root
    * @param {object} WSDLRootFile the array of parsed xmls
    * @param {object} parsedWSDL the array of parsed xmls
    * @param {object} parsedSchemas the array of parsed xmls
    * @param {string} wsdlRoot the wsdl root according to the version
    * @param {string} attributePlaceHolder the character for attributes according the xml parser
    * @param {object} wsdlParser the WSDL parser according to WSDL version
+   * @param {Array} parsedXMLsAndFileNames array of content files and files names
    * @returns {object} the root
    */
   resolveImportsFromRootFile(WSDLRootFile, parsedWSDL, parsedSchemas, wsdlRoot, attributePlaceHolder,
-    wsdlParser) {
+    wsdlParser, parsedXMLsAndFileNames) {
     let principalPrefix = getPrincipalPrefix(WSDLRootFile, wsdlRoot),
-      imports = getWSDLImports(WSDLRootFile, principalPrefix, wsdlRoot);
+      imports = getWSDLImports(WSDLRootFile, principalPrefix, wsdlRoot),
+      includes = getWSDLIncludes(WSDLRootFile, principalPrefix, wsdlRoot);
     imports.forEach((importInformation) => {
       let importedFound = this.getParsedWSDLOrSchemaByTargetNamespace(
         WSDLRootFile,
@@ -209,9 +263,26 @@ class WSDLMerger {
       );
       if (importedFound.found) {
         this.assignImportedProperties(WSDLRootFile, importedFound, parsedWSDL, parsedSchemas, wsdlRoot,
-          principalPrefix, attributePlaceHolder, wsdlParser);
+          principalPrefix, attributePlaceHolder, wsdlParser, parsedXMLsAndFileNames);
       }
     });
+
+    includes.forEach((importInformation) => {
+      let importedFound = this.getParsedWSDLOrSchemaBySchemaLocation(
+        WSDLRootFile,
+        parsedWSDL,
+        parsedSchemas,
+        getAttributeByName(importInformation, ATTRIBUTE_SCHEMALOCATION),
+        wsdlRoot,
+        principalPrefix,
+        parsedXMLsAndFileNames
+      );
+      if (importedFound.found) {
+        this.assignImportedProperties(WSDLRootFile, importedFound, parsedWSDL, parsedSchemas, wsdlRoot,
+          principalPrefix, attributePlaceHolder, wsdlParser, parsedXMLsAndFileNames);
+      }
+    });
+
     return WSDLRootFile;
   }
 
@@ -225,23 +296,17 @@ class WSDLMerger {
    * @param {string} principalPrefix the wsdl principal prefix
    * @param {string} attributePlaceHolder the character for attributes according the xml parser
    * @param {object} wsdlParser the WSDL parser according to WSDL version
+   * @param {Array} parsedXMLsAndFileNames the parsed files and names
    * @returns {object} the root
    */
-  assignImportedPropertiesDefinitions(
-    root,
-    importedTag,
-    parsedWSDL,
-    parsedSchemas,
-    wsdlRoot,
-    principalPrefix,
-    attributePlaceHolder,
-    wsdlParser
+  assignImportedPropertiesDefinitions(root, importedTag, parsedWSDL, parsedSchemas, wsdlRoot, principalPrefix,
+    attributePlaceHolder, wsdlParser, parsedXMLsAndFileNames
   ) {
     let definitionsProperty = importedTag[principalPrefix + wsdlRoot],
       hasImports = wsdlHasImports(importedTag, principalPrefix, wsdlRoot);
     if (hasImports) {
       this.resolveImportsFromRootFile(importedTag, parsedWSDL, parsedSchemas, wsdlRoot, principalPrefix,
-        attributePlaceHolder);
+        attributePlaceHolder, parsedXMLsAndFileNames);
     }
     Object.keys(definitionsProperty).forEach((importedProperty) => {
       let rootProperty = getNodeByName(root[principalPrefix + wsdlRoot], '', importedProperty),
@@ -442,10 +507,11 @@ class WSDLMerger {
    * @param {object} principalPrefix the WSDL principal prefix
    * @param {string} attributePlaceHolder the character for attributes according the xml parser
    * @param {object} wsdlParser the WSDL parser according to WSDL version
+   * @param {Array} parsedXMLsAndFileNames the parsed files and names
    * @returns {object} the root
    */
   assignImportedProperties(WSDLRootFile, importedTag, parsedWSDL, parsedSchemas, wsdlRoot, principalPrefix,
-    attributePlaceHolder, wsdlParser) {
+    attributePlaceHolder, wsdlParser, parsedXMLsAndFileNames) {
     let isWSDLDefinition = importedTag.found[principalPrefix + wsdlRoot];
     if (isWSDLDefinition) {
       this.assignImportedPropertiesDefinitions(
@@ -456,7 +522,8 @@ class WSDLMerger {
         wsdlRoot,
         principalPrefix,
         attributePlaceHolder,
-        wsdlParser
+        wsdlParser,
+        parsedXMLsAndFileNames
       );
     }
     else {

--- a/lib/utils/textUtils.js
+++ b/lib/utils/textUtils.js
@@ -48,10 +48,19 @@ getLastSegmentURL = (value) => {
   return segment;
 };
 
+getFileNameFromPath = (value) => {
+  if (!value) {
+    return '';
+  }
+  let segment = value.substring(value.lastIndexOf('/') + 1);
+  return segment;
+};
+
 module.exports = {
   removeLineBreak,
   isPmVariable,
   removeLineBreakTabsSpaces,
   removeDoubleQuotes,
-  getLastSegmentURL
+  getLastSegmentURL,
+  getFileNameFromPath
 };

--- a/test/data/separatedFiles/includeTag/Services.wsdl
+++ b/test/data/separatedFiles/includeTag/Services.wsdl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:ns="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://namespace/2008"
+    targetNamespace="http://namespace/2008">
+
+    <!-- This starts the Types section  -->
+
+    <types>
+        <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="http://namespace/2008"
+            xmlns="http://namespace/2008" version="2021.0.05.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:include schemaLocation="Types.xsd"/>
+        </xsd:schema>
+    </types>
+
+    <!-- This starts the Message section  -->
+
+    <message name="MessageFault">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <message name="PingInput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+    <message name="PingOutput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <!-- This starts the PortType section  -->
+
+    <portType name="LTSService">
+
+        <operation name="Ping">
+            <input message="tns:PingInput" />
+            <output message="tns:PingOutput" />
+            <fault name="Fault" message="tns:MessageFault" />
+        </operation>
+
+    </portType>
+
+    <!-- This starts the Binding section  -->
+
+    <binding name="LTSServiceSoapBinding" type="tns:LTSService">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <operation name="Ping">
+            <soap:operation soapAction="http://jackhenry.com/ws/Ping" />
+            <input>
+                <soap:body use="literal" />
+            </input>
+            <output>
+                <soap:body use="literal" />
+            </output>
+            <fault name="Fault">
+                <soap:fault name="Fault" use="literal" />
+            </fault>
+        </operation>
+    </binding>
+
+    <!-- This starts the Service section  -->
+
+    <service name="LTSService">
+        <documentation>Service Description for the LTSService Interface</documentation>
+        <port name="LTSServiceSoap" binding="tns:LTSServiceSoapBinding">
+            <soap:address location="https://{{url}}/LTS.svc" />
+        </port>
+    </service>
+</definitions>

--- a/test/data/separatedFiles/includeTag/Types.xsd
+++ b/test/data/separatedFiles/includeTag/Types.xsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+  xmlns="http://namespace/2008" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://namespace/2008" 
+  version="2021.0.05.1"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:element name="ElementType" type="xsd:string" />
+</xsd:schema>

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -661,7 +661,6 @@ describe('merge and validate', function () {
     });
   });
 
-
   it('Should create from folder where targetnamespace is the same in imported schema than in wsdl', function (done) {
     let folderPath = path.join(__dirname, SEPARATED_FILES, '/sameTargetnamespace'),
       array = [
@@ -709,4 +708,36 @@ describe('merge and validate', function () {
       done();
     });
   });
+
+  it('Should create from folder where uses include tag', function (done) {
+    let folderPath = path.join(__dirname, SEPARATED_FILES, '/includeTag'),
+      array = [
+        { fileName: folderPath + '/Services.wsdl' },
+        { fileName: folderPath + '/Types.xsd' }
+      ];
+    const schemaPack = new SchemaPack({ type: 'folder', data: array }, {});
+    schemaPack.mergeAndValidate((err, status) => {
+      if (err) {
+        expect.fail(null, null, err);
+      }
+      if (status.result) {
+        schemaPack.convert((error, result) => {
+          if (error) {
+            expect.fail(null, null, err);
+          }
+          expect(result.result).to.equal(true);
+          expect(result.output.length).to.equal(1);
+          expect(result.output[0].type).to.have.equal('collection');
+          expect(result.output[0].data).to.have.property('info');
+          expect(result.output[0].data).to.have.property('item');
+          expect(result.output[0].data.info.name).to.equal('LTSService');
+          done();
+        });
+      }
+      else {
+        expect.fail(null, null, status.reason);
+      }
+    });
+  });
+
 });

--- a/test/unit/WSDLMerger.test.js
+++ b/test/unit/WSDLMerger.test.js
@@ -926,7 +926,7 @@ describe('WSDLMerger merge', function() {
 
     merger.merge({ data: files, xmlFiles: processedInput }, new XMLParser())
       .then(() => {
-        expect.fail(null, null, status.reason);
+        expect.fail(null, null, 'Should throw error');
       })
       .catch((err) => {
         expect(err.message).to.equal(WSDL_DIFF_VERSION);


### PR DESCRIPTION
add support for include tag

change the merge process to read files and preserve the filename.
we now need the name of the file to support include tag (only uses the name for linking)
treat include as an import tag with same namespace
change the way we determine the root file (now can have includes and services not only imports)

Added scenarios for support functions and main scenario