### PR TITLE
Update WsdlInformationService11.js

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -23,6 +23,7 @@ const
   SCHEMA_NS_URL = 'http://www.w3.org/2001/XMLSchema',
   SOAP_TRANSPORT_URL = 'http://schemas.xmlsoap.org/soap/http',
   TNS_NS_KEY = 'xmlns:tns',
+  XMLNS_ATTRIBUTE = 'xmlns',
   ATTRIBUTE_NAME = 'name',
   ATTRIBUTE_STYLE = 'style',
   ATTRIBUTE_VERB = 'verb',
@@ -496,9 +497,14 @@ class WsdlInformationService11 {
     }
     else if (protocolKey === '') {
       const innerBinding = getNodeByName(binding, protocolPrefix, BINDING_TAG),
-        transport = getAttributeByName(innerBinding, ATTRIBUTE_TRANSPORT);
-      if (transport === SOAP_TRANSPORT_URL) {
+        transport = getAttributeByName(innerBinding, ATTRIBUTE_TRANSPORT),
+        xmlns = getAttributeByName(innerBinding, XMLNS_ATTRIBUTE);
+      if (transport === SOAP_TRANSPORT_URL && xmlns === SOAP_NS_URL) {
         protocol = SOAP_PROTOCOL;
+        verb = POST_METHOD;
+      }
+      else if (transport === SOAP_TRANSPORT_URL && xmlns === SOAP_12_NS_URL) {
+        protocol = SOAP12_PROTOCOL;
         verb = POST_METHOD;
       }
     }


### PR DESCRIPTION
Compare url to identify the protocol instead of assuming soap

When the binding tag does not have the prefix in the namespace compare the local defined with the url for SOAP or SOAP 1.2 and generate the protocol and verb information accordingly 