### PR TITLE
Validate soap action header

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -114,7 +114,8 @@ class TransactionValidator {
             requestItem.id,
             validateHeadersOption,
             false,
-            options
+            options,
+            operationFromWSDL
           ),
           requestBodyMismatches = this.validateBody(
             requestItem.request.body,
@@ -208,7 +209,8 @@ class TransactionValidator {
     responseItem.forEach((response) => {
       const header = response.header,
         id = response.id,
-        headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true, options);
+        headerMismatches = this.validateHeaders(header, id, validateHeadersOption, true, options,
+          operationFromWSDL);
       let bodyMismatches = [],
         mismatches,
         matched;
@@ -489,11 +491,13 @@ class TransactionValidator {
    * @param {boolean} validateHeadersOption if validateHeadersOption option value, False by default
    * @param {boolean} isResponse true if the entity is response false if not
    * @param {object} options options validation process
+   * @param {Operation} operationFromWSDL wsdl operation that corresponds to either the request or response
    * @returns {Array} missmatchs array
    */
-  validateHeaders(requestHeaders, entityId, validateHeadersOption, isResponse, options) {
+  validateHeaders(requestHeaders, entityId, validateHeadersOption, isResponse, options, operationFromWSDL) {
     const validator = new HeadersValidator();
-    return validator.validate(requestHeaders, entityId, validateHeadersOption, isResponse, options);
+    return validator.validate(requestHeaders, entityId, validateHeadersOption, isResponse, options,
+      operationFromWSDL);
   }
 
   /**

--- a/lib/transactionValidator/HeadersValidator.js
+++ b/lib/transactionValidator/HeadersValidator.js
@@ -1,4 +1,5 @@
 const MISSING_IN_REQUEST_REASON_CODE = 'MISSING_IN_REQUEST',
+  MISSING_IN_SCHEMA_REASON_CODE = 'MISSING_IN_SCHEMA',
   INVALID_TYPE_REASON_CODE = 'INVALID_TYPE',
   CONTENT_TYPE_HEADER_KEY = 'Content-Type',
   SOAP_ACTION_HEADER_KEY = 'SOAPAction',
@@ -96,11 +97,35 @@ class HeadersValidator {
   validateSoapActionHeader(headers, isResponse, options, operationFromWSDL) {
     let index = headers.findIndex((header) => { return header.key === SOAP_ACTION_HEADER_KEY; }),
       soapActionHeader = headers[index];
-    const { ignoreUnresolvedVariables } = options;
-    if (isResponse || !operationFromWSDL.soapAction) {
+    const { ignoreUnresolvedVariables, showMissingInSchemaErrors } = options;
+    if (isResponse) {
       return;
     }
-    if (!soapActionHeader) {
+    if (soapActionHeader) {
+      if (!operationFromWSDL.soapAction && soapActionHeader.value && showMissingInSchemaErrors) {
+        return {
+          property: HEADER_PROPERTY,
+          transactionJsonPath: '$.request.header',
+          schemaJsonPath: 'schemaPathPrefix',
+          reasonCode: MISSING_IN_SCHEMA_REASON_CODE,
+          reason: 'The header "SoapAction" was not found in the schema'
+        };
+      }
+      if (ignoreUnresolvedVariables && isPmVariable(soapActionHeader.value)) {
+        return;
+      }
+      if (soapActionHeader.value !== operationFromWSDL.soapAction) {
+        return {
+          property: HEADER_PROPERTY,
+          transactionJsonPath: `$.request.header[${index}].value`,
+          schemaJsonPath: 'schemaPathPrefix',
+          reasonCode: INVALID_TYPE_REASON_CODE,
+          reason: `The header "SoapAction" needs to be "${operationFromWSDL.soapAction}" ` +
+          `but we found "${soapActionHeader.value}" instead`
+        };
+      }
+    }
+    if (!soapActionHeader && operationFromWSDL.soapAction) {
       return {
         property: HEADER_PROPERTY,
         transactionJsonPath: '$.request.header',
@@ -109,19 +134,7 @@ class HeadersValidator {
         reason: 'The header "SoapAction" was not found in the transaction'
       };
     }
-    if (ignoreUnresolvedVariables && isPmVariable(soapActionHeader.value)) {
-      return;
-    }
-    if (soapActionHeader.value !== operationFromWSDL.soapAction) {
-      return {
-        property: HEADER_PROPERTY,
-        transactionJsonPath: `$.request.header[${index}].value`,
-        schemaJsonPath: 'schemaPathPrefix',
-        reasonCode: INVALID_TYPE_REASON_CODE,
-        reason: `The header "SoapAction" needs to be "${operationFromWSDL.soapAction}" ` +
-        `but we found "${soapActionHeader.value}" instead`
-      };
-    }
+
   }
 
 }

--- a/lib/transactionValidator/HeadersValidator.js
+++ b/lib/transactionValidator/HeadersValidator.js
@@ -1,8 +1,12 @@
 const MISSING_IN_REQUEST_REASON_CODE = 'MISSING_IN_REQUEST',
   INVALID_TYPE_REASON_CODE = 'INVALID_TYPE',
   CONTENT_TYPE_HEADER_KEY = 'Content-Type',
+  SOAP_ACTION_HEADER_KEY = 'SOAPAction',
   VALID_CONTENT_TYPES = ['text/xml', 'application/soap+xml'],
-  HEADER_PROPERTY = 'HEADER';
+  HEADER_PROPERTY = 'HEADER',
+  {
+    isPmVariable
+  } = require('../utils/textUtils');
 
 /**
  * Class to validate postman request headers
@@ -17,16 +21,23 @@ class HeadersValidator {
    * @param {boolean} validateHeadersOption if validateHeadersOption option value, False by default
    * @param {boolean} isResponse true if the entity is response false if not
    * @param {object} options options validation process
+   * @param {Operation} operationFromWSDL wsdl operation that corresponds to either the request or response
    * @returns {Array} missmatchs array
    */
-  validate(requestHeaders, entityId, validateHeadersOption, isResponse, options) {
+  validate(requestHeaders, entityId, validateHeadersOption, isResponse, options, operationFromWSDL) {
     let missmatches = [],
-      contentTypeMissmatch;
+      contentTypeMissmatch,
+      soapActionMissmatch;
     if (validateHeadersOption) {
       contentTypeMissmatch = this.validateContentTypeHeader(requestHeaders, entityId, isResponse, options);
+      soapActionMissmatch = this.validateSoapActionHeader(requestHeaders, isResponse, options,
+        operationFromWSDL);
     }
     if (contentTypeMissmatch) {
       missmatches.push(contentTypeMissmatch);
+    }
+    if (soapActionMissmatch) {
+      missmatches.push(soapActionMissmatch);
     }
     return missmatches;
   }
@@ -69,6 +80,46 @@ class HeadersValidator {
         reasonCode: INVALID_TYPE_REASON_CODE,
         reason: `The header "Content-Type" needs to be "${VALID_CONTENT_TYPES[0]}" or "${VALID_CONTENT_TYPES[1]}" ` +
         `but we found "${contentTypeHeader.value}" instead`
+      };
+    }
+  }
+
+  /**
+   *
+   * @description validates if the content type header is pressent and if has value of text/xml
+   * @param {object} headers headers list
+   * @param {boolean} isResponse true if the entity is response false if not
+   * @param {object} options options validation process
+   * @param {Operation} operationFromWSDL wsdl operation that corresponds to either the request or response
+   * @returns {object} missmatch object if the case
+   */
+  validateSoapActionHeader(headers, isResponse, options, operationFromWSDL) {
+    let index = headers.findIndex((header) => { return header.key === SOAP_ACTION_HEADER_KEY; }),
+      soapActionHeader = headers[index];
+    const { ignoreUnresolvedVariables } = options;
+    if (isResponse || !operationFromWSDL.soapAction) {
+      return;
+    }
+    if (!soapActionHeader) {
+      return {
+        property: HEADER_PROPERTY,
+        transactionJsonPath: '$.request.header',
+        schemaJsonPath: 'schemaPathPrefix',
+        reasonCode: MISSING_IN_REQUEST_REASON_CODE,
+        reason: 'The header "SoapAction" was not found in the transaction'
+      };
+    }
+    if (ignoreUnresolvedVariables && isPmVariable(soapActionHeader.value)) {
+      return;
+    }
+    if (soapActionHeader.value !== operationFromWSDL.soapAction) {
+      return {
+        property: HEADER_PROPERTY,
+        transactionJsonPath: `$.request.header[${index}].value`,
+        schemaJsonPath: 'schemaPathPrefix',
+        reasonCode: INVALID_TYPE_REASON_CODE,
+        reason: `The header "SoapAction" needs to be "${operationFromWSDL.soapAction}" ` +
+        `but we found "${soapActionHeader.value}" instead`
       };
     }
   }

--- a/test/convert-validation/validateTransactions.test.js
+++ b/test/convert-validation/validateTransactions.test.js
@@ -111,6 +111,14 @@ describe('Test validate Transactions method in SchemaPack', function () {
                 schemaJsonPath: 'schemaPathPrefix',
                 reasonCode: 'MISSING_IN_REQUEST',
                 reason: 'The header "Content-Type" was not found in the transaction'
+              },
+              {
+                property: 'HEADER',
+                transactionJsonPath: '$.request.header[0].value',
+                schemaJsonPath: 'schemaPathPrefix',
+                reasonCode: 'INVALID_TYPE',
+                reason: 'The header "SoapAction" needs to be "" but we found ' +
+                '"http://www.dataaccess.com/webservicesserver/NumberToWords" instead'
               }],
               responses: {
                 'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
@@ -206,6 +214,14 @@ describe('Test validate Transactions method in SchemaPack', function () {
                 reasonCode: 'INVALID_TYPE',
                 reason: 'The header \"Content-Type\" needs to be \"text/xml\" or \"application/soap+xml\" but we ' +
                   'found \"text/plain; charset=utf-8\" instead'
+              },
+              {
+                property: 'HEADER',
+                transactionJsonPath: '$.request.header[1].value',
+                schemaJsonPath: 'schemaPathPrefix',
+                reasonCode: 'INVALID_TYPE',
+                reason: 'The header "SoapAction" needs to be "" but we found ' +
+                '"http://www.dataaccess.com/webservicesserver/NumberToWords" instead'
               }],
               responses: {
                 'd36c56cf-0cf6-4273-a34d-973e842bf80f': {

--- a/test/data/transactionsValidation/numberToWordsCollectionItemsCTHeaderNXML.json
+++ b/test/data/transactionsValidation/numberToWordsCollectionItemsCTHeaderNXML.json
@@ -15,6 +15,10 @@
     "header": [{
       "key": "Content-Type",
       "value": "text/plain; charset=utf-8"
+    },
+    {
+      "key": "SOAPAction",
+      "value": "http://www.dataaccess.com/webservicesserver/NumberToWords"
     }],
     "method": "POST",
     "body": {

--- a/test/data/transactionsValidation/numberToWordsCollectionItemsCTHeaderPMVariable.json
+++ b/test/data/transactionsValidation/numberToWordsCollectionItemsCTHeaderPMVariable.json
@@ -15,6 +15,10 @@
     "header": [{
       "key": "Content-Type",
       "value": "{{unresolvedVariable}}"
+    },
+    {
+      "key": "SOAPAction",
+      "value": "http://www.dataaccess.com/webservicesserver/NumberToWords"
     }],
     "method": "POST",
     "body": {
@@ -41,6 +45,10 @@
       "header": [{
         "key": "Content-Type",
         "value": "{{unresolvedVariable}}"
+      },
+      {
+        "key": "SOAPAction",
+        "value": "http://www.dataaccess.com/webservicesserver/NumberToWords"
       }],
       "method": "POST",
       "body": {
@@ -58,6 +66,10 @@
     "header": [{
       "key": "Content-Type",
       "value": "{{unresolvedVariable}}"
+    },
+    {
+      "key": "SOAPAction",
+      "value": "http://www.dataaccess.com/webservicesserver/NumberToWords"
     }],
     "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToWordsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToWordsResult>place your string value here</NumberToWordsResult>\n    </NumberToWordsResponse>\n  </soap:Body>\n</soap:Envelope>\n",
     "cookie": [],

--- a/test/data/transactionsValidation/numberToWordsCollectionItemsNOSOAPAcHeader.json
+++ b/test/data/transactionsValidation/numberToWordsCollectionItemsNOSOAPAcHeader.json
@@ -1,0 +1,265 @@
+[{
+  "id": "aebb36fc-1be3-44c3-8f4a-0b5042dc17d0",
+  "name": "NumberToWords",
+  "description": {
+    "content": "Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n</soap:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "d36c56cf-0cf6-4273-a34d-973e842bf80f",
+    "name": "NumberToWords response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap:Body>\n</soap:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/plain; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToWordsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToWordsResult>place your string value here</NumberToWordsResult>\n    </NumberToWordsResponse>\n  </soap:Body>\n</soap:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}, {
+  "id": "395c9db6-d6f5-45a7-90f5-09f5aab4fe92",
+  "name": "NumberToDollars",
+  "description": {
+    "content": "Returns the non-zero dollar amount of the passed number.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap:Body>\n</soap:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "8a0c6532-84f9-45c7-838a-f4bf1a6de002",
+    "name": "NumberToDollars response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap:Body>\n</soap:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <NumberToDollarsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToDollarsResult>place your string value here</NumberToDollarsResult>\n    </NumberToDollarsResponse>\n  </soap:Body>\n</soap:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}, {
+  "id": "353e33da-1eee-41c1-8865-0f72b2e1fd10",
+  "name": "NumberToWords",
+  "description": {
+    "content": "Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap12:Body>\n</soap12:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "c8a892b6-4b2e-4523-9cc3-fc3e08c835c4",
+    "name": "NumberToWords response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToWords xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <ubiNum>18446744073709</ubiNum>\n    </NumberToWords>\n  </soap12:Body>\n</soap12:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToWordsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToWordsResult>place your string value here</NumberToWordsResult>\n    </NumberToWordsResponse>\n  </soap12:Body>\n</soap12:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}, {
+  "id": "18403328-4213-4c3e-b0e9-b21a636697c3",
+  "name": "NumberToDollars",
+  "description": {
+    "content": "Returns the non-zero dollar amount of the passed number.",
+    "type": "text/plain"
+  },
+  "request": {
+    "url": {
+      "path": ["webservicesserver", "NumberConversion.wso"],
+      "host": ["https://www.dataaccess.com"],
+      "query": [],
+      "variable": []
+    },
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "method": "POST",
+    "body": {
+      "mode": "raw",
+      "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap12:Body>\n</soap12:Envelope>\n",
+      "options": {
+        "raw": {
+          "language": "xml"
+        }
+      }
+    }
+  },
+  "response": [{
+    "id": "1763f0b2-9f34-4796-a390-b94ee5c37c7c",
+    "name": "NumberToDollars response",
+    "originalRequest": {
+      "url": {
+        "protocol": "https",
+        "path": ["webservicesserver", "NumberConversion.wso"],
+        "host": ["www", "dataaccess", "com"],
+        "query": [],
+        "variable": []
+      },
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/xml; charset=utf-8"
+      }],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToDollars xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <dNum>1</dNum>\n    </NumberToDollars>\n  </soap12:Body>\n</soap12:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "status": "OK",
+    "code": 200,
+    "header": [{
+      "key": "Content-Type",
+      "value": "text/xml; charset=utf-8"
+    }],
+    "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap12:Envelope xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <NumberToDollarsResponse xmlns=\"http://www.dataaccess.com/webservicesserver/\">\n      <NumberToDollarsResult>place your string value here</NumberToDollarsResult>\n    </NumberToDollarsResponse>\n  </soap12:Body>\n</soap12:Envelope>\n",
+    "cookie": [],
+    "_postman_previewlanguage": "xml"
+  }],
+  "event": []
+}]

--- a/test/data/transactionsValidation/numberToWordsCollectionItemsNoCTHeader.json
+++ b/test/data/transactionsValidation/numberToWordsCollectionItemsNoCTHeader.json
@@ -12,7 +12,10 @@
       "query": [],
       "variable": []
     },
-    "header": [],
+    "header": [{
+      "key": "SOAPAction",
+      "value": "http://www.dataaccess.com/webservicesserver/NumberToWords"
+    }],
     "method": "POST",
     "body": {
       "mode": "raw",

--- a/test/unit/TransactionValidator.test.js
+++ b/test/unit/TransactionValidator.test.js
@@ -37,6 +37,9 @@ const notIdCollectionItems = require('./../data/transactionsValidation/notIdColl
    require('./../data/transactionsValidation/numberToWordsCollectionItemsInvalidXMLBody.json'),
   expectedMissingEndpointaebb36fc =
   require('./../data/transactionsValidation/resultValidation/expectedMissingEndpointaebb36fc'),
+  numberToWordsCollectionItemsNOSOAPAcHeader =
+  require('./../data/transactionsValidation/numberToWordsCollectionItemsNOSOAPAcHeader.json'),
+
   {
     assert,
     expect
@@ -840,6 +843,105 @@ describe('Validate Headers', function() {
       }
     });
   });
+
+  it('Should return missmatch when soap action header is missing',
+    function () {
+      const options = getOptions({
+          usage: ['VALIDATION']
+        }),
+        validateHeaderOption = options.find((option) => { return option.id === 'validateHeader'; });
+      let optionFromOptions = {},
+        transactionValidator,
+        result;
+      optionFromOptions[`${validateHeaderOption.id}`] = true;
+      transactionValidator = new TransactionValidator();
+      result = transactionValidator.validateTransaction(numberToWordsCollectionItemsNOSOAPAcHeader,
+        numberToWordsWSDLObject, new XMLParser(), optionFromOptions);
+      expect(result).to.be.an('object').and.to.deep.include({
+        matched: false,
+        requests: {
+          '18403328-4213-4c3e-b0e9-b21a636697c3': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap12 NumberToDollars',
+              mismatches: [],
+              responses: {
+                '1763f0b2-9f34-4796-a390-b94ee5c37c7c': {
+                  id: '1763f0b2-9f34-4796-a390-b94ee5c37c7c',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '18403328-4213-4c3e-b0e9-b21a636697c3'
+          },
+          '353e33da-1eee-41c1-8865-0f72b2e1fd10': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap12 NumberToWords',
+              mismatches: [],
+              responses: {
+                'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4': {
+                  id: 'c8a892b6-4b2e-4523-9cc3-fc3e08c835c4',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '353e33da-1eee-41c1-8865-0f72b2e1fd10'
+          },
+          '395c9db6-d6f5-45a7-90f5-09f5aab4fe92': {
+            endpoints: [{
+              matched: true,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap NumberToDollars',
+              mismatches: [],
+              responses: {
+                '8a0c6532-84f9-45c7-838a-f4bf1a6de002': {
+                  id: '8a0c6532-84f9-45c7-838a-f4bf1a6de002',
+                  matched: true,
+                  mismatches: []
+                }
+              }
+            }],
+            requestId: '395c9db6-d6f5-45a7-90f5-09f5aab4fe92'
+          },
+          'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0': {
+            endpoints: [{
+              matched: false,
+              endpointMatchScore: 1,
+              endpoint: 'POST soap NumberToWords',
+              mismatches: [
+                {
+                  property: 'HEADER',
+                  transactionJsonPath: '$.request.header',
+                  schemaJsonPath: 'schemaPathPrefix',
+                  reasonCode: 'MISSING_IN_REQUEST',
+                  reason: 'The header "SoapAction" was not found in the transaction'
+                }
+              ],
+              responses: {
+                'd36c56cf-0cf6-4273-a34d-973e842bf80f': {
+                  id: 'd36c56cf-0cf6-4273-a34d-973e842bf80f',
+                  matched: false,
+                  mismatches: [{
+                    'property': 'HEADER',
+                    'reason': 'The header "Content-Type" needs to be "text/xml" or "application/soap+xml" ' +
+                    'but we found "text/plain; charset=utf-8" instead',
+                    'reasonCode': 'INVALID_TYPE',
+                    'schemaJsonPath': 'schemaPathPrefix',
+                    'transactionJsonPath': '$.responses[d36c56cf-0cf6-4273-a34d-973e842bf80f].header[0].value'
+                  }]
+                }
+              }
+            }],
+            requestId: 'aebb36fc-1be3-44c3-8f4a-0b5042dc17d0'
+          }
+        }
+      });
+    });
 });
 
 


### PR DESCRIPTION
Add SOAPAction header validation while validating transaction.

Options ignore unresolved variables and show missing schema errors.

If the WSDL operation has soapAction then the header must be present and have the same value
If the WSDL operation does not have soapAction then the header must not be present but if the show missing schema errors is true must show the  mismatch as missing in schema
if the value is a PM variable and ignore unresolved variables is true then no mismatch must be present