### PR TITLE
Fixed issue where tns was used as fixed name for defining current namespace.

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -18,6 +18,7 @@ const
   WSDL_NS_URL = 'http://schemas.xmlsoap.org/wsdl/',
   SOAP_NS_URL = 'http://schemas.xmlsoap.org/wsdl/soap/',
   SOAP_NS_KEY = 'xmlns:soap',
+  HTTP_NS_URL = 'http://schemas.xmlsoap.org/wsdl/http/',
   HTTP_NS_KEY = 'xmlns:http',
   SOAP_12_NS_URL = 'http://schemas.xmlsoap.org/wsdl/soap12/',
   SCHEMA_NS_URL = 'http://www.w3.org/2001/XMLSchema',
@@ -95,6 +96,7 @@ class WsdlInformationService11 {
     this.SchemaNamespaceURL = SCHEMA_NS_URL;
     this.RootTagName = WSDL_ROOT;
     this.WSDLNamespaceURL = WSDL_NS_URL;
+    this.HTTPNamespaceURL = HTTP_NS_URL;
     this.HTTPNamespaceKey = HTTP_NS_KEY;
     this.THISNamespaceKey = TNS_NS_KEY;
     this.TargetNamespaceKey = TARGETNAMESPACE_KEY;
@@ -117,10 +119,13 @@ class WsdlInformationService11 {
   * gets the port type name corresponding to the sent binding
   * found by the tag type
   * @param {string} binding the binding object from wsdl
+  * @param {object} tnsNamespace tns namespace object
   * @returns {string} the porttype name
   */
-  getAbstractDefinitionName(binding) {
-    return getAttributeByName(binding, ATTRIBUTE_TYPE).replace(THIS_NS_PREFIX, '');
+  getAbstractDefinitionName(binding, tnsNamespace) {
+    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX;
+
+    return getAttributeByName(binding, ATTRIBUTE_TYPE).replace(tnsNamespacePrefix, '');
   }
 
   getOperationxPathInfo(bindingName, operationName, wsdlNamespaceUrl) {
@@ -207,9 +212,11 @@ class WsdlInformationService11 {
    * @param {object} elementsFromWSDL all the elements of the document
    * @param {string} principalPrefix the principal prefix of the document
    * @param {string} tag the tag for search of could be input output fault
+   * @param {object} tnsNamespace tns namespace object
    * @returns {object} the WSDLObject
    */
-  getElementFromPortTypeInterfaceOperation(parsedXml, portTypeOperation, elementsFromWSDL, principalPrefix, tag) {
+  getElementFromPortTypeInterfaceOperation(parsedXml, portTypeOperation, elementsFromWSDL, principalPrefix, tag,
+    tnsNamespace) {
     let information = getNodeByName(portTypeOperation, principalPrefix, tag),
       messageName, elementName,
       elementsArray = [];
@@ -220,7 +227,7 @@ class WsdlInformationService11 {
       information.forEach((informationTag) => {
         let foundElement;
         messageName = getAttributeByName(informationTag, ATTRIBUTE_MESSAGE);
-        elementName = this.getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName);
+        elementName = this.getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName, tnsNamespace);
         elementName = excludeSeparatorFromName(elementName);
         foundElement = elementsFromWSDL.find((element) => {
           return element.name === elementName;
@@ -243,23 +250,26 @@ class WsdlInformationService11 {
    * @param {object} parsedXml the content file in javascript object representation
    * @param {string} principalPrefix the principal prefix of the document
    * @param {string} messageName the name too look up for
+   * @param {object} tnsNamespace tns namespace object
    * @returns {object} the message from WSDLObject
    */
-  getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName) {
+  getMessageElementNameByMessageName(parsedXml, principalPrefix, messageName, tnsNamespace) {
     let definitions = getNodeByName(parsedXml, principalPrefix, WSDL_ROOT),
+      tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX,
       part, elementName,
-      messageOnlyName = messageName.replace(THIS_NS_PREFIX, ''),
+      messageOnlyName = messageName.replace(tnsNamespacePrefix, ''),
       messages = getArrayFrom(getNodeByName(definitions, principalPrefix, MESSAGE_TAG)),
       foundMessage = messages.find((message) => {
         return getAttributeByName(message, ATTRIBUTE_NAME) === messageOnlyName;
       });
+
     if (foundMessage) {
       part = getNodeByName(foundMessage, principalPrefix, PART_TAG);
       elementName = getAttributeByName(part, ATTRIBUTE_ELEMENT);
       if (!elementName || Array.isArray(elementName)) {
-        return messageName.replace(THIS_NS_PREFIX, '');
+        return messageName.replace(tnsNamespacePrefix, '');
       }
-      elementName = elementName.replace(THIS_NS_PREFIX, '');
+      elementName = elementName.replace(tnsNamespacePrefix, '');
     }
     return elementName;
   }

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -77,6 +77,7 @@ class WsdlInformationService20 {
     this.RootTagName = WSDL_ROOT;
     this.WSDLNamespaceURL = WSDL_NS_URL;
     this.HTTPNamespaceKey = HTTP_NS_KEY;
+    this.HTTPNamespaceURL = HTTP_NS_URL;
     this.THISNamespaceKey = TNS_NS_KEY;
     this.TargetNamespaceKey = TARGETNAMESPACE_KEY;
     this.XMLPolicyURL = XML_POLICY;
@@ -89,19 +90,25 @@ class WsdlInformationService20 {
   /**
   * gets the binding operation name from the binding object
   * @param {object} bindingOperation the WSDL Binding operation
+  * @param {object} tnsNamespace tns namespace object
   * @returns {string} the fault tag name
   */
-  getBindingOperationName(bindingOperation) {
-    return getAttributeByName(bindingOperation, ATTRIBUTE_REF).replace(THIS_NS_PREFIX, '');
+  getBindingOperationName(bindingOperation, tnsNamespace) {
+    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX;
+
+    return getAttributeByName(bindingOperation, ATTRIBUTE_REF).replace(tnsNamespacePrefix, '');
   }
 
   /**
   * gets the interface name corresponding to the sent binding
   * @param {string} binding the binding object from wsdl
+  * @param {object} tnsNamespace tns namespace object
   * @returns {string} the interface name
   */
-  getAbstractDefinitionName(binding) {
-    return getAttributeByName(binding, INTERFACE_TAG).replace(THIS_NS_PREFIX, '');
+  getAbstractDefinitionName(binding, tnsNamespace) {
+    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX;
+
+    return getAttributeByName(binding, INTERFACE_TAG).replace(tnsNamespacePrefix, '');
   }
 
   /**
@@ -423,11 +430,12 @@ class WsdlInformationService20 {
    * @param {object} elementsFromWSDL all the elements of the document
    * @param {string} principalPrefix the principal prefix of the document
    * @param {string} tag the tag for search of could be input output fault
+   * @param {object} tnsNamespace tns namespace object
    * @param {string} portTypeInterfaceName interface name
    * @returns {object} the WSDLObject
    */
   getElementFromPortTypeInterfaceOperation(parsedXML, interfaceOperation, elementsFromWSDL,
-    principalPrefix, tag, portTypeInterfaceName) {
+    principalPrefix, tag, tnsNamespace, portTypeInterfaceName) {
 
     let interfaceElement = this.getInterfaceByInterfaceName(portTypeInterfaceName,
       parsedXML, principalPrefix);

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -6,6 +6,7 @@ const
     getPrincipalPrefix,
     getNamespaceByURL,
     getNamespaceByKey,
+    getTnsNamespace,
     getAllNamespaces,
     getServices,
     getBindings,
@@ -64,19 +65,20 @@ class WsdlParser {
     const allNameSpaces = getAllNamespaces(parsedXml, this.informationService.RootTagName),
       wsdlNamespace = getNamespaceByURL(parsedXml, this.informationService.WSDLNamespaceURL,
         this.informationService.RootTagName),
-      soapNamespace = getNamespaceByKey(parsedXml, this.informationService.SOAPNamespaceKey,
-        this.informationService.RootTagName),
+      soapNamespace = getNamespaceByURL(parsedXml, this.informationService.SOAPNamesapceURL,
+        this.informationService.RootTagName) ||
+        getNamespaceByKey(parsedXml, this.informationService.SOAPNamespaceKey, this.informationService.RootTagName),
       soap12Namespace = getNamespaceByURL(parsedXml, this.informationService.SOAP12NamesapceURL,
         this.informationService.RootTagName),
-      tnsNamespace = getNamespaceByKey(parsedXml, this.informationService.THISNamespaceKey,
-        this.informationService.RootTagName),
-      { globalSchemaNamespace, localSchemaNamespaces } = getSchemaNamespace(parsedXml,
-        this.informationService.RootTagName, tnsNamespace),
-      HTTPNamespace = getNamespaceByKey(parsedXml, this.informationService.HTTPNamespaceKey,
-        this.informationService.RootTagName),
-
       targetNamespace = getNamespaceByKey(parsedXml, this.informationService.TargetNamespaceKey,
         this.informationService.RootTagName),
+      tnsNamespace = getTnsNamespace(parsedXml, this.informationService.THISNamespaceKey,
+        targetNamespace, allNameSpaces, this.informationService.RootTagName),
+      { globalSchemaNamespace, localSchemaNamespaces } = getSchemaNamespace(parsedXml,
+        this.informationService.RootTagName, tnsNamespace),
+      HTTPNamespace = getNamespaceByURL(parsedXml, this.informationService.HTTPNamespaceURL,
+        this.informationService.RootTagName) ||
+        getNamespaceByKey(parsedXml, this.informationService.HTTPNamespaceKey, this.informationService.RootTagName),
       securityPolicyNamespace = getNamespaceByURL(parsedXml, this.informationService.XMLPolicyURL,
         this.informationService.RootTagName);
 
@@ -152,7 +154,7 @@ class WsdlParser {
           newWsdlObject.HTTPNamespace),
         bindingOperations = getBindingOperation(binding, principalPrefix, newWsdlObject),
 
-        portTypeInterfaceName = this.informationService.getAbstractDefinitionName(binding);
+        portTypeInterfaceName = this.informationService.getAbstractDefinitionName(binding, newWsdlObject.tnsNamespace);
 
       bindingOperations.forEach((bindingOperation) => {
         let wsdlOperation = new Operation(),
@@ -162,7 +164,7 @@ class WsdlParser {
           serviceAndPort,
           operationDocumentation,
           bindingOperationName =
-            this.informationService.getBindingOperationName(bindingOperation);
+            this.informationService.getBindingOperationName(bindingOperation, newWsdlObject.tnsNamespace);
 
         serviceAndPort = this.informationService.getServiceAndExpossedInfoByBindingName(
           getAttributeByName(binding, this.informationService.NameTag),
@@ -206,6 +208,7 @@ class WsdlParser {
           elements,
           principalPrefix,
           this.informationService.InputTagName,
+          newWsdlObject.tnsNamespace,
           portTypeInterfaceName
         );
         wsdlOperation.output = this.informationService.getElementFromPortTypeInterfaceOperation(
@@ -214,6 +217,7 @@ class WsdlParser {
           elements,
           principalPrefix,
           this.informationService.OutputTagName,
+          newWsdlObject.tnsNamespace,
           portTypeInterfaceName
         );
         wsdlOperation.fault = this.informationService.getElementFromPortTypeInterfaceOperation(
@@ -222,6 +226,7 @@ class WsdlParser {
           elements,
           principalPrefix,
           this.informationService.FaultTagName,
+          newWsdlObject.tnsNamespace,
           portTypeInterfaceName
         );
         wsdlOperation.xpathInfo = this.informationService.getOperationxPathInfo(

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -186,6 +186,27 @@ function getNamespaceByKey(parsedXml, key, wsdlRoot) {
 }
 
 /**
+ * Finds the namespace lookin by url
+ * creates a namespace object with the found information
+ * @param {object} parsedXml the binding operation object
+ * @param {string} defaultTnsKey default prefix key for tns namespace
+ * @param {object} targetNamespace target namespace object
+ * @param {array} allNameSpaces all namespaces object
+ * @param {string} wsdlRoot the root tag for the document
+ * @returns {NameSpace} the  new NameSpace object
+ */
+function getTnsNamespace(parsedXml, defaultTnsKey, targetNamespace, allNameSpaces, wsdlRoot) {
+  let tnsNamespace = allNameSpaces.find((ns) => {
+    return ns.url === targetNamespace.url && ns.key !== targetNamespace.key;
+  });
+
+  if (tnsNamespace) {
+    return tnsNamespace;
+  }
+  return getNamespaceByKey(parsedXml, defaultTnsKey, wsdlRoot);
+}
+
+/**
  * Finds all the  namespaces of the document
  * creates a namespace array object with the found information
  * @param {object} parsedXml the binding operation object
@@ -590,6 +611,7 @@ module.exports = {
   getPrincipalPrefix,
   getNamespaceByURL,
   getNamespaceByKey,
+  getTnsNamespace,
   getAllNamespaces,
   XML_NAMESPACE_SEPARATOR,
   XML_NAMESPACE_DECLARATION,

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -110,7 +110,7 @@ class SchemaBuilderXSD {
       sortedSchemas.forEach((schemaTag) => {
 
         schemaStrings.push(this.getXMLSchemaProcessed(schemaTag.foundSchemaTag, schemaTag.foundLocalSchemaNamespace,
-          schemaTag.targetNamespace, parserPlaceholder));
+          schemaTag.targetNamespace, schemaTag.tnsNamespace, parserPlaceholder));
       });
       jsonSchemas = xsdParser.parseAllSchemas(schemaStrings);
       mergedDefinitionsSchema = this.mergeAllSchemaDefinitionsInOne(jsonSchemas);
@@ -182,10 +182,16 @@ class SchemaBuilderXSD {
     }
     if (globalSchemaTag) {
       globalSchemaTag.forEach((schemaTag) => {
+        let targetNamespace = getXMLAttributeByName(schemaTag, parserPlaceholder, ATTRIBUTE_TARGET_NAMESPACE),
+          tnsNamespace = Array.isArray(wsdlObject.allNameSpaces) && wsdlObject.allNameSpaces.find((ns) => {
+            return targetNamespace === ns.url;
+          });
+
         schemaTags.push({
           foundSchemaTag: schemaTag,
           foundLocalSchemaNamespace: wsdlObject.schemaNamespace,
-          targetNamespace: getXMLAttributeByName(schemaTag, parserPlaceholder, ATTRIBUTE_TARGET_NAMESPACE)
+          targetNamespace,
+          tnsNamespace
         });
       });
     }
@@ -272,7 +278,7 @@ class SchemaBuilderXSD {
       return newElements;
     }
     filtered = messages.filter((message) => {
-      let part = getXMLNodeByName(message, principalPrefix, ATTRIBUTE_PART),
+      let part = getXMLNodeByName(message, principalPrefix, ATTRIBUTE_PART) || {},
         hasPartKey = Object.keys(part).find((key) => {
           if (key === `${parserPlaceholder}type`) {
             return true;
@@ -392,10 +398,11 @@ class SchemaBuilderXSD {
    * @param {object} schemaTag the wsdl schema information object
    * @param {NameSpace} schemaNamespace  the schema namespace information from the wsdl
    * @param {NameSpace} tnsNamespaceURL  the this namespace url
+   * @param {array} tnsNamespace the this namespace object
    * @param {string} parserPlaceholder the corresponding parser prefix for ATTRIBUTEs
    * @returns {string} the xml representation of the object
    */
-  getXMLSchemaProcessed(schemaTag, schemaNamespace, tnsNamespaceURL, parserPlaceholder) {
+  getXMLSchemaProcessed(schemaTag, schemaNamespace, tnsNamespaceURL, tnsNamespace, parserPlaceholder) {
     let localSchemaTag = {
         ...schemaTag
       },
@@ -407,7 +414,13 @@ class SchemaBuilderXSD {
     else {
       localSchemaTag[parserPlaceholder + 'xmlns:' + schemaNamespace.key] = schemaNamespace.url;
     }
-    localSchemaTag[parserPlaceholder + 'xmlns:tns'] = tnsNamespaceURL;
+    if (tnsNamespace) {
+      // assign tns namespace for current schema if present at wsdl root level
+      localSchemaTag[parserPlaceholder + 'xmlns:' + tnsNamespace.key] = tnsNamespace.url;
+    }
+    else {
+      localSchemaTag[parserPlaceholder + 'xmlns:tns'] = tnsNamespaceURL;
+    }
     objectSchema = {};
     objectSchema[schemaNamespace.prefixFilter + SCHEMA_TAG] = localSchemaTag;
     schema = this.parseObjectToXML(objectSchema);
@@ -498,6 +511,10 @@ class SchemaBuilderXSD {
       jsonSchemaSimpleTypesProcessed;
     const definitionsNames = Object.keys(jsonSchema.definitions),
       scTag = schemaTagInformation.foundSchemaTag;
+
+    // set current tnsNamespace under this
+    this.tnsNamespace = schemaTagInformation.tnsNamespace;
+
     complexTypesFromCurrentTag = getArrayFrom(this.getComplexTypesFromSchema(scTag, schemaPrefixFilter));
     simpleTypesFromCurrentTag = getArrayFrom(this.getSimpleTypesFromSchema(scTag, schemaPrefixFilter));
     elementTypesFromCurrentTag = getArrayFrom(this.getElementsFromSchema(scTag, schemaPrefixFilter));
@@ -1320,12 +1337,17 @@ class SchemaBuilderXSD {
    */
   getComplexTypeByName(complexTypeName, complexTypes) {
     let complexType,
-      complexTypeNameFound;
+      complexTypeNameFound,
+      tnsNamespacePrefix = 'tns:';
+
+    if (this.tnsNamespace && typeof this.tnsNamespace.key === 'string') {
+      tnsNamespacePrefix = this.tnsNamespace.key + ':';
+    }
 
     if (complexTypeName.startsWith('FORWARD_REFERENCE#')) {
       complexTypeNameFound = complexTypeName.split('/').reverse()[0];
-      complexTypeNameFound = complexTypeNameFound.includes('tns:') ? complexTypeNameFound.replace('tns:', '') :
-        complexTypeNameFound;
+      complexTypeNameFound = complexTypeNameFound.includes(tnsNamespacePrefix) ?
+        complexTypeNameFound.replace(tnsNamespacePrefix, '') : complexTypeNameFound;
     }
     else {
       complexTypeNameFound = getLastSegmentURL(complexTypeName);
@@ -1365,12 +1387,17 @@ class SchemaBuilderXSD {
    */
   getSimpleTypeByName(simpleTypeName, simpleTypes) {
     let simpleType,
-      simpleTypeNameToSearch = '';
+      simpleTypeNameToSearch = '',
+      tnsNamespacePrefix = 'tns:';
+
+    if (this.tnsNamespace && typeof this.tnsNamespace.key === 'string') {
+      tnsNamespacePrefix = this.tnsNamespace.key + ':';
+    }
 
     if (simpleTypeName.startsWith('FORWARD_REFERENCE#')) {
       simpleTypeNameToSearch = simpleTypeName.split('/').reverse()[0];
-      simpleTypeNameToSearch = simpleTypeNameToSearch.includes('tns:') ? simpleTypeNameToSearch.replace('tns:', '') :
-        simpleTypeNameToSearch;
+      simpleTypeNameToSearch = simpleTypeNameToSearch.includes(tnsNamespacePrefix) ?
+        simpleTypeNameToSearch.replace(tnsNamespacePrefix, '') : simpleTypeNameToSearch;
     }
     else {
       simpleTypeNameToSearch = getLastSegmentURL(simpleTypeName);

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -184,7 +184,7 @@ class SchemaBuilderXSD {
       globalSchemaTag.forEach((schemaTag) => {
         let targetNamespace = getXMLAttributeByName(schemaTag, parserPlaceholder, ATTRIBUTE_TARGET_NAMESPACE),
           tnsNamespace = Array.isArray(wsdlObject.allNameSpaces) && wsdlObject.allNameSpaces.find((ns) => {
-            return targetNamespace === ns.url;
+            return targetNamespace === ns.url && ns.key !== ATTRIBUTE_TARGET_NAMESPACE;
           });
 
         schemaTags.push({

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -1139,7 +1139,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'SayHelloHttpSoap11Endpoint',
         serviceName: 'SayHello',
         xpathInfo: {
-          xpath: '//description//binding[@name="SayHelloSoap11Binding"]//operation[@ref="tns:hi"]',
+          xpath: '//description//binding[@name="SayHelloSoap11Binding"]//operation[@ref="ns:hi"]',
           wsdlNamespaceUrl: 'http://www.w3.org/ns/wsdl'
         }
       });
@@ -1153,7 +1153,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'SayHelloHttpSoap12Endpoint',
         serviceName: 'SayHello',
         xpathInfo: {
-          xpath: '//description//binding[@name="SayHelloSoap12Binding"]//operation[@ref="tns:hi"]',
+          xpath: '//description//binding[@name="SayHelloSoap12Binding"]//operation[@ref="ns:hi"]',
           wsdlNamespaceUrl: 'http://www.w3.org/ns/wsdl'
         }
       });
@@ -1167,7 +1167,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'SayHelloHttpEndpoint',
         serviceName: 'SayHello',
         xpathInfo: {
-          xpath: '//description//binding[@name="SayHelloHttpBinding"]//operation[@ref="tns:hi"]',
+          xpath: '//description//binding[@name="SayHelloHttpBinding"]//operation[@ref="ns:hi"]',
           wsdlNamespaceUrl: 'http://www.w3.org/ns/wsdl'
         }
       });


### PR DESCRIPTION
This PR fixes issue where if namespace prefix other then `tns` was used, the conversion failed for it. Same is case for `soap` and `http` namespace where we assumed fixed key to be present instead of relying on URL.

https://github.com/postmanlabs/postman-app-support/issues/10067#issuecomment-924106783

