### PR TITLE
Issue/nested folders

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,0 +1,9 @@
+id|type|available options|default|description|usage
+|---|---|---|---|---|---|
+folderStrategy|enum|No folders, Port/Endpoint, Service|Port/Endpoint|Select whether to create folders according to the WSDL port/endpoing service or without folders|CONVERSION
+validateHeader|boolean|-|false|Select true to validate your collection requests/responses headers are correctly set|VALIDATION
+validationPropertiesToIgnore|array|-||Specific properties (parts of a request/response pair) to ignore during validation. Must be sent as an array of strings. Valid inputs in the array:  BODY, RESPONSE_BODY, SOAP_METHOD|VALIDATION
+ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting from unresolved variables in the Postman request|VALIDATION
+detailedBlobValidation|boolean|-|false|If it is true, all the mismatches will contain detailed info about the error generated if false, the mismatch will return a general description for the error|VALIDATION
+showMissingInSchemaErrors|boolean|-|true|If true (as default), it will report mismatches generated from errors with elements that are not in the schema but are in the request body, if false it will not report those errors|VALIDATION
+suggestAvailableFixes|boolean|-|false|If is true, all the mismatches in the body will contain the current and wrong value in your request an a suggestion with a value valid in schema|VALIDATION

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The converter can be used as a CLI tool as well. The following [command line opt
   Used to pretty print the collection object while writing to a file
 
 - `-O`, `--options`
-  Used to supply options to the converter, for complete options details see [here](/OPTIONS.md)
+  Used to supply options to the converter
 
 - `-c`, `--options-config`  
-  Used to supply options to the converter through config file, for complete options details see [here](/OPTIONS.md)
+  Used to supply options to the converter through config file
 
 - `-h`, `--help`  
   Specifies all the options along with a few usage examples on the terminal

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Enables Postman support of the WSDL specification
 browserify index.js --standalone xsd2jsonschemafaker > xsd2jsonschemafaker.js
 
+### Options:
+
+Check out complete list of options and their usage at [OPTIONS.md](/OPTIONS.md)
 
 ## Command Line Interface
 
@@ -27,10 +30,10 @@ The converter can be used as a CLI tool as well. The following [command line opt
   Used to pretty print the collection object while writing to a file
 
 - `-O`, `--options`
-  Used to supply options to the converter
+  Used to supply options to the converter, for complete options details see [here](/OPTIONS.md)
 
 - `-c`, `--options-config`  
-  Used to supply options to the converter through config file
+  Used to supply options to the converter through config file, for complete options details see [here](/OPTIONS.md)
 
 - `-h`, `--help`  
   Specifies all the options along with a few usage examples on the terminal

--- a/README.md
+++ b/README.md
@@ -4,6 +4,58 @@ Enables Postman support of the WSDL specification
 browserify index.js --standalone xsd2jsonschemafaker > xsd2jsonschemafaker.js
 
 
+## Command Line Interface
+
+The converter can be used as a CLI tool as well. The following [command line options](#options) are available.
+
+`wsdl2postman [options]`
+
+### Options
+- `-v`, `--version`  
+  Specifies the version of the converter
+
+- `-s <source>`, `--spec <source>`  
+  Used to specify the WSDL specification (file path) which is to be converted
+
+- `-o <destination>`, `--output <destination>`  
+  Used to specify the destination file in which the collection is to be written
+
+- `-t`, `--test`  
+  Used to test the collection with an in-built sample specification
+
+- `-p`, `--pretty`  
+  Used to pretty print the collection object while writing to a file
+
+- `-O`, `--options`
+  Used to supply options to the converter, for complete options details see [here](/OPTIONS.md)
+
+- `-c`, `--options-config`  
+  Used to supply options to the converter through config file, for complete options details see [here](/OPTIONS.md)
+
+- `-h`, `--help`  
+  Specifies all the options along with a few usage examples on the terminal
+
+
+### Usage
+
+**Sample usage examples of the converter CLI**
+
+
+- Takes a specification (spec.wsdl) as an input and writes to a file (collection.json) with pretty printing and using provided options
+```terminal
+$ wsdl2postman -s spec.wsdl -o collection.json -p -O folderStrategy=Service
+```
+
+- Takes a specification (spec.wsdl) as an input and writes to a file (collection.json) with pretty printing and using provided options via config file
+```terminal
+$ wsdl2postman -s spec.wsdl -o collection.json -p  -c ./examples/cli-options-config.json
+```
+
+- Testing the converter
+```terminal
+$ wsdl2postman --test
+```
+
 
 ## Conversion Schema data example values
 

--- a/bin/wsdl2postman.js
+++ b/bin/wsdl2postman.js
@@ -77,7 +77,7 @@ outputFile = options.output || false;
 testFlag = options.test || false;
 prettyPrintFlag = options.pretty || false;
 configFile = options.optionsConfig || false;
-definedOptions = (!(program.options instanceof Array) ? program.options : {});
+definedOptions = (!(options.options instanceof Array) ? options.options : {});
 wsdlData;
 
 
@@ -121,7 +121,7 @@ function convert(wsdlData) {
   }
 
   // override options provided via cli
-  if (definedOptions && definedOptions.length > 0) {
+  if (definedOptions && Object.keys(definedOptions).length > 0) {
     options = definedOptions;
   }
 

--- a/bin/wsdl2postman.js
+++ b/bin/wsdl2postman.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/* eslint-disable no-restricted-modules */
+var program = require('commander'),
+  Converter = require('../index.js'),
+  fs = require('fs'),
+  path = require('path'),
+  availableOptions = require('../lib/utils/options').getOptions('use', { usage: ['CONVERSION'] }),
+  inputFile,
+  outputFile,
+  prettyPrintFlag,
+  configFile,
+  definedOptions,
+  testFlag,
+  wsdlData;
+
+/**
+ * Parses comma separated options mentioned in command args and generates JSON object
+ *
+ * @param {String} value - User defined options value
+ * @returns {Object} - Parsed option in format of JSON object
+ */
+function parseOptions(value) {
+  let definedOptions = value.split(','),
+    parsedOptions = {};
+
+  definedOptions.forEach((definedOption) => {
+    let option = definedOption.split('=');
+
+    if (option.length === 2 && Object.keys(availableOptions).includes(option[0])) {
+      try {
+        // parse parsable data types (e.g. boolean, integer etc)
+        parsedOptions[option[0]] = JSON.parse(option[1]);
+      }
+      catch (e) {
+        // treat value as string if can not be parsed
+        parsedOptions[option[0]] = option[1];
+      }
+    }
+    else {
+      console.warn('\x1b[33m%s\x1b[0m', 'Warning: Invalid option supplied ', option[0]);
+    }
+  });
+
+  return parsedOptions;
+}
+
+program
+  .version(require('../package.json').version, '-v, --version')
+  .option('-s, --spec <spec>', 'Convert given WSDL 1.1 or 2.0 spec to Postman Collection v2.0')
+  .option('-o, --output <output>', 'Write the collection to an output file')
+  .option('-t, --test', 'Test the WSDL converter')
+  .option('-p, --pretty', 'Pretty print the JSON file')
+  .option('-c, --options-config <optionsConfig>', 'JSON file containing Converter options')
+  .option('-O, --options <options>', 'comma separated list of options', parseOptions);
+
+program.on('--help', function () {
+  /* eslint-disable */
+  console.log('    Converts a given WSDL specification to POSTMAN Collections v2.1.0   ');
+  console.log(' ');
+  console.log('    Examples:');
+  console.log(' 		Read spec.wsdl and store the output in output.json after conversion     ');
+  console.log('	           ./wsdl2postman -s spec.wsdl -o output.json ');
+  console.log(' ');
+  console.log('	        Read spec.wsdl and print the output to the Console        ');
+  console.log('                   ./wsdl2postman -s spec.wsdl ');
+  console.log(' ');
+  console.log('                Read spec.wsdl and print the prettified output to the Console');
+  console.log('                  ./wsdl2postman -s spec.wsdl -p');
+  console.log(' ');
+  /* eslint-enable */
+});
+
+program.parse(process.argv);
+const options = program.opts();
+inputFile = options.spec;
+outputFile = options.output || false;
+testFlag = options.test || false;
+prettyPrintFlag = options.pretty || false;
+configFile = options.optionsConfig || false;
+definedOptions = (!(program.options instanceof Array) ? program.options : {});
+wsdlData;
+
+
+/**
+ * Helper function for the CLI to perform file writes based on the flags
+ * @param {Boolean} prettyPrintFlag - flag for pretty printing while writing the file
+ * @param {String} file - Destination file to which the write is to be performed
+ * @param {Object} collection - POSTMAN collection object
+ * @returns {void}
+ */
+function writeToFile(prettyPrintFlag, file, collection) {
+  if (prettyPrintFlag) {
+    fs.writeFile(file, JSON.stringify(collection, null, 4), (err) => {
+      if (err) { console.log('Could not write to file', err); } // eslint-disable-line no-console
+      // eslint-disable-next-line no-console
+      console.log('\x1b[32m%s\x1b[0m', 'Conversion successful, collection written to file');
+    });
+  }
+  else {
+    fs.writeFile(file, JSON.stringify(collection), (err) => {
+      if (err) { console.log('Could not write to file', err); } // eslint-disable-line no-console
+      // eslint-disable-next-line no-console
+      console.log('\x1b[32m%s\x1b[0m', 'Conversion successful, collection written to file');
+    });
+  }
+}
+
+/**
+ * Helper function for the CLI to convert swagger data input
+ * @param {String} wsdlData - swagger data used for conversion input
+ * @returns {void}
+ */
+function convert(wsdlData) {
+  let options = {};
+
+  // apply options from config file if present
+  if (configFile) {
+    configFile = path.resolve(configFile);
+    console.log('Options Config file: ', configFile); // eslint-disable-line no-console
+    options = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+  }
+
+  // override options provided via cli
+  if (definedOptions && definedOptions.length > 0) {
+    options = definedOptions;
+  }
+
+  Converter.convert({
+    type: 'string',
+    data: wsdlData
+  }, options, (err, status) => {
+    if (err) {
+      return console.error(err);
+    }
+    if (!status.result) {
+      console.log(status.reason); // eslint-disable-line no-console
+      process.exit(0);
+    }
+    else if (outputFile) {
+      let file = path.resolve(outputFile);
+      console.log('Writing to file: ', prettyPrintFlag, file, status); // eslint-disable-line no-console
+      writeToFile(prettyPrintFlag, file, status.output[0].data);
+    }
+    else {
+      console.log(status.output[0].data); // eslint-disable-line no-console
+      process.exit(0);
+    }
+  });
+}
+
+if (testFlag) {
+  wsdlData = fs.readFileSync(path.resolve(__dirname, '..', 'test/data/validWSDLs11',
+    'calculator-soap11and12.wsdl'), 'utf8');
+  console.log('testing conversion...'); // eslint-disable-line no-console
+  convert(wsdlData);
+}
+else if (inputFile) {
+  inputFile = path.resolve(inputFile);
+  console.log('Input file: ', inputFile); // eslint-disable-line no-console
+  wsdlData = fs.readFileSync(inputFile, 'utf8');
+  convert(wsdlData);
+}
+else {
+  program.emit('--help');
+  process.exit(0);
+}

--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ const {
 module.exports = {
   convert: function (input, options, cb) {
     const schema = new SchemaPack(input, options);
-    return schema.convert(cb);
+    if (schema.validationResult.result) {
+      return schema.convert(cb);
+    }
+    return cb(null, schema.validationResult);
   },
 
   validate: function (input) {

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -47,7 +47,7 @@ class Validator {
     }
 
     if (this.notContainsWsdlSpec(xml)) {
-      return this.result(undefined, false, 'Not WSDL Specification found in your document');
+      return this.result(undefined, false, 'Provided document is not a valid WSDL specification');
     }
 
     if (input.type !== 'folder') {

--- a/lib/WSDLParserFactory.js
+++ b/lib/WSDLParserFactory.js
@@ -63,7 +63,7 @@ class WSDLParserFactory {
     if (xmlDocumentContent.includes('description>')) {
       return V20;
     }
-    throw new WsdlError('Not WSDL Specification found in your document');
+    throw new WsdlError('Provided document is not a valid WSDL specification');
   }
 
   /**

--- a/lib/utils/WSDLMerger.js
+++ b/lib/utils/WSDLMerger.js
@@ -25,7 +25,7 @@ const
     getArrayFrom
   } = require('./objectUtils'),
   {
-    getFileNameFromPath
+    getFolderNameFromPath
   } = require('./textUtils'),
   WsdlError = require('../WsdlError'),
   {
@@ -67,8 +67,10 @@ class WSDLMerger {
 
     if (files) {
       filesPathArray.forEach((filePath) => {
-        contentFiles.push({ content: files[path.resolve(filePath.fileName)],
-          fileName: filePath.fileName });
+        contentFiles.push({
+          content: files[path.resolve(filePath.fileName)],
+          fileName: filePath.fileName
+        });
 
       });
       return new Promise((resolve, reject) => {
@@ -115,8 +117,10 @@ class WSDLMerger {
     }
 
     parsedXMLsAndFileNames = filesPathArray.map((file) => {
-      return { parsed: xmlParser.safeParseToObject(file.content),
-        fileName: file.fileName };
+      return {
+        parsed: xmlParser.safeParseToObject(file.content),
+        fileName: file.fileName
+      };
     }).filter((tuple) => {
       return tuple.parsed !== '';
     });
@@ -214,17 +218,19 @@ class WSDLMerger {
    * @param {string} wsdlRoot the wsdl root according to the version
    * @param {string} principalPrefix the wsdl principal prefix
    * @param {Array} parsedXMLsAndFileNames array of content files and files names
+   * @param {string} parentFolder the parents folder path
    * @returns {object} the root
    */
   getParsedWSDLOrSchemaBySchemaLocation(parentXML, parsedWSDL, parsedSchemas, schemaLocation, wsdlRoot,
-    principalPrefix, parsedXMLsAndFileNames) {
+    principalPrefix, parsedXMLsAndFileNames, parentFolder) {
     let schemaPrefix = '',
       found,
       allEllements = parsedWSDL.concat(parsedSchemas).filter((xmlParsed) => {
         return xmlParsed !== parentXML;
       });
     parsedXMLsAndFileNames.forEach((tuple) => {
-      if (getFileNameFromPath(tuple.fileName) === schemaLocation) {
+      let absolutePath = path.resolve(parentFolder, schemaLocation);
+      if (absolutePath === tuple.fileName) {
         if (!tuple.parsed[principalPrefix + wsdlRoot]) {
           schemaPrefix = getSchemaPrefixFromParsedSchema(tuple.parsed);
         }
@@ -251,6 +257,7 @@ class WSDLMerger {
     wsdlParser, parsedXMLsAndFileNames) {
     let principalPrefix = getPrincipalPrefix(WSDLRootFile, wsdlRoot),
       imports = getWSDLImports(WSDLRootFile, principalPrefix, wsdlRoot),
+      parentFolder = '',
       includes = getWSDLIncludes(WSDLRootFile, principalPrefix, wsdlRoot);
     imports.forEach((importInformation) => {
       let importedFound = this.getParsedWSDLOrSchemaByTargetNamespace(
@@ -266,6 +273,8 @@ class WSDLMerger {
           principalPrefix, attributePlaceHolder, wsdlParser, parsedXMLsAndFileNames);
       }
     });
+    parentFolder =
+      getFolderNameFromPath(parsedXMLsAndFileNames.find((tuple) => { return tuple.parsed === WSDLRootFile; }).fileName);
 
     includes.forEach((importInformation) => {
       let importedFound = this.getParsedWSDLOrSchemaBySchemaLocation(
@@ -275,7 +284,8 @@ class WSDLMerger {
         getAttributeByName(importInformation, ATTRIBUTE_SCHEMALOCATION),
         wsdlRoot,
         principalPrefix,
-        parsedXMLsAndFileNames
+        parsedXMLsAndFileNames,
+        parentFolder
       );
       if (importedFound.found) {
         this.assignImportedProperties(WSDLRootFile, importedFound, parsedWSDL, parsedSchemas, wsdlRoot,

--- a/lib/utils/textUtils.js
+++ b/lib/utils/textUtils.js
@@ -37,6 +37,12 @@ isPmVariable = (value) => {
   return typeof value === 'string' && value.startsWith('{{') && value.endsWith('}}');
 };
 
+/**
+* Returns the last part of an url e.g. www.any.com/some.txt returns some.txt
+* if the received value is empty returns empty string
+* @param {string} value the text to get the last part of an url
+* @returns {string} the modified text
+*/
 getLastSegmentURL = (value) => {
   if (!value) {
     return '';
@@ -48,6 +54,14 @@ getLastSegmentURL = (value) => {
   return segment;
 };
 
+
+/**
+* Returns the file name from a path
+* e.g. ./../schemas/Types.xsd returns Types.txt
+* if the received value is empty returns empty string
+* @param {string} value the text to get the last part of an url
+* @returns {string} the modified text
+*/
 getFileNameFromPath = (value) => {
   if (!value) {
     return '';
@@ -56,11 +70,27 @@ getFileNameFromPath = (value) => {
   return segment;
 };
 
+/**
+* Returns the path without the file name name from a full path
+* e.g.  schemas/Types.xsd returns schemas
+* if the received value is empty returns empty string
+* @param {string} value the text to get the last part of an url
+* @returns {string} the modified text
+*/
+getFolderNameFromPath = (value) => {
+  if (!value) {
+    return '';
+  }
+  let fileName = getFileNameFromPath(value);
+  return fileName ? value.replace(fileName, '') : value;
+};
+
 module.exports = {
   removeLineBreak,
   isPmVariable,
   removeLineBreakTabsSpaces,
   removeDoubleQuotes,
   getLastSegmentURL,
-  getFileNameFromPath
+  getFileNameFromPath,
+  getFolderNameFromPath
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -778,6 +778,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "commander": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
+      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA=="
+    },
     "comment-parser": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Convert a given WSDL specification (1.1) to Postman Collection",
   "main": "index.js",
   "bin": {
-    "openapi2postmanv2": "./bin/openapi2postmanv2.js"
+    "wsdl2postman": "./bin/wsdl2postman.js"
   },
   "scripts": {
     "test": "./scripts/test.sh",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Convert a given WSDL specification (1.1) to Postman Collection",
   "main": "index.js",
+  "bin": {
+    "openapi2postmanv2": "./bin/openapi2postmanv2.js"
+  },
   "scripts": {
     "test": "./scripts/test.sh",
     "unit-tests": "./node_modules/mocha/bin/mocha \"test/unit/**/**.test.js\"",
@@ -54,6 +57,7 @@
   "dependencies": {
     "ajv": "8.1.0",
     "clone": "2.1.2",
+    "commander": "8.2.0",
     "fast-xml-parser": "3.18.0",
     "libxmljs": "0.19.7",
     "libxmljs2": "0.27.0",

--- a/test/data/invalidWSDLs11/calculator-invalid.wsdl
+++ b/test/data/invalidWSDLs11/calculator-invalid.wsdl
@@ -1,0 +1,185 @@
+<wsdl:definitionsw xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:tns="http://tempuri.org/"
+    xmlns:s="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
+    <wsdl:types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+            <s:element name="Add">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="AddResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="AddResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Subtract">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="SubtractResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="SubtractResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Multiply">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="MultiplyResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="MultiplyResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Divide">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="DivideResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="DivideResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+        </s:schema>
+    </wsdl:types>
+    <wsdl:message name="AddSoapIn">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="AddSoapOut">
+        <wsdl:part name="parameters" element="tns:AddResponse" />
+    </wsdl:message>
+    <wsdl:message name="SubtractSoapIn">
+        <wsdl:part name="parameters" element="tns:Subtract" />
+    </wsdl:message>
+    <wsdl:message name="SubtractSoapOut">
+        <wsdl:part name="parameters" element="tns:SubtractResponse" />
+    </wsdl:message>
+    <wsdl:message name="MultiplySoapIn">
+        <wsdl:part name="parameters" element="tns:Multiply" />
+    </wsdl:message>
+    <wsdl:message name="MultiplySoapOut">
+        <wsdl:part name="parameters" element="tns:MultiplyResponse" />
+    </wsdl:message>
+    <wsdl:message name="DivideSoapIn">
+        <wsdl:part name="parameters" element="tns:Divide" />
+    </wsdl:message>
+    <wsdl:message name="DivideSoapOut">
+        <wsdl:part name="parameters" element="tns:DivideResponse" />
+    </wsdl:message>
+ 
+    <wsdl:binding name="CalculatorSoap" type="tns:CalculatorSoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Add">
+            <soap:operation soapAction="http://tempuri.org/Add" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <soap:operation soapAction="http://tempuri.org/Subtract" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <soap:operation soapAction="http://tempuri.org/Multiply" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <soap:operation soapAction="http://tempuri.org/Divide" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Add">
+            <soap12:operation soapAction="http://tempuri.org/Add" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <soap12:operation soapAction="http://tempuri.org/Subtract" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <soap12:operation soapAction="http://tempuri.org/Multiply" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <soap12:operation soapAction="http://tempuri.org/Divide" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Calculator">
+        <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+            <soap:address location="http://www.dneonline.com/calculator.asmx" />
+        </wsdl:port>
+        <wsdl:port name="CalculatorSoap12" binding="tns:CalculatorSoap12">
+            <soap12:address location="http://www.dneonline.com/calculator.asmx" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitionsw>

--- a/test/data/separatedFiles/nestedFolders/schemas/Types.xsd
+++ b/test/data/separatedFiles/nestedFolders/schemas/Types.xsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+  xmlns="http://namespace/2008" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://namespace/2008" 
+  version="2021.0.05.1"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:element name="ElementType" type="xsd:string" />
+</xsd:schema>

--- a/test/data/separatedFiles/nestedFolders/wsdl/Services.wsdl
+++ b/test/data/separatedFiles/nestedFolders/wsdl/Services.wsdl
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:ns="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://namespace/2008"
+    targetNamespace="http://namespace/2008">
+
+    <!-- This starts the Types section  -->
+
+    <types>
+        <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="http://namespace/2008"
+            xmlns="http://namespace/2008" version="2021.0.05.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:include schemaLocation="./../schemas/Types.xsd" />
+
+        </xsd:schema>
+    </types>
+
+    <!-- This starts the Message section  -->
+
+    <message name="MessageFault">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <message name="PingInput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+    <message name="PingOutput">
+        <part name="parameters" element="tns:ElementType" />
+    </message>
+
+    <!-- This starts the PortType section  -->
+
+    <portType name="LTSService">
+
+        <operation name="Ping">
+            <input message="tns:PingInput" />
+            <output message="tns:PingOutput" />
+            <fault name="Fault" message="tns:MessageFault" />
+        </operation>
+
+    </portType>
+
+    <!-- This starts the Binding section  -->
+
+    <binding name="LTSServiceSoapBinding" type="tns:LTSService">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <operation name="Ping">
+            <soap:operation soapAction="http://jackhenry.com/ws/Ping" />
+            <input>
+                <soap:body use="literal" />
+            </input>
+            <output>
+                <soap:body use="literal" />
+            </output>
+            <fault name="Fault">
+                <soap:fault name="Fault" use="literal" />
+            </fault>
+        </operation>
+    </binding>
+
+    <!-- This starts the Service section  -->
+
+    <service name="LTSService">
+        <documentation>Service Description for the LTSService Interface</documentation>
+        <port name="LTSServiceSoap" binding="tns:LTSServiceSoapBinding">
+            <soap:address location="https://{{url}}/LTS.svc" />
+        </port>
+    </service>
+</definitions>

--- a/test/system/indexFunctions.test.js
+++ b/test/system/indexFunctions.test.js
@@ -17,7 +17,7 @@ describe('Test validate function in SchemaPack through Index', function() {
     expect(result).to.be.an('object')
       .and.to.include({
         result: false,
-        reason: 'Not WSDL Specification found in your document'
+        reason: 'Provided document is not a valid WSDL specification'
       });
   });
 
@@ -26,7 +26,7 @@ describe('Test validate function in SchemaPack through Index', function() {
     expect(result).to.be.an('object')
       .and.to.include({
         result: false,
-        reason: 'Not WSDL Specification found in your document'
+        reason: 'Provided document is not a valid WSDL specification'
       });
   });
 

--- a/test/system/structure.test.js
+++ b/test/system/structure.test.js
@@ -1,0 +1,42 @@
+const expect = require('chai').expect,
+  fs = require('fs');
+getOptions = require('../../lib/utils/options').getOptions;
+
+
+/**
+ * Generates markdown table documentation of options from getOptions()
+ *
+ * @param {Object} options - options from getOptions()
+ * @returns {String} - markdown table consisting documetation for options
+ */
+function generateOptionsDoc(options) {
+  var doc = 'id|type|available options|default|description|usage\n|---|---|---|---|---|---|\n';
+  options.forEach((option) => {
+    var convertArrayToDoc = (array) => {
+        if (!array) {
+          return '-';
+        }
+        return array.reduce((acc, ele) => {
+          return (!acc ? acc : acc + ', ') + ele;
+        }, '');
+      },
+      defaultOption = option.default;
+    (defaultOption === undefined) && (defaultOption = JSON.stringify(defaultOption));
+    doc += `${option.id}|${option.type}|${convertArrayToDoc(option.availableOptions, true)}|` +
+      `${defaultOption}|${option.description}|${convertArrayToDoc(option.usage)}\n`;
+  });
+  return doc;
+}
+
+
+describe('OPTIONS.md', function () {
+  it('generates file', function () {
+    const content = generateOptionsDoc(getOptions());
+    fs.writeFileSync('OPTIONS.md', content);
+  });
+
+  it('must contain all details of options', function () {
+    const optionsDoc = fs.readFileSync('OPTIONS.md', 'utf-8');
+    expect(optionsDoc).to.eql(generateOptionsDoc(getOptions()));
+  });
+});

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -740,4 +740,35 @@ describe('merge and validate', function () {
     });
   });
 
+  it('Should create collection from nested folders send only file info', function (done) {
+    let folderPath = path.join(__dirname, SEPARATED_FILES, '/nestedFolders'),
+      array = [
+        { fileName: folderPath + '/wsdl/Services.wsdl' },
+        { fileName: folderPath + '/schemas/Types.xsd' }
+      ];
+    const schemaPack = new SchemaPack({ type: 'folder', data: array }, {});
+    schemaPack.mergeAndValidate((err, status) => {
+      if (err) {
+        expect.fail(null, null, err);
+      }
+      if (status.result) {
+        schemaPack.convert((error, result) => {
+          if (error) {
+            expect.fail(null, null, err);
+          }
+          expect(result.result).to.equal(true);
+          expect(result.output.length).to.equal(1);
+          expect(result.output[0].type).to.have.equal('collection');
+          expect(result.output[0].data).to.have.property('info');
+          expect(result.output[0].data).to.have.property('item');
+          expect(result.output[0].data.info.name).to.equal('LTSService');
+          done();
+        });
+      }
+      else {
+        expect.fail(null, null, status.reason);
+      }
+    });
+  });
+
 });

--- a/test/unit/cliTool.test.js
+++ b/test/unit/cliTool.test.js
@@ -3,7 +3,7 @@ const expect = require('chai').expect,
   exec = require('child_process').exec,
   moduleVersion = require('../../package.json').version;
 
-describe('wsdl2postman ', function() {
+describe('wsdl2postman ', function () {
   const tempOutputFile = 'tempOutput.json';
 
   after(function () {
@@ -12,24 +12,24 @@ describe('wsdl2postman ', function() {
     }
   });
 
-  it('should print help to console', function(done) {
-    exec('./bin/wsdl2postman.js --help', function(err, stdout) {
+  it('should print help to console', function (done) {
+    exec('./bin/wsdl2postman.js --help', function (err, stdout) {
       expect(err).to.be.null;
       expect(stdout).to.include('Converts a given WSDL specification to POSTMAN Collections v2.1.0 ');
       done();
     });
   });
 
-  it('should print version to console', function(done) {
-    exec('./bin/wsdl2postman.js -v', function(err, stdout) {
+  it('should print version to console', function (done) {
+    exec('./bin/wsdl2postman.js -v', function (err, stdout) {
       expect(err).to.be.null;
       expect(stdout).to.include(moduleVersion);
       done();
     });
   });
 
-  it('should print to the console testing conversion when test onption is sent', function(done) {
-    exec('./bin/wsdl2postman.js -t', function(err, stdout) {
+  it('should print to the console testing conversion when test onption is sent', function (done) {
+    exec('./bin/wsdl2postman.js -t', function (err, stdout) {
       expect(err).to.be.null;
       expect(stdout).to.include('testing conversion...');
       expect(stdout).to.include('CalculatorSoap');
@@ -37,8 +37,8 @@ describe('wsdl2postman ', function() {
     });
   });
 
-  it('should print to console test file', function(done) {
-    exec('./bin/wsdl2postman.js -t', function(err, stdout) {
+  it('should print to console test file', function (done) {
+    exec('./bin/wsdl2postman.js -t', function (err, stdout) {
       expect(err).to.be.null;
       expect(stdout).to.include('CalculatorSoap');
       done();
@@ -58,10 +58,24 @@ describe('wsdl2postman ', function() {
       });
   });
 
-  it('should show appropriate messages for invalid input', function (done) {
-    exec('./bin/wsdl2postman.js -s test/data/invalidWSDLs11/calculator-invalid.wsdl', function(err, stdout) {
+  it('should print to  with options', function (done) {
+    exec('./bin/wsdl2postman.js -s test/data/validWSDLs11/calculator-soap11and12.wsdl -o tempOutput.json' +
+      ' -O folderStrategy=Service',
+    function (err) {
       expect(err).to.be.null;
-      expect(stdout).to.include('Not WSDL Specification found in your document');
+      fs.readFile(tempOutputFile, 'utf8', (err, data) => {
+        let collection = JSON.parse(data);
+        expect(collection.info.name).to.equal('Calculator');
+        expect(collection.item.length).to.equal(8);
+        done();
+      });
+    });
+  });
+
+  it('should show appropriate messages for invalid input', function (done) {
+    exec('./bin/wsdl2postman.js -s test/data/invalidWSDLs11/calculator-invalid.wsdl', function (err, stdout) {
+      expect(err).to.be.null;
+      expect(stdout).to.include('Provided document is not a valid WSDL specification');
       done();
     });
   });

--- a/test/unit/cliTool.test.js
+++ b/test/unit/cliTool.test.js
@@ -1,0 +1,68 @@
+const expect = require('chai').expect,
+  fs = require('fs'),
+  exec = require('child_process').exec,
+  moduleVersion = require('../../package.json').version;
+
+describe('wsdl2postman ', function() {
+  const tempOutputFile = 'tempOutput.json';
+
+  after(function () {
+    if (fs.existsSync(tempOutputFile)) {
+      fs.unlinkSync(tempOutputFile);
+    }
+  });
+
+  it('should print help to console', function(done) {
+    exec('./bin/wsdl2postman.js --help', function(err, stdout) {
+      expect(err).to.be.null;
+      expect(stdout).to.include('Converts a given WSDL specification to POSTMAN Collections v2.1.0 ');
+      done();
+    });
+  });
+
+  it('should print version to console', function(done) {
+    exec('./bin/wsdl2postman.js -v', function(err, stdout) {
+      expect(err).to.be.null;
+      expect(stdout).to.include(moduleVersion);
+      done();
+    });
+  });
+
+  it('should print to the console testing conversion when test onption is sent', function(done) {
+    exec('./bin/wsdl2postman.js -t', function(err, stdout) {
+      expect(err).to.be.null;
+      expect(stdout).to.include('testing conversion...');
+      expect(stdout).to.include('CalculatorSoap');
+      done();
+    });
+  });
+
+  it('should print to console test file', function(done) {
+    exec('./bin/wsdl2postman.js -t', function(err, stdout) {
+      expect(err).to.be.null;
+      expect(stdout).to.include('CalculatorSoap');
+      done();
+    });
+  });
+
+  it('should print to file', function (done) {
+    exec('./bin/wsdl2postman.js -s test/data/validWSDLs11/calculator-soap11and12.wsdl -o tempOutput.json',
+      function (err) {
+        expect(err).to.be.null;
+        fs.readFile(tempOutputFile, 'utf8', (err, data) => {
+          let collection = JSON.parse(data);
+          expect(collection.info.name).to.equal('Calculator');
+          expect(collection.item.length).to.equal(2);
+          done();
+        });
+      });
+  });
+
+  it('should show appropriate messages for invalid input', function (done) {
+    exec('./bin/wsdl2postman.js -s test/data/invalidWSDLs11/calculator-invalid.wsdl', function(err, stdout) {
+      expect(err).to.be.null;
+      expect(stdout).to.include('Not WSDL Specification found in your document');
+      done();
+    });
+  });
+});

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -7,6 +7,7 @@ const expect = require('chai').expect,
     mergeAndValidate
   } = require('../../index'),
   validWSDLs = 'test/data/validWSDLs11',
+  invalidWSDLs = 'test/data/invalidWSDLs11',
   fs = require('fs'),
   path = require('path');
 
@@ -65,6 +66,20 @@ describe('convert', function () {
       expect(result.output).to.be.an('array');
       expect(result.output[0].data).to.be.an('object');
       expect(result.output[0].type).to.equal('collection');
+    });
+
+  });
+
+  it('Should return Not WSDL Specification found in your document whit invalid file', function () {
+    const
+      VALID_WSDL_PATH = invalidWSDLs + '/calculator-invalid.wsdl';
+    convert({
+      type: 'file',
+      data: VALID_WSDL_PATH
+    }, {}, (error, result) => {
+      expect(error).to.be.null;
+      expect(result.result).to.equal(false);
+      expect(result.reason).to.equal('Not WSDL Specification found in your document');
     });
 
   });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -70,7 +70,7 @@ describe('convert', function () {
 
   });
 
-  it('Should return Not WSDL Specification found in your document whit invalid file', function () {
+  it('Should return "Provided document is not a valid WSDL specification" with invalid file', function () {
     const
       VALID_WSDL_PATH = invalidWSDLs + '/calculator-invalid.wsdl';
     convert({
@@ -79,7 +79,7 @@ describe('convert', function () {
     }, {}, (error, result) => {
       expect(error).to.be.null;
       expect(result.result).to.equal(false);
-      expect(result.reason).to.equal('Not WSDL Specification found in your document');
+      expect(result.reason).to.equal('Provided document is not a valid WSDL specification');
     });
 
   });

--- a/test/unit/parserFactory.test.js
+++ b/test/unit/parserFactory.test.js
@@ -189,7 +189,7 @@ describe('Parser Factory getWsdlVersion', function () {
   </user>`);
     }
     catch (error) {
-      expect(error.message).to.equal('Not WSDL Specification found in your document');
+      expect(error.message).to.equal('Provided document is not a valid WSDL specification');
     }
   });
 
@@ -354,7 +354,7 @@ describe('Parser Factory getParser', function () {
       assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Not WSDL Specification found in your document');
+      expect(error.message).to.equal('Provided document is not a valid WSDL specification');
     }
   });
 

--- a/test/unit/validator.test.js
+++ b/test/unit/validator.test.js
@@ -105,7 +105,7 @@ string`, function () {
     expect(validator.validate(input, new XMLParser()).valResult).to.be.an('object')
       .and.to.include({
         result: false,
-        reason: 'Not WSDL Specification found in your document'
+        reason: 'Provided document is not a valid WSDL specification'
       });
   });
 


### PR DESCRIPTION
1. Problem description / What is the issue?

If a folder contains a nested folder structure, we are not resolving all files correctly.
E.g we have this files:

path/wsdl/some.wsdl
path/schemas/some.xsd

Some.wsdl has an include with schemaLocation=”../schemas/some.xsd”
We are not able to import and merge the schema


2. Root cause analysis / What caused the issue?
We compare the schema location with the name of the file having in this case (some.xsd != ../schemas/some.xsd) two different values.

If the schema location is a relative path then the comparison fails and we do not merge the imported schema


3. fix we implemented / What is the resolution?
First we need to obtain the parent’s (root in the current iteration) folder path, then we use path.resolve to obtain the absolute path of the imported schema and then we compare it against the filename which has the absolute path. Once we find the imported schema we continue with the process.
 
