### PR TITLE
Fixed issue where returns from few functions were not consistent.

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -241,7 +241,7 @@ class WsdlInformationService11 {
       });
       return elementsArray;
     }
-    return null;
+    return [];
   }
 
 
@@ -358,7 +358,7 @@ class WsdlInformationService11 {
 
       operationReturn = operations.find((operation) => {
         return getAttributeByName(operation, NAME_TAG) === operationName;
-      });
+      }) || {};
 
       return operationReturn;
     }

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -387,7 +387,7 @@ class WsdlInformationService20 {
       operations = getArrayFrom(getNodeByName(interfaceFound, principalPrefix, OPERATION_TAG));
       operationReturn = operations.find((operation) => {
         return getAttributeByName(operation, NAME_TAG) === getQNameLocal(operationName);
-      });
+      }) || {};
       return operationReturn;
     }
     catch (error) {
@@ -473,7 +473,7 @@ class WsdlInformationService20 {
       }
       return elements;
     }
-    return null;
+    return [];
   }
 
   /**
@@ -490,7 +490,7 @@ class WsdlInformationService20 {
     let faults,
       information = interfaceOperation[principalPrefix + tag];
     if (!information) {
-      return null;
+      return [];
     }
     const faultReference = getAttributeByName(information, ATTRIBUTE_REF);
 
@@ -511,7 +511,7 @@ class WsdlInformationService20 {
         }
       }
     }
-    return null;
+    return [];
   }
 
   /**

--- a/test/unit/WsdlInformationService20.test.js
+++ b/test/unit/WsdlInformationService20.test.js
@@ -154,20 +154,20 @@ describe('WSDL 2.0 parser getLocationFromBindingOperation', function () {
 });
 
 describe('WSDL 2.0 getElementFromInterfaceOperationFault', function () {
-  it('should get null when found element but not found ref', function () {
+  it('should get empty array when found element but not found ref', function () {
     const informationService = new WsdlInformationService20(),
       element = informationService.getElementFromInterfaceOperationFault({}, {
         outfault: {}
       }, null, '', 'outfault');
-    expect(element).to.eq(null);
+    expect(element).to.have.length(0);
   });
 });
 
 describe('WSDL 2.0 getElementFromInterfaceOperationInOut', function () {
-  it('should get null when not found element', function () {
+  it('should get empty array when not found element', function () {
     const informationService = new WsdlInformationService20(),
       element = informationService.getElementFromInterfaceOperationInOut({}, null, 'notfound', '');
-    expect(element).to.eq(null);
+    expect(element).to.have.length(0);
   });
 });
 

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -779,7 +779,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
       });
     expect(wsdlObject.operationsArray[1].input).to.be.an('Array');
     expect(wsdlObject.operationsArray[1].output).to.be.an('Array');
-    expect(wsdlObject.operationsArray[1].fault).to.be.null;
+    expect(wsdlObject.operationsArray[1].fault).to.have.length(0);
 
     expect(wsdlObject.operationsArray[2]).to.be.an('object')
       .and.to.include({


### PR DESCRIPTION
Fixed issue where `validateTranscation` was failing with TypeError. Due to an issue where we weren't returning consistent datatype meanwhile accessing returned data from these function as only one type.

https://user-images.githubusercontent.com/16756296/135325842-ba07bb2a-587e-4b79-b35a-9f2f8b43b111.mov

To reproduce, take any specification and generate a collection from it. Now change operation name under `<interface>`. And try `validateTranscation`.

