### PR TITLE
Body builder cache

### DIFF
--- a/lib/WsdlToPostmanCollectionBodyMapper.js
+++ b/lib/WsdlToPostmanCollectionBodyMapper.js
@@ -25,6 +25,11 @@ const XML = 'xml',
  */
 class WsdlToPostmanCollectionBodyMapper {
 
+  constructor() {
+    this.sOAPMessageHelper = new SOAPMessageHelper();
+    this.xMLMessageHelper = new XMLMessageHelper();
+  }
+
   /**
   * Generates the request's body for the sent operation
   * depending on operation protocol
@@ -112,9 +117,8 @@ class WsdlToPostmanCollectionBodyMapper {
       return this.createBodyForSOAP(elementToCreateBody, securityPolicyArray, xmlParser, SOAP_PROTOCOL);
     }
     else if (!isInput) {
-      let helper = new XMLMessageHelper();
       if (operation.mimeContentOutput && operation.mimeContentOutput.mimeType === MIME_TYPE_XML) {
-        return helper.convertInputToMessage(elementToCreateBody, xmlParser);
+        return this.xMLMessageHelper.convertInputToMessage(elementToCreateBody, xmlParser);
       }
       return this.getSOAPBodyMessage(elementToCreateBody, securityPolicyArray, SOAP_PROTOCOL,
         xmlParser);
@@ -134,8 +138,7 @@ class WsdlToPostmanCollectionBodyMapper {
   * elements and the default values examples
   */
   getSOAPBodyMessage(nodeElement, securityPolicyArray, protocol, xmlParser) {
-    const soapMessageHelper = new SOAPMessageHelper();
-    return soapMessageHelper.convertInputToMessage(nodeElement, securityPolicyArray, protocol,
+    return this.sOAPMessageHelper.convertInputToMessage(nodeElement, securityPolicyArray, protocol,
       xmlParser);
   }
 

--- a/lib/WsdlToPostmanCollectionMapper.js
+++ b/lib/WsdlToPostmanCollectionMapper.js
@@ -29,6 +29,7 @@ const XML = 'xml',
 class WsdlToPostmanCollectionMapper {
   constructor(wsdlObject) {
     this.wsdlObject = wsdlObject;
+    this.wsdlToPostmanCollectionBodyMapper = new WsdlToPostmanCollectionBodyMapper();
   }
 
   /**
@@ -338,8 +339,8 @@ class WsdlToPostmanCollectionMapper {
    */
   createItemsFromOperations(operations, urlVariablesData, securityPolicyArray, xmlParser) {
     let items = operations.map((operation) => {
-      let bodyMapper = new WsdlToPostmanCollectionBodyMapper(),
-        requestBody = bodyMapper.getBody(operation, operation.input[0], securityPolicyArray, xmlParser),
+      let requestBody = this.wsdlToPostmanCollectionBodyMapper
+          .getBody(operation, operation.input[0], securityPolicyArray, xmlParser),
         postmanItem = {
           name: operation.name,
           request: {
@@ -412,8 +413,8 @@ class WsdlToPostmanCollectionMapper {
    */
   buildResponseObject(sufixName, status, code, operation, requestBody,
     responseBodyElement, xmlParser) {
-    let bodyMapper = new WsdlToPostmanCollectionBodyMapper(),
-      responseBody = bodyMapper.getResponseBody(operation, responseBodyElement, undefined, xmlParser),
+    let responseBody = this.wsdlToPostmanCollectionBodyMapper
+        .getResponseBody(operation, responseBodyElement, undefined, xmlParser),
       response = new Response({
         name: operation.name + sufixName,
         status: status,

--- a/lib/utils/Cache.js
+++ b/lib/utils/Cache.js
@@ -1,0 +1,43 @@
+class Cache {
+
+  constructor() {
+    this.cache = {};
+  }
+
+  /**
+  * Retrieves an element from the cache
+  * @param {string} key element's key
+  * @returns {object} undefined if not found.
+  */
+  getFromCache(key) {
+    return this.cache[key];
+  }
+
+  /**
+  * Adds an element in the cache
+  * @param {string} key element's key
+  * @param {object} elementToCache elementToAddToCache
+  * @returns {undefined} nothing
+  */
+  addToCache(key, elementToCache) {
+    if (!this.getFromCache(key)) {
+      this.cache[key] = elementToCache;
+
+    }
+  }
+
+  /**
+  * Overrides an element in the cache
+  * @param {string} key element's key
+  * @param {object} elementToCache elementToAddToCache
+  * @returns {undefined} nothing
+  */
+  addOverWriteCache(key, elementToCache) {
+    this.cache[key] = elementToCache;
+  }
+
+}
+
+module.exports = {
+  Cache
+};

--- a/lib/utils/SOAPMessageHelper.js
+++ b/lib/utils/SOAPMessageHelper.js
@@ -36,8 +36,12 @@ class SOAPMessageHelper {
    * @returns {string} the compound key
    */
   getCompundKey(rootParametersElement, headerInfo, protocol, concatString) {
+    let headerInfoToUse;
+    if (Array.isArray(headerInfo) && headerInfo.length > 0) {
+      headerInfoToUse = headerInfo;
+    }
     return concatString(JSON.stringify(rootParametersElement),
-      concatString(JSON.stringify(headerInfo), JSON.stringify(protocol)));
+      concatString(JSON.stringify(headerInfoToUse), JSON.stringify(protocol)));
   }
 
   /**

--- a/lib/utils/SOAPMessageHelper.js
+++ b/lib/utils/SOAPMessageHelper.js
@@ -3,8 +3,14 @@ const
     SOAPBody
   } = require('./SOAPBody'),
   {
+    Cache
+  } = require('./Cache'),
+  {
     SOAPHeader
   } = require('./SOAPHeader'),
+  {
+    hash
+  } = require('./textUtils'),
   envelopeName =
     ':Envelope',
   bodyName =
@@ -17,19 +23,67 @@ const
 
 class SOAPMessageHelper {
 
+  constructor() {
+    this.cache = new Cache();
+  }
+
+  /**
+   * calculates the compound key
+   * @param {object} rootParametersElement root element in message
+   * @param {object} headerInfo the found information for the soap header
+   * @param {string} protocol could be either soap or soap12
+   * @param {function} concatString function to concatenate strings
+   * @returns {string} the compound key
+   */
+  getCompundKey(rootParametersElement, headerInfo, protocol, concatString) {
+    return concatString(JSON.stringify(rootParametersElement),
+      concatString(JSON.stringify(headerInfo), JSON.stringify(protocol)));
+  }
+
+  /**
+   * concatenates two strings
+   * @param {string} stringA the first string to concatenate
+   * @param {string} stringB the second string to concatenate
+   * @returns {string} the hashed for this input
+   */
+  concatString(stringA, stringB) {
+    return stringA + stringB;
+  }
+
+  /**
+   * hashes and input into a sha1 base64
+   * @param {object} rootParametersElement root element in message
+   * @param {object} headerInfo the found information for the soap header
+   * @param {string} protocol could be either soap or soap12
+   * @param {function} getCompundKey function to calculate the compund key
+   * @param {function} concatString function to concatenate strings
+   * @returns {string} the hashed for this input
+   */
+  getHashedKey(rootParametersElement, headerInfo, protocol, getCompundKey, concatString) {
+    return hash(getCompundKey(rootParametersElement, headerInfo, protocol, concatString), 'sha1',
+      'base64');
+  }
+
   /**
    * Generates the body message from a nodeElement
    * @param {Element} rootParametersElement node taken from parsedXml
    * @param {Element} headerInfo node taken from parsedXml
    * @param {string} protocol Protocol being used
-   * @param {boolean} xmlParser indicates if xmlns should be removed from the root node
+   * @param {Object} xmlParser the xml parser for the process
    * @returns {string} the rootParametersElement in xml string
    */
   convertInputToMessage(rootParametersElement, headerInfo, protocol, xmlParser) {
     let envelopeAndProtocol = protocol + envelopeName,
       jObj = {},
       bodyAndProtocol = protocol + bodyName,
-      headerAndProtocol = protocol + headerName;
+      resultMessage = '',
+      cacheKey = this.getHashedKey(rootParametersElement, headerInfo, protocol, this.getCompundKey,
+        this.concatString),
+      headerAndProtocol = protocol + headerName,
+      cachedElement = this.cache.getFromCache(cacheKey);
+    if (cachedElement) {
+      return cachedElement;
+    }
     jObj[envelopeAndProtocol] = {};
     jObj[envelopeAndProtocol][`${xmlParser.attributePlaceHolder}xmlns:` + protocol] =
      this.getSOAPNamespaceFromProtocol(protocol);
@@ -39,7 +93,9 @@ class SOAPMessageHelper {
     jObj[envelopeAndProtocol][bodyAndProtocol] = soapParametersUtils.create(rootParametersElement,
       protocol);
 
-    return xmlHeader + this.parseObjectToXML(jObj, xmlParser);
+    resultMessage = xmlHeader + this.parseObjectToXML(jObj, xmlParser);
+    this.cache.addToCache(cacheKey, resultMessage);
+    return resultMessage;
   }
 
 

--- a/lib/utils/XMLMessageHelper.js
+++ b/lib/utils/XMLMessageHelper.js
@@ -2,9 +2,39 @@ const
   {
     SOAPBody
   } = require('./SOAPBody'),
+  {
+    Cache
+  } = require('./Cache'),
+  {
+    hash
+  } = require('./textUtils'),
   xmlHeader = '<?xml version="1.0" encoding="utf-8"?>\n';
 
 class XMLMessageHelper {
+
+  constructor() {
+    this.cache = new Cache();
+  }
+
+  /**
+  * hashes and input into a sha1 base64
+  * @param {sting} input string to hash
+  * @returns {string} the hashed input
+  */
+  hash(input) {
+    return crypto.createHash('sha1').update(input).digest('base64');
+  }
+
+
+  /**
+   * hashes and input into a sha1 base64
+   * @param {object} rootParametersElement root element in message
+   * @returns {string} the hashed for this input
+   */
+  getHashedKey(rootParametersElement) {
+    return hash(JSON.stringify(rootParametersElement), 'sha1',
+      'base64');
+  }
 
   /**
    * Generates the body message from a nodeElement
@@ -13,10 +43,19 @@ class XMLMessageHelper {
    * @returns {string} the rootParametersElement in xml string
    */
   convertInputToMessage(rootParametersElement, xmlParser) {
-    let jObj = {};
+    let jObj = {},
+      resultMessage,
+      cacheKey = this.getHashedKey(rootParametersElement),
+      cachedElement = this.cache.getFromCache(cacheKey);
+    if (cachedElement) {
+      return cachedElement;
+    }
+
     const soapParametersUtils = new SOAPBody(xmlParser);
     jObj = soapParametersUtils.create(rootParametersElement);
-    return xmlHeader + this.parseObjectToXML(jObj, xmlParser);
+    resultMessage = xmlHeader + this.parseObjectToXML(jObj, xmlParser);
+    this.cache.addToCache(cacheKey, resultMessage);
+    return resultMessage;
   }
 
   /**

--- a/lib/utils/textUtils.js
+++ b/lib/utils/textUtils.js
@@ -1,4 +1,5 @@
-const { URL } = require('url');
+const { URL } = require('url'),
+  crypto = require('crypto');
 
 /**
 * Removes new line characters of a string
@@ -135,6 +136,19 @@ getAbsoultePathFromRelativeAndBase = (basePath, relativePath) => {
   return objectURL.href;
 };
 
+/**
+* Returns absolute path from a base patha and a relative one
+* @param {string} input the url base
+* @param {string} algorithm  The `algorithm` is dependent on the available algorithms supported by the
+* version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
+* @param {string} encoding The `encoding` of the return value.
+* @returns {string} the full path from URL
+*/
+hash = (input, algorithm, encoding) => {
+  return crypto.createHash(algorithm).update(input).digest(encoding);
+
+};
+
 module.exports = {
   removeLineBreak,
   isPmVariable,
@@ -145,5 +159,6 @@ module.exports = {
   stringIsAValidUrl,
   getFolderNameFromPath,
   stringIsValidURLFilePath,
-  getAbsoultePathFromRelativeAndBase
+  getAbsoultePathFromRelativeAndBase,
+  hash
 };

--- a/test/data/validWSDLs11/multipleSchemaUsed.wsdl
+++ b/test/data/validWSDLs11/multipleSchemaUsed.wsdl
@@ -1,0 +1,151 @@
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:tns="http://tempuri.org/"
+    xmlns:s="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
+    <wsdl:types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+            <s:element name="Add">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+        </s:schema>
+    </wsdl:types>
+    <wsdl:message name="AddSoapIn">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="AddSoapOut">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="SubtractSoapIn">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="SubtractSoapOut">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="MultiplySoapIn">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="MultiplySoapOut">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="DivideSoapIn">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="DivideSoapOut">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:portType name="CalculatorSoap">
+        <wsdl:operation name="Add">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Adds two integers. This is a test WebService. ©DNE Online</wsdl:documentation>
+            <wsdl:input message="tns:AddSoapIn" />
+            <wsdl:output message="tns:AddSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <wsdl:input message="tns:SubtractSoapIn" />
+            <wsdl:output message="tns:SubtractSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <wsdl:input message="tns:MultiplySoapIn" />
+            <wsdl:output message="tns:MultiplySoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <wsdl:input message="tns:DivideSoapIn" />
+            <wsdl:output message="tns:DivideSoapOut" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="CalculatorSoap" type="tns:CalculatorSoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Add">
+            <soap:operation soapAction="http://tempuri.org/Add" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <soap:operation soapAction="http://tempuri.org/Subtract" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <soap:operation soapAction="http://tempuri.org/Multiply" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <soap:operation soapAction="http://tempuri.org/Divide" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Add">
+            <soap12:operation soapAction="http://tempuri.org/Add" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <soap12:operation soapAction="http://tempuri.org/Subtract" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <soap12:operation soapAction="http://tempuri.org/Multiply" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <soap12:operation soapAction="http://tempuri.org/Divide" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Calculator">
+        <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+            <soap:address location="http://www.dneonline.com/calculator.asmx" />
+        </wsdl:port>
+        <wsdl:port name="CalculatorSoap12" binding="tns:CalculatorSoap12">
+            <soap12:address location="http://www.dneonline.com/calculator.asmx" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/unit/SOAPMessageHelper.test.js
+++ b/test/unit/SOAPMessageHelper.test.js
@@ -126,10 +126,12 @@ describe('SOAPMessageHelper convertInputToMessage ', function () {
         type: 'complex',
         namespace: 'http://www.dataaccess.com/webservicesserver/'
       },
+      cacheKey = parametersUtils.getHashedKey(node, [], 'soap', parametersUtils.getCompundKey,
+        parametersUtils.concatString),
       xmlParameters = parametersUtils.convertInputToMessage(node, [], 'soap', new XMLParser());
     expect(xmlParameters).to.be.an('string');
     expect(xmlParameters.replace(/[\r\n\s]+/g, '')).to.equal(xmlOutput.replace(/[\r\n\s]+/g, ''));
-
+    expect(parametersUtils.cache.getFromCache(cacheKey)).to.be.an('string');
   });
 
   it('should get an string representing the xml of the corresponding nodes ex2', function () {
@@ -360,5 +362,42 @@ describe('SOAPMessageHelper getSOAPNamespaceFromProtocol', function () {
     expect(url).to.be.an('string');
     expect(url).to.equal('http://schemas.xmlsoap.org/soap/envelope/');
 
+  });
+});
+
+describe('SOAPMessageHelper  cache', function () {
+  it('should get second element from cache', function () {
+    const parametersUtils = new SOAPMessageHelper(),
+      xmlOutput = '<?xml version="1.0" encoding="utf-8"?>' +
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">' +
+        '<soap:Body>' +
+        '<NumberToWords xmlns="http://www.dataaccess.com/webservicesserver/">' +
+        '<ubiNum>10</ubiNum>' +
+        '</NumberToWords>' +
+        '</soap:Body>' +
+        '</soap:Envelope>',
+      child = {
+        children: [],
+        name: 'ubiNum',
+        isComplex: false,
+        type: 'integer',
+        maximum: 10,
+        minimum: 10
+      },
+      node = {
+        children: [child],
+        name: 'NumberToWords',
+        isComplex: true,
+        type: 'complex',
+        namespace: 'http://www.dataaccess.com/webservicesserver/'
+      },
+      cacheKey = parametersUtils.getHashedKey(node, [], 'soap', parametersUtils.getCompundKey,
+        parametersUtils.concatString),
+      xmlParameters = parametersUtils.convertInputToMessage(node, [], 'soap', new XMLParser()),
+      secondXmlParameters = parametersUtils.convertInputToMessage(node, [], 'soap', new XMLParser());
+    expect(xmlParameters).to.be.an('string');
+    expect(xmlParameters).to.equal(secondXmlParameters);
+    expect(xmlParameters.replace(/[\r\n\s]+/g, '')).to.equal(xmlOutput.replace(/[\r\n\s]+/g, ''));
+    expect(parametersUtils.cache.getFromCache(cacheKey)).to.be.an('string');
   });
 });

--- a/test/unit/cache.test.js
+++ b/test/unit/cache.test.js
@@ -1,0 +1,47 @@
+const expect = require('chai').expect,
+  {
+    Cache
+  } = require('../../lib/utils/Cache');
+
+describe('SOAPMessageHelper  cache', function () {
+  it('should add to cache', function () {
+    const parametersUtils = new Cache();
+    parametersUtils.addToCache('key', { prop: 'value' });
+    expect(parametersUtils.cache.key).to.not.be.undefined;
+  });
+
+  it('should get from cache', function () {
+    const parametersUtils = new Cache();
+    parametersUtils.addToCache('key', { prop: 'value' });
+    expect(parametersUtils.cache.key).to.not.be.undefined;
+    let found = parametersUtils.getFromCache('key');
+    expect(found).to.not.be.undefined;
+  });
+
+  it('should return undefined from cache when is empty', function () {
+    const parametersUtils = new Cache();
+    let found = parametersUtils.getFromCache('key');
+    expect(found).to.be.undefined;
+  });
+
+  it('should overwrite cache entry', function () {
+    const parametersUtils = new Cache();
+    parametersUtils.addToCache('key', { prop: 'value' });
+    expect(parametersUtils.cache.key).to.not.be.undefined;
+
+    parametersUtils.addOverWriteCache('key', { prop: 'newValue' });
+    let found = parametersUtils.getFromCache('key');
+    expect(found.prop).to.equal('newValue');
+  });
+
+  it('should not overwrite cache entry when call add', function () {
+    const parametersUtils = new Cache();
+    parametersUtils.addToCache('key', { prop: 'value' });
+    expect(parametersUtils.cache.key).to.not.be.undefined;
+
+    parametersUtils.addToCache('key', { prop: 'newValue' });
+    let found = parametersUtils.getFromCache('key');
+    expect(found.prop).to.equal('value');
+  });
+});
+

--- a/test/unit/textUtils.test.js
+++ b/test/unit/textUtils.test.js
@@ -2,8 +2,10 @@ const expect = require('chai').expect,
   {
     getLastSegmentURL,
     stringIsAValidUrl,
-    stringIsValidURLFilePath
-  } = require('../../lib/utils/textUtils');
+    stringIsValidURLFilePath,
+    hash
+  } = require('../../lib/utils/textUtils'),
+  crypto = require('crypto');
 
 describe('Text Utils getLastSegmentURL', function () {
   it('should get Add when called with "http://tempuri.org/Add"', function () {
@@ -137,4 +139,13 @@ describe('Text Utils getAbsoultePathFromRelativeAndBase', function () {
     expect(result).to.equal('https://raw.com/postmanlabs/wsdl-to-postman/wsdl/Types.xsd');
   });
 
+});
+
+describe('Text Utils hash', function () {
+  it('should get a correct hash in ', function () {
+    expect(hash('textToHash', 'sha1',
+      'base64')).to.equal(crypto.createHash('sha1').update('textToHash').digest('base64'));
+    const result = stringIsAValidUrl('http://tempuri.org/Add');
+    expect(result).to.equal(true);
+  });
 });


### PR DESCRIPTION
Add a cache in body builders

for soap using the root element, protocol and header info to generate a hash (same rules that OAS2Postman)
that hash is going to be the cached element's key.
If the xml message has been previously generated we will return the generated message instead of generating it again.

The cache lives per execution.

Added also cache to xmlMessageHelper for not soap messages