### PR TITLE
Fixed issue with indentCharacter option not working as ecpected.

### DIFF
--- a/lib/XMLParser.js
+++ b/lib/XMLParser.js
@@ -23,8 +23,12 @@ class XMLParser {
       indentBy: '  ',
       supressEmptyNode: true
     };
+    // set indentation as tab provided option with the Tab as value
     if (processOptions && processOptions.indentCharacter) {
-      this.parserOptions.indentBy = processOptions.indentCharacter;
+      if (typeof processOptions.indentCharacter === 'string' &&
+        processOptions.indentCharacter.toLowerCase() === 'tab') {
+        this.parserOptions.indentBy = '\t';
+      }
     }
   }
 

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -213,7 +213,7 @@ describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
 
   it('Should get an object representing PM Collection with tabs in message', function () {
     let fileContent = fs.readFileSync(validWSDLs + '/calculator-soap11and12.wsdl', 'utf8');
-    const options = { folderStrategy: 'Port/Endpoint', indentCharacter: '\t' },
+    const options = { folderStrategy: 'Port/Endpoint', indentCharacter: 'Tab' },
       schemaPack = new SchemaPack({
         data: fileContent,
         type: 'string'

--- a/test/unit/XMLParser.test.js
+++ b/test/unit/XMLParser.test.js
@@ -196,7 +196,7 @@ describe('XMLparser parseObjectToXML', function () {
         '\t</soap:Body>\n</soap:Envelope>\n';
 
     let processOptions = {};
-    processOptions[`${indentCharacter.id}`] = '\t';
+    processOptions[`${indentCharacter.id}`] = 'Tab';
     localParser = new XMLParser(processOptions);
     parsed = localParser.parseObjectToXML(simpleInput);
     expect(parsed).to.be.an('string');


### PR DESCRIPTION
This PR fixes issue where even if one of `availableOptions` (`Space` or `Tab`) was provided to `indentCharacter` option, generated collection didn't contain the correct indentation. And had this weird string as indentation. i.e.

```
<?xml version="1.0" encoding="utf-8"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
Tab<soap:Body>
TabTab<Put_Opportunity_Response xmlns="urn:com.workday/bsvc" wd:version="v37.0">
TabTabTab<Opportunity_Reference Descriptor="string">
TabTabTabTab<ID type="string"/>
TabTabTab</Opportunity_Reference>
TabTab</Put_Opportunity_Response>
Tab</soap:Body>
</soap:Envelope>

```