### PR TITLE
Fixed typo in the options description

### DIFF
--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -32,7 +32,7 @@ function getOptions(mode = 'document', criteria = {}) {
       type: 'enum',
       default: 'Port/Endpoint',
       availableOptions: ['No folders', 'Port/Endpoint', 'Service'],
-      description: 'Select whether to create folders according to the WSDL port/endpoing service or without folders',
+      description: 'Select whether to create folders according to the WSDL port/endpoint service or without folders',
       external: true,
       usage: ['CONVERSION']
     },


### PR DESCRIPTION
Reported in https://github.com/postmanlabs/postman-app-support/issues/10513 (endpoing -> endpoint)