### PR TITLE
Fixed issue where no imports were found for certain kind of WSDL definition.

### DIFF
--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -1,4 +1,5 @@
-const {
+const _ = require('lodash'),
+  {
     SecurityAssertionsHelper
   } = require('./security/SecurityAssertionsHelper'),
   {
@@ -572,15 +573,27 @@ function getWSDLImportsOrIncludes(xmlParsed, principalPrefix, wsdlRoot, tag) {
           return type[schemaProperty];
         });
         schemas.filter((schema) => {
-          let importProperties = Object.keys(schema).filter((propertyName) => {
-            return propertyName.includes(tag);
-          });
-          if (importProperties) {
-            let imports = getArrayFrom(schema[importProperties]);
-            if (imports && importProperties.length > 0) {
-              globalImports = globalImports.concat(imports);
+          if (_.isArray(schema)) {
+            // for each element of schema, identify import tags and add it to globalImports
+            _.forEach(schema, (element) => {
+              _.forEach(element, (elementValue, elementName) => {
+                if (elementName.includes(tag)) {
+                  globalImports.push(elementValue);
+                }
+              });
+            });
+          }
+          else {
+            let importProperties = Object.keys(schema).filter((propertyName) => {
+              return propertyName.includes(tag);
+            });
+            if (importProperties) {
+              let imports = getArrayFrom(schema[importProperties]);
+              if (imports && importProperties.length > 0) {
+                globalImports = globalImports.concat(imports);
+              }
+              return schema[importProperties];
             }
-            return schema[importProperties];
           }
         });
       }

--- a/lib/XMLParser.js
+++ b/lib/XMLParser.js
@@ -1,6 +1,7 @@
 const fastXMLParser = require('fast-xml-parser'),
   Parser = require('fast-xml-parser').j2xParser,
   WsdlError = require('./WsdlError'),
+  { fixComments } = require('./utils/textUtils'),
   PARSER_ATTRIBUTE_NAME_PLACE_HOLDER = '@_',
   optionsForFastXMLParser = {
     ignoreAttributes: false,
@@ -41,7 +42,7 @@ class XMLParser {
     if (!xmlDocumentContent) {
       throw new WsdlError('Empty input was proportionated');
     }
-    const parsed = fastXMLParser.parse(xmlDocumentContent, optionsForFastXMLParser);
+    const parsed = fastXMLParser.parse(fixComments(xmlDocumentContent), optionsForFastXMLParser);
     if (!parsed) {
       throw new WsdlError('Not xml file found in your document');
     }
@@ -57,7 +58,7 @@ class XMLParser {
     if (!xmlDocumentContent) {
       return '';
     }
-    return fastXMLParser.parse(xmlDocumentContent, optionsForFastXMLParser);
+    return fastXMLParser.parse(fixComments(xmlDocumentContent), optionsForFastXMLParser);
   }
 
   /**

--- a/lib/utils/textUtils.js
+++ b/lib/utils/textUtils.js
@@ -29,6 +29,24 @@ removeDoubleQuotes = (text) => {
 };
 
 /**
+* Fixes certain occurences from text that aren't parsed correctly by fast-xml-parser.
+* (Issue has been raised at https://github.com/NaturalIntelligence/fast-xml-parser/issues/423)
+*
+* @param {string} text the text in which to fix comments
+* @returns {string} the modified text
+*/
+fixComments = (text) => {
+  return text.replace(/(<!-->)|(<-->)/g, (_, p1, p2) => {
+    if (p1) {
+      return '<!-- >';
+    }
+    else if (p2) {
+      return '< -->';
+    }
+  });
+};
+
+/**
   *
   * @description Identifies if a value is a Postman Variable
   * collection/environment variables are in format - {{var}}
@@ -154,6 +172,7 @@ module.exports = {
   isPmVariable,
   removeLineBreakTabsSpaces,
   removeDoubleQuotes,
+  fixComments,
   getLastSegmentURL,
   getFileNameFromPath,
   stringIsAValidUrl,

--- a/test/unit/textUtils.test.js
+++ b/test/unit/textUtils.test.js
@@ -156,8 +156,8 @@ describe('Text Utils fixComments', function () {
   <xsd:complexType>
     <!-->> ROOT DICTIONARY TYPES <<-->
       <xsd:sequence>
-           <!-->> ISO DICTIONARY TYPES <<-->
-           <xsd:element minOccurs="0" name="address" nillable="true" type="Address" />
+          <!-->> ISO DICTIONARY TYPES <<-->
+          <xsd:element minOccurs="0" name="address" nillable="true" type="Address" />
       </xsd:sequence>
   </xsd:complexType>
 </xsd:element>`;
@@ -167,8 +167,8 @@ describe('Text Utils fixComments', function () {
   <xsd:complexType>
     <!-- >> ROOT DICTIONARY TYPES << -->
       <xsd:sequence>
-            <!-- >> ISO DICTIONARY TYPES << -->
-            <xsd:element minOccurs="0" name="address" nillable="true" type="Address" />
+          <!-- >> ISO DICTIONARY TYPES << -->
+          <xsd:element minOccurs="0" name="address" nillable="true" type="Address" />
       </xsd:sequence>
   </xsd:complexType>
 </xsd:element>`);

--- a/test/unit/textUtils.test.js
+++ b/test/unit/textUtils.test.js
@@ -3,7 +3,8 @@ const expect = require('chai').expect,
     getLastSegmentURL,
     stringIsAValidUrl,
     stringIsValidURLFilePath,
-    hash
+    hash,
+    fixComments
   } = require('../../lib/utils/textUtils'),
   crypto = require('crypto');
 
@@ -147,5 +148,29 @@ describe('Text Utils hash', function () {
       'base64')).to.equal(crypto.createHash('sha1').update('textToHash').digest('base64'));
     const result = stringIsAValidUrl('http://tempuri.org/Add');
     expect(result).to.equal(true);
+  });
+});
+
+describe('Text Utils fixComments', function () {
+  let xmlData = `<xsd:element name="AccountHolderDetails">
+  <xsd:complexType>
+    <!-->> ROOT DICTIONARY TYPES <<-->
+      <xsd:sequence>
+           <!-->> ISO DICTIONARY TYPES <<-->
+           <xsd:element minOccurs="0" name="address" nillable="true" type="Address" />
+      </xsd:sequence>
+  </xsd:complexType>
+</xsd:element>`;
+
+  it('should get a correct parsed XML data (without comments polluted nodes)', function () {
+    expect(fixComments(xmlData)).to.eql(`<xsd:element name="AccountHolderDetails">
+  <xsd:complexType>
+    <!-- >> ROOT DICTIONARY TYPES << -->
+      <xsd:sequence>
+            <!-- >> ISO DICTIONARY TYPES << -->
+            <xsd:element minOccurs="0" name="address" nillable="true" type="Address" />
+      </xsd:sequence>
+  </xsd:complexType>
+</xsd:element>`);
   });
 });

--- a/test/unit/wsdlParserCommon.test.js
+++ b/test/unit/wsdlParserCommon.test.js
@@ -297,7 +297,67 @@ whttp:methodDefault="POST" type="http://www.w3.org/ns/wsdl/http">
                 xmlns:xsd="http://www.w3.org/2001/XMLSchema">
                 <xsd:import namespace="http://namespace/2008" schemaLocation="Types.xsd"/>
             </xsd:schema>
-        </types>`;
+        </types>`,
+  WSDL_IMPORTS_MULTIPLE = `<?xml version="1.0" encoding="utf-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:wsoap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+  xmlns:client="http://schemas.com/Hello/04"
+  xmlns:ns3="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:req="http://schemas.com/Hello/04/Req"
+  xmlns:rpy="http://schemas.com/Hello/04/Rpy"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  name="Hello" targetNamespace="http://schemas.com/Hello/04">
+	<types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+			<xsd:import namespace="http://schemas.com/Hello/04/Req" schemaLocation="Hello_04_Req.xsd"/>
+		</xsd:schema>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+			<xsd:import namespace="http://schemas.com/Hello/04/Rpy" schemaLocation="Hello_04_Rpy.xsd"/>
+		</xsd:schema>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:client="http://schemas.com/Hello/04"
+      targetNamespace="http://schemas.com/Hello/04">
+			<xsd:element name="DummyPart" type="xsd:string"/>
+		</xsd:schema>
+	</types>
+	<message name="HelloResponseMessage">
+		<part name="payload" element="rpy:Hello04Rpy"/>
+	</message>
+	<message name="HelloRequestMessage">
+		<part name="payload" element="req:Hello04Req"/>
+	</message>
+	<message name="SOAPFaultDummyPart">
+		<part name="DummyPart" element="client:DummyPart"/>
+	</message>
+	<portType name="Hello">
+		<operation name="Hello">
+			<input message="client:HelloRequestMessage"/>
+			<output message="client:HelloResponseMessage"/>
+			<fault name="SOAPFault" message="client:SOAPFaultDummyPart"/>
+		</operation>
+	</portType>
+	<binding name="HelloBinding" type="client:Hello">
+		<wsoap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="Hello">
+			<wsoap12:operation soapAction="Hello" style="document"/>
+			<input>
+				<wsoap12:body use="literal"/>
+			</input>
+			<output>
+				<wsoap12:body use="literal"/>
+			</output>
+			<fault name="SOAPFault">
+				<wsoap12:fault name="SOAPFault" use="literal"/>
+			</fault>
+		</operation>
+	</binding>
+	<service name="Hello">
+		<port name="HelloPort" binding="client:HelloBinding">
+			<wsoap12:address location="https://schemas.com/Hello/04"/>
+		</port>
+	</service>
+</definitions>
+`;
 
 describe('WSDL parser common getNamespaceByKey', function () {
 
@@ -1971,6 +2031,16 @@ describe('WSDL parser common getWSDLImports', function () {
       result = getWSDLImports(parsed, '', informationService.RootTagName);
     expect(result).to.be.an('array');
     expect(result.length).to.equal(1);
+  });
+
+  it('should get correct imports for specification with multiple imports under same namespace' +
+    'in different elements', function () {
+    const parser = new XMLParser(),
+      informationService = new WsdlInformationService11();
+    let parsed = parser.parseToObject(WSDL_IMPORTS_MULTIPLE),
+      result = getWSDLImports(parsed, '', informationService.RootTagName);
+    expect(result).to.be.an('array');
+    expect(result.length).to.equal(2);
   });
 });
 


### PR DESCRIPTION
Fixes following issue:

-  No imports were identified for certain kinds of WSDL definition where multiple imports were present under schema with same namespaces.
- XML with certain kinds of comments not being parsed correctly by fast-xml-parser. (Have raised issue [here](https://github.com/NaturalIntelligence/fast-xml-parser/issues/423), but till it's fixed have introduced temporary solution)