### PR TITLE
Updated sourceUrl option to be not set as external.

### DIFF
--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -51,7 +51,7 @@ function getOptions(mode = 'document', criteria = {}) {
       type: 'string',
       default: '',
       description: 'Specify source URL of definition to resolve remote references mentioned in it.',
-      external: true,
+      external: false,
       usage: ['CONVERSION']
     },
     {


### PR DESCRIPTION
Fixed issue where `sourceUrl` option was set as an external option even though not supported yet from App.