### PR TITLE
Add support tns and other namespace with same url

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -263,7 +263,7 @@ class WsdlInformationService11 {
       tnsNamespacePrefix = (tnsNamespace && typeof (tnsNamespace.key) === 'string') ?
         tnsNamespace.key + ':' : THIS_NS_PREFIX,
       part, elementName,
-      messageOnlyName = messageName.replace(tnsNamespacePrefix, ''),
+      messageOnlyName = getQNameLocal(messageName),
       messages = getArrayFrom(getNodeByName(definitions, principalPrefix, MESSAGE_TAG)),
       foundMessage = messages.find((message) => {
         return getAttributeByName(message, ATTRIBUTE_NAME) === messageOnlyName;

--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -223,14 +223,13 @@ function getNamespaceByKey(parsedXml, key, wsdlRoot) {
  * @returns {NameSpace} the  new NameSpace object
  */
 function getTnsNamespace(parsedXml, defaultTnsKey, targetNamespace, allNameSpaces, wsdlRoot) {
-  let tnsNamespace = allNameSpaces.find((ns) => {
-    return ns.url === targetNamespace.url && ns.key !== targetNamespace.key;
-  });
-
-  if (tnsNamespace) {
-    return tnsNamespace;
+  let tnsNamespace = getNamespaceByKey(parsedXml, defaultTnsKey, wsdlRoot);
+  if (!tnsNamespace.url) {
+    tnsNamespace = allNameSpaces.find((ns) => {
+      return ns.url === targetNamespace.url && ns.key !== targetNamespace.key;
+    });
   }
-  return getNamespaceByKey(parsedXml, defaultTnsKey, wsdlRoot);
+  return tnsNamespace;
 }
 
 /**

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -190,7 +190,7 @@ class SchemaBuilderXSD {
     if (globalSchemaTag) {
       globalSchemaTag.forEach((schemaTag) => {
         let targetNamespace = getXMLAttributeByName(schemaTag, parserPlaceholder, ATTRIBUTE_TARGET_NAMESPACE),
-          tnsNamespace = Array.isArray(wsdlObject.allNameSpaces) && wsdlObject.allNameSpaces.find((ns) => {
+          tnsNamespace = Array.isArray(wsdlObject.allNameSpaces) && wsdlObject.allNameSpaces.filter((ns) => {
             return targetNamespace === ns.url && ns.key !== ATTRIBUTE_TARGET_NAMESPACE;
           });
 
@@ -453,7 +453,9 @@ class SchemaBuilderXSD {
     }
     if (tnsNamespace) {
       // assign tns namespace for current schema if present at wsdl root level
-      localSchemaTag[parserPlaceholder + 'xmlns' + XML_NAMESPACE_SEPARATOR + tnsNamespace.key] = tnsNamespace.url;
+      tnsNamespace.forEach((sameURLNS) => {
+        localSchemaTag[parserPlaceholder + 'xmlns:' + sameURLNS.key] = sameURLNS.url;
+      });
     }
     else {
       localSchemaTag[parserPlaceholder + 'xmlns' + XML_NAMESPACE_SEPARATOR + 'tns'] = tnsNamespaceURL;

--- a/test/data/validWSDLs11/2namespaceSameURL.wsdl
+++ b/test/data/validWSDLs11/2namespaceSameURL.wsdl
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:sch="http://spring.io/guides/gs-producing-web-service"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:tns="http://spring.io/guides/gs-producing-web-service" targetNamespace="http://spring.io/guides/gs-producing-web-service">
+  <wsdl:types>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://spring.io/guides/gs-producing-web-service">
+
+      <xs:element name="getCountryRequest">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="name" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:element name="getCountryResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="country" type="tns:country"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <xs:complexType name="country">
+        <xs:sequence>
+          <xs:element name="name" type="xs:string"/>
+          <xs:element name="population" type="xs:int"/>
+          <xs:element name="capital" type="xs:string"/>
+          <xs:element name="currency" type="tns:currency"/>
+        </xs:sequence>
+      </xs:complexType>
+
+      <xs:simpleType name="currency">
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="GBP"/>
+          <xs:enumeration value="EUR"/>
+          <xs:enumeration value="PLN"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getCountryResponse">
+    <wsdl:part element="tns:getCountryResponse" name="getCountryResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getCountryRequest">
+    <wsdl:part element="tns:getCountryRequest" name="getCountryRequest">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="CountriesPort">
+    <wsdl:operation name="getCountry">
+      <wsdl:input message="tns:getCountryRequest" name="getCountryRequest">
+      </wsdl:input>
+      <wsdl:output message="tns:getCountryResponse" name="getCountryResponse">
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CountriesPortSoap11" type="tns:CountriesPort">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getCountry">
+      <soap:operation soapAction=""/>
+      <wsdl:input name="getCountryRequest">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getCountryResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CountriesPortService">
+    <wsdl:port binding="tns:CountriesPortSoap11" name="CountriesPortSoap11">
+      <soap:address location="http://localhost:8080/ws"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -1139,7 +1139,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'SayHelloHttpSoap11Endpoint',
         serviceName: 'SayHello',
         xpathInfo: {
-          xpath: '//description//binding[@name="SayHelloSoap11Binding"]//operation[@ref="ns:hi"]',
+          xpath: '//description//binding[@name="SayHelloSoap11Binding"]//operation[@ref="tns:hi"]',
           wsdlNamespaceUrl: 'http://www.w3.org/ns/wsdl'
         }
       });
@@ -1153,7 +1153,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'SayHelloHttpSoap12Endpoint',
         serviceName: 'SayHello',
         xpathInfo: {
-          xpath: '//description//binding[@name="SayHelloSoap12Binding"]//operation[@ref="ns:hi"]',
+          xpath: '//description//binding[@name="SayHelloSoap12Binding"]//operation[@ref="tns:hi"]',
           wsdlNamespaceUrl: 'http://www.w3.org/ns/wsdl'
         }
       });
@@ -1167,7 +1167,7 @@ provides functions that convert numbers into words or dollar amounts.</documenta
         portName: 'SayHelloHttpEndpoint',
         serviceName: 'SayHello',
         xpathInfo: {
-          xpath: '//description//binding[@name="SayHelloHttpBinding"]//operation[@ref="ns:hi"]',
+          xpath: '//description//binding[@name="SayHelloHttpBinding"]//operation[@ref="tns:hi"]',
           wsdlNamespaceUrl: 'http://www.w3.org/ns/wsdl'
         }
       });


### PR DESCRIPTION
## Description

This fixes the next issue:

https://github.com/postmanlabs/postman-app-support/issues/11296

As the document has a tns and other namespaces with the same URL, the process takes the first of them and then it does not identify other elements (messages) correctly.

```
  xmlns:sch="http://spring.io/guides/gs-producing-web-service"
  xmlns:tns="http://spring.io/guides/gs-producing-web-service"
```
##Solution

We are now trying to locate the elements and not taking into consideration the namespace (for locating messages only)
Also needed to add all the namespaces to the schema prior to generate the json schema

## How to test this ticket

- Run all the tests

### Checklist:

- Added relevant unit tests for my code
