### PR TITLE
Feat/remote refs decoupling

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,7 +1,7 @@
 id|type|available options|default|description|usage
 |---|---|---|---|---|---|
 folderStrategy|enum|No folders, Port/Endpoint, Service|Port/Endpoint|Select whether to create folders according to the WSDL port/endpoint service or without folders|CONVERSION
-resolveRemoteRefs|boolean|-|false|Select whether to resolve remote references.|CONVERSION
+resolveRemoteRefs|boolean|-|false|Select whether to resolve remote references.|CONVERSION, VALIDATION, BUNDLING
 sourceUrl|string|-||Specify source URL of definition to resolve remote references mentioned in it.|CONVERSION
 indentCharacter|enum|Space, Tab|Space|Option for setting indentation character|CONVERSION
 validateHeader|boolean|-|false|Select true to validate your collection requests/responses headers are correctly set|VALIDATION
@@ -10,5 +10,4 @@ ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting
 detailedBlobValidation|boolean|-|false|If it is true, all the mismatches will contain detailed info about the error generated if false, the mismatch will return a general description for the error|VALIDATION
 showMissingInSchemaErrors|boolean|-|true|If true (as default), it will report mismatches generated from errors with elements that are not in the schema but are in the request body, if false it will not report those errors|VALIDATION
 suggestAvailableFixes|boolean|-|false|If is true, all the mismatches in the body will contain the current and wrong value in your request an a suggestion with a value valid in schema|VALIDATION
-resolveRemoteRefs|boolean|-|false|Select whether to resolve remote references or not|CONVERSION, VALIDATION, BUNDLING
 remoteRefsResolver|function|-|undefined|Function that can resolve the given URL and provides content present at the reference|CONVERSION, VALIDATION, BUNDLING

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -10,3 +10,5 @@ ignoreUnresolvedVariables|boolean|-|false|Whether to ignore mismatches resulting
 detailedBlobValidation|boolean|-|false|If it is true, all the mismatches will contain detailed info about the error generated if false, the mismatch will return a general description for the error|VALIDATION
 showMissingInSchemaErrors|boolean|-|true|If true (as default), it will report mismatches generated from errors with elements that are not in the schema but are in the request body, if false it will not report those errors|VALIDATION
 suggestAvailableFixes|boolean|-|false|If is true, all the mismatches in the body will contain the current and wrong value in your request an a suggestion with a value valid in schema|VALIDATION
+resolveRemoteRefs|boolean|-|false|Select whether to resolve remote references or not|CONVERSION, VALIDATION, BUNDLING
+remoteRefsResolver|function|-|undefined|Function that can resolve the given URL and provides content present at the reference|CONVERSION, VALIDATION, BUNDLING

--- a/lib/SchemaPack.js
+++ b/lib/SchemaPack.js
@@ -164,17 +164,31 @@ class SchemaPack {
    * @returns {boolean} validation
    */
   validateTransaction(transactions, callback) {
-    const wsdlParser = new WSDLParserFactory().getParser(this.input.data),
-      transactionValidator = new TransactionValidator(),
-      wsdlObject = wsdlParser.getWsdlObject(this.parsedXML);
-    let result;
-    try {
-      result = transactionValidator.validateTransaction(transactions, wsdlObject, this.xmlParser, this.options);
-      callback(null, result);
-    }
-    catch (error) {
-      callback(error);
-    }
+    resolveRemoteRefs(this.input, this.xmlParser, this.options, (result) => {
+      let { mergedFile, newParsed, err } = result;
+      if (err) {
+        return callback(null, {
+          result: false,
+          reason: err.name + ': ' + err.message
+        });
+      }
+      this.input.data = mergedFile;
+      if (newParsed) {
+        this.parsedXML = newParsed;
+      }
+      const wsdlParser = new WSDLParserFactory().getParser(this.input.data),
+        transactionValidator = new TransactionValidator(),
+        wsdlObject = wsdlParser.getWsdlObject(this.parsedXML);
+      try {
+        let validationResult =
+          transactionValidator.validateTransaction(transactions, wsdlObject, this.xmlParser, this.options);
+        callback(null, validationResult);
+      }
+      catch (error) {
+        callback(error);
+      }
+
+    });
   }
 
   /**

--- a/lib/utils/WSDLRemoteResolver.js
+++ b/lib/utils/WSDLRemoteResolver.js
@@ -105,6 +105,13 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
 
 
   parsedRootFile = xmlParser.safeParseToObject(processingFile);
+  if (parsedRootFile === '') {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 1);
+    });
+  }
   parserFactory = new WSDLParserFactory();
   WSDLSpecVersion = parserFactory.getSafeWsdlVersion(processingFile);
   if (!WSDLSpecVersion) {
@@ -296,7 +303,7 @@ async function resolveRemoteRefsNoMerge(input, xmlParser, options = {}) {
    * Validates the input of the remote ref solver
    * Throws error
    * @param {object} specRoot - root file information
-   * @param {boolean} batch - wheter is a batch validation
+   * @param {boolean} batch - whether is a batch validation
    * @returns {undefined} -
    */
 function validateInputGetRemoteReferences(specRoot, batch = false) {
@@ -345,7 +352,7 @@ async function resolveRemoteRefsMultiFile(input, xmlParser, options) {
   let remoteRefRes =
   await getRemoteReferencesArray(input.rootFiles, xmlParser, options),
     foundRemoteRefs = remoteRefRes.flat();
-  return foundRemoteRefs; // input.data.push(...foundRemoteRefs);
+  return foundRemoteRefs;
 }
 
 

--- a/lib/utils/WSDLRemoteResolver.js
+++ b/lib/utils/WSDLRemoteResolver.js
@@ -176,7 +176,7 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
     values.forEach((content, index) => {
       const alreadyDownloaded = downloadedReferences.find((downloadedReference) => {
         return downloadedReference.schemaLocation === remoteReferencesToResolve[index].schemaLocation &&
-        downloadedReference.namespace === remoteReferencesToResolve[index].namespace ;
+        downloadedReference.namespace === remoteReferencesToResolve[index].namespace;
       });
       if (!alreadyDownloaded) {
         downloadedReferences.push({

--- a/lib/utils/WSDLRemoteResolver.js
+++ b/lib/utils/WSDLRemoteResolver.js
@@ -21,7 +21,8 @@ const { WSDLParserFactory } = require('../WSDLParserFactory'),
   {
     WSDLMerger
   } = require('./WSDLMerger'),
-  validExtensions = ['wsdl', 'xsd'];
+  validExtensions = ['wsdl', 'xsd'],
+  MISSING_REMOTE_FILE_IDENTIFIER = '{"$ref":}';
 var promises = [];
 
 /**
@@ -172,7 +173,7 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
       const { schemaLocation } = remoteReference;
       if (res.status !== 200) {
         if (ignoreIOErrors) {
-          return '{"$ref":}' + remoteReference.schemaLocation;
+          return MISSING_REMOTE_FILE_IDENTIFIER + remoteReference.schemaLocation;
         }
         throw new Error(`Received status code ${res.status}: ${schemaLocation}`);
       }
@@ -193,7 +194,7 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
           fileName: getLastSegmentURL(remoteReferencesToResolve[index].schemaLocation)
         });
       }
-      if (!content.includes('{"$ref":}')) {
+      if (!content.includes(MISSING_REMOTE_FILE_IDENTIFIER)) {
         return processAFile(content, xmlParser, downloadedReferences, parentBaseURL, optionProcessURL,
           origin, remoteRefsResolver);
       }
@@ -361,5 +362,6 @@ module.exports = {
   calculateDownloadPathAndParentBaseURL,
   resolveRemoteRefsNoMerge,
   getRemoteReferencesArray,
-  resolveRemoteRefsMultiFile
+  resolveRemoteRefsMultiFile,
+  MISSING_REMOTE_FILE_IDENTIFIER
 };

--- a/lib/utils/WSDLRemoteResolver.js
+++ b/lib/utils/WSDLRemoteResolver.js
@@ -25,6 +25,21 @@ const { WSDLParserFactory } = require('../WSDLParserFactory'),
 var promises = [];
 
 /**
+ * Takes a list of arguments and resolve them acording its content
+ * @param {string} origin The arguments that will be resolved
+ * @param {string} remoteRefsResolver The arguments that will be resolved
+ * @returns {array} The list of arguments after have been resolved
+ */
+function resolveFetchFunction(origin, remoteRefsResolver) {
+  if (remoteRefsResolver) {
+    return remoteRefsResolver;
+  }
+  if (origin !== 'browser') {
+    return require('node-fetch');
+  }
+}
+
+/**
 * Receives a string and determines if is an absolute path of a wsdl or xsd file
 * @param {string} filePath string path
 * @return {boolean} true if is a correct file path to a wsdl or xsd otherwise false
@@ -40,7 +55,7 @@ function validateIsWSDLOrXSDFilePath(filePath) {
  * @param {string} optionProcessURL the option set for the user for process url
  * @returns {object} A valid Result object with format {parentBaseURL: <string>, downloadPath: <string>}
  */
-function calculateDowloadPathAndParentBaseURL(schemaLocation, parentBaseURL, optionProcessURL) {
+function calculateDownloadPathAndParentBaseURL(schemaLocation, parentBaseURL, optionProcessURL) {
   let downloadPath,
     calculatedParentBaseURL;
   if (validateIsWSDLOrXSDFilePath(schemaLocation)) {
@@ -69,10 +84,11 @@ function calculateDowloadPathAndParentBaseURL(schemaLocation, parentBaseURL, opt
  *  or empty
  * @param {string} optionProcessURL the option set for the user for process url
  * @param {string} origin app's context
- * @return {promise} promise to resolve file downloadings
+ * @param {function} remoteRefsResolver function for fetching files
+ * @return {promise} promise to resolve file downloads
  */
 function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBaseURL, optionProcessURL,
-  origin) {
+  origin, remoteRefsResolver) {
   let parserFactory,
     parsedRootFile,
     wsdlRootTagName,
@@ -85,9 +101,8 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
     localPromises = [],
     downloadPath = '',
     processingFile = filesToProcess;
-  if (origin !== 'browser') {
-    var fetch = require('node-fetch');
-  }
+  var fetch = resolveFetchFunction(origin, remoteRefsResolver);
+
 
   parsedRootFile = xmlParser.safeParseToObject(processingFile);
   parserFactory = new WSDLParserFactory();
@@ -112,7 +127,7 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
     if (!schemaLocation) {
       schemaLocation = getAttributeByName(importInformation, ATTRIBUTE_SCHEMALOCATION);
     }
-    ({ parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(schemaLocation, parentBaseURL,
+    ({ parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(schemaLocation, parentBaseURL,
       optionProcessURL));
     if (downloadPath) {
       const alreadyDownloaded = downloadedReferences.find((downloadedReference) => {
@@ -130,7 +145,7 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
 
   includes.forEach((importInformation) => {
     let schemaLocation = getAttributeByName(importInformation, ATTRIBUTE_SCHEMALOCATION);
-    ({ parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(schemaLocation, parentBaseURL,
+    ({ parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(schemaLocation, parentBaseURL,
       optionProcessURL));
 
     if (downloadPath) {
@@ -145,7 +160,6 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
       }
     }
   });
-
   remoteReferencesToResolve.forEach((remoteReference) => {
     localPromises.push(fetch(remoteReference.schemaLocation).then(function (res) {
       const { schemaLocation } = remoteReference;
@@ -160,15 +174,21 @@ function processAFile(filesToProcess, xmlParser, downloadedReferences, parentBas
   });
   promise = Promise.all(localPromises).then((values) => {
     values.forEach((content, index) => {
-      downloadedReferences.push({
-        content: content,
-        schemaLocation: remoteReferencesToResolve[index].schemaLocation,
-        namespace: remoteReferencesToResolve[index].namespace,
-        fileName: getLastSegmentURL(remoteReferencesToResolve[index].schemaLocation)
+      const alreadyDownloaded = downloadedReferences.find((downloadedReference) => {
+        return downloadedReference.schemaLocation === remoteReferencesToResolve[index].schemaLocation &&
+        downloadedReference.namespace === remoteReferencesToResolve[index].namespace ;
       });
+      if (!alreadyDownloaded) {
+        downloadedReferences.push({
+          content: content,
+          schemaLocation: remoteReferencesToResolve[index].schemaLocation,
+          namespace: remoteReferencesToResolve[index].namespace,
+          fileName: getLastSegmentURL(remoteReferencesToResolve[index].schemaLocation)
+        });
+      }
       if (!content.includes('{"$ref":}')) {
         return processAFile(content, xmlParser, downloadedReferences, parentBaseURL, optionProcessURL,
-          origin);
+          origin, remoteRefsResolver);
       }
     });
   });
@@ -197,12 +217,12 @@ function processRemoteReferences(wsdl, xmlParser, options = {}, downloadedRefere
     return wsdl;
   }
   filesToProcess.push(wsdl);
-  promise = processAFile(wsdl, xmlParser, downloadedReferences, '', sourceUrl, origin);
+  promise = processAFile(wsdl, xmlParser, downloadedReferences, '', sourceUrl, origin, options.remoteRefsResolver);
   return promise;
 }
 
 /**
- * Receives a WSDL Resolve remote references in imported tags from a WSDL
+ * Receives a WSDL the resolves remote references in imported tags from a WSDL then merge the result
  * @param {object} input the process input
  * @param {object} xmlParser the parser class to parse xml to object or vice versa
  * @param {object} options contains options to the process
@@ -215,7 +235,7 @@ function resolveRemoteRefs(input, xmlParser, options = {}, cb) {
     downloadedInfo = [];
   if (options.resolveRemoteRefs) {
     try {
-      return processRemoteReferences(data, xmlParser, options, downloadedReferences, input.origin)
+      return processRemoteReferences(data, xmlParser, options, downloadedReferences, origin)
         .then(function () {
           Promise.all(promises).then(() => {
             let merger = new WSDLMerger(),
@@ -245,7 +265,35 @@ function resolveRemoteRefs(input, xmlParser, options = {}, cb) {
   return cb({ mergedFile: data });
 }
 
+/**
+ * Receives a WSDL then resolves remote references in imported tags from a WSDL
+ * @param {object} input the process input
+ * @param {object} xmlParser the parser class to parse xml to object or vice versa
+ * @param {object} options contains options to the process
+ * @return {string} a merged file and its parsed rep
+ */
+async function resolveRemoteRefsNoMerge(input, xmlParser, options = {}) {
+  let downloadedReferences = [],
+    { data, origin } = input,
+    downloadedInfo = [];
+  if (options.resolveRemoteRefs) {
+    try {
+      await processRemoteReferences(data, xmlParser, options, downloadedReferences, origin);
+      await Promise.all(promises);
+
+      downloadedInfo = downloadedReferences.map((downloaded) => {
+        return { content: downloaded.content, path: downloaded.fileName };
+      });
+    }
+    catch (err) {
+      throw err;
+    }
+  }
+  return downloadedInfo;
+}
+
 module.exports = {
   resolveRemoteRefs,
-  calculateDowloadPathAndParentBaseURL
+  calculateDownloadPathAndParentBaseURL,
+  resolveRemoteRefsNoMerge
 };

--- a/lib/utils/WSDLRemoteResolver.js
+++ b/lib/utils/WSDLRemoteResolver.js
@@ -270,7 +270,7 @@ function resolveRemoteRefs(input, xmlParser, options = {}, cb) {
  * @param {object} input the process input
  * @param {object} xmlParser the parser class to parse xml to object or vice versa
  * @param {object} options contains options to the process
- * @return {string} a merged file and its parsed rep
+ * @return {object} {path, content} a merged file and its parsed rep
  */
 async function resolveRemoteRefsNoMerge(input, xmlParser, options = {}) {
   let downloadedReferences = [],
@@ -292,8 +292,67 @@ async function resolveRemoteRefsNoMerge(input, xmlParser, options = {}) {
   return downloadedInfo;
 }
 
+/**
+   * Validates the input of the remote ref solver
+   * Throws error
+   * @param {object} specRoot - root file information
+   * @param {boolean} batch - wheter is a batch validation
+   * @returns {undefined} -
+   */
+function validateInputGetRemoteReferences(specRoot, batch = false) {
+  if (!specRoot || specRoot.length === 0) {
+    if (batch) {
+      return false;
+    }
+    throw new Error('Root file must be defined');
+  }
+  return true;
+}
+
+/**
+ * Find and downloads the remote references from the specRoots array
+ * @param {array} specRoots - root file information
+ * @param {object} xmlParser the parser class to parse xml to object or vice versa
+ * @param {object} options contains options to the process
+ * @returns {object} - Remote references result object
+ */
+async function getRemoteReferencesArray(specRoots, xmlParser, options = {}) {
+  if (!specRoots || specRoots.length === 0) {
+    return [];
+  }
+  let cleanRoots = specRoots.filter((root) => {
+      let isValid = validateInputGetRemoteReferences(root, true);
+      return isValid;
+    }),
+    result = [];
+
+  for (let index = 0; index < cleanRoots.length; index++) {
+    let res = await resolveRemoteRefsNoMerge(cleanRoots[index], xmlParser, options);
+    result.push(res);
+  }
+  return result;
+}
+
+/**
+   * @description resolve the remote references and assign the information to the input
+   * @param {object} input - Process input data
+   * @param {object} xmlParser the parser class to parse xml to object or vice versa
+   * @param {object} options - Process options
+   *
+   * @returns {undefined} - nothing
+   */
+async function resolveRemoteRefsMultiFile(input, xmlParser, options) {
+  let remoteRefRes =
+  await getRemoteReferencesArray(input.rootFiles, xmlParser, options),
+    foundRemoteRefs = remoteRefRes.flat();
+  return foundRemoteRefs; // input.data.push(...foundRemoteRefs);
+}
+
+
 module.exports = {
   resolveRemoteRefs,
   calculateDownloadPathAndParentBaseURL,
-  resolveRemoteRefsNoMerge
+  resolveRemoteRefsNoMerge,
+  getRemoteReferencesArray,
+  resolveRemoteRefsMultiFile
 };

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -43,7 +43,7 @@ function getOptions(mode = 'document', criteria = {}) {
       default: false,
       description: 'Select whether to resolve remote references.',
       external: false,
-      usage: ['CONVERSION']
+      usage: ['CONVERSION', 'VALIDATION', 'BUNDLING']
     },
     {
       name: 'Source URL of definition',
@@ -124,6 +124,15 @@ function getOptions(mode = 'document', criteria = {}) {
         'your request an a suggestion with a value valid in schema',
       external: true,
       usage: ['VALIDATION']
+    },
+    {
+      name: 'Remote references resolver',
+      id: 'remoteRefsResolver',
+      type: 'function',
+      default: undefined,
+      description: 'Function that can resolve the given URL and provides content present at the reference',
+      external: true,
+      usage: ['CONVERSION', 'VALIDATION', 'BUNDLING']
     }
   ];
 

--- a/test/convert-validation/validateTransactions.test.js
+++ b/test/convert-validation/validateTransactions.test.js
@@ -397,7 +397,7 @@ describe('Test validate Transactions method in SchemaPack', function () {
     });
   });
 
-  it('Should return no missmatches if entry is valid', function () {
+  it('Should return no mismatches if entry is valid', function () {
     schemaPack.convert((error, result) => {
       expect(error).to.be.null;
       expect(result).to.be.an('object');
@@ -408,5 +408,4 @@ describe('Test validate Transactions method in SchemaPack', function () {
       });
     });
   });
-
 });

--- a/test/data/transactionsValidation/remoteStockquoteserviceCollectionItems.json
+++ b/test/data/transactionsValidation/remoteStockquoteserviceCollectionItems.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "06a2536d-f3fd-4e6a-86c8-9b002d87a71c",
+    "name": "GetLastTradePrice",
+    "request": {
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "url": {
+        "query": [],
+        "variable": []
+      },
+      "header": [
+        {
+          "key": "Content-Type",
+          "value": "text/xml; charset=utf-8"
+        },
+        {
+          "key": "SOAPAction",
+          "value": "http://example.com/GetLastTradePrice"
+        }
+      ],
+      "method": "POST",
+      "body": {
+        "mode": "raw",
+        "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <TradePriceRequest xmlns=\"http://example.com/stockquote/schemas\">\n      <tickerSymbol>string</tickerSymbol>\n    </TradePriceRequest>\n  </soap:Body>\n</soap:Envelope>\n",
+        "options": {
+          "raw": {
+            "language": "xml"
+          }
+        }
+      }
+    },
+    "response": [
+      {
+        "id": "cbdfb1a5-0ae0-4c1b-a1c2-3b1ee3442e77",
+        "name": "GetLastTradePrice response",
+        "originalRequest": {
+          "url": {
+            "query": [],
+            "variable": []
+          },
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/xml; charset=utf-8"
+            },
+            {
+              "key": "SOAPAction",
+              "value": "http://example.com/GetLastTradePrice"
+            }
+          ],
+          "method": "POST",
+          "body": {
+            "mode": "raw",
+            "raw": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <TradePriceRequest xmlns=\"http://example.com/stockquote/schemas\">\n      <tickerSymbol>string</tickerSymbol>\n    </TradePriceRequest>\n  </soap:Body>\n</soap:Envelope>\n",
+            "options": {
+              "raw": {
+                "language": "xml"
+              }
+            }
+          }
+        },
+        "status": "OK",
+        "code": 200,
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "text/xml; charset=utf-8"
+          }
+        ],
+        "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <TradePrice xmlns=\"http://example.com/stockquote/schemas\">\n      <price>23</price>\n    </TradePrice>\n  </soap:Body>\n</soap:Envelope>\n",
+        "cookie": [],
+        "_postman_previewlanguage": "xml"
+      }
+    ],
+    "event": []
+  }
+]

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -24,7 +24,9 @@ const expect = require('chai').expect,
     'suggestAvailableFixes',
     'resolveRemoteRefs',
     'sourceUrl',
-    'indentCharacter'
+    'indentCharacter',
+    'resolveRemoteRefs',
+    'remoteRefsResolver'
   ],
   getOptions = require('../../lib/utils/options').getOptions;
 
@@ -276,7 +278,7 @@ describe('SchemaPack getOptions', function () {
   it('Should return external options when called with mode = document', function () {
     const options = SchemaPack.getOptions('document');
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(10);
+    expect(options.length).to.eq(11);
   });
 
   it('Should return external options when called with mode = use', function () {
@@ -318,13 +320,13 @@ describe('SchemaPack getOptions', function () {
       usage: ['CONVERSION']
     });
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(4);
+    expect(options.length).to.eq(5);
   });
 
   it('Should return external options when called with mode document and usage not an object', function () {
     const options = SchemaPack.getOptions('document', 2);
     expect(options).to.be.an('array');
-    expect(options.length).to.eq(10);
+    expect(options.length).to.eq(11);
   });
 
   it('Should return default empty array in validationPropertiesToIgnore', function () {

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -355,7 +355,7 @@ describe('validateTransaction method', function () {
     });
   });
 
-  it('Should return no missmatches when entry is valid', function () {
+  it('Should return no mismatches when entry is valid', function () {
     const
       VALID_WSDL_PATH = fs.readFileSync(validWSDLs + '/calculator-soap11and12.wsdl', 'utf8'),
       schemaPack = new SchemaPack({
@@ -378,6 +378,53 @@ describe('validateTransaction method', function () {
       schemaPack.validateTransaction(historyRequests, (error, result) => {
         expect(error).to.be.null;
         expect(result).to.be.an('object');
+      });
+    });
+  });
+
+  it('Should get a collection and validate when send a file with remote refs and option is set to true', function () {
+    const options = getOptions({ usage: ['CONVERSION'] }),
+      resolveRemoteRefsOption = options.find((option) => { return option.id === 'resolveRemoteRefs'; }),
+      remoteRefsCollectionItems =
+        require('./../data/transactionsValidation/remoteStockquoteserviceCollectionItems.json');
+
+    let optionFromOptions = {},
+      schemaPack;
+    fileContent = fs.readFileSync(REMOTE_REFS + '/remoteStockquoteservice.wsdl', 'utf8');
+    optionFromOptions[`${resolveRemoteRefsOption.id}`] = true;
+
+    schemaPack = new SchemaPack({
+      data: fileContent,
+      type: 'string'
+    }, optionFromOptions);
+
+    schemaPack.validateTransaction(remoteRefsCollectionItems, (error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.deep.equal({
+        matched: true,
+        requests: {
+          '06a2536d-f3fd-4e6a-86c8-9b002d87a71c': {
+            requestId: '06a2536d-f3fd-4e6a-86c8-9b002d87a71c',
+            endpoints: [
+              {
+                matched: true,
+                endpointMatchScore: 1,
+                endpoint: 'POST soap GetLastTradePrice',
+                mismatches: [
+                ],
+                responses: {
+                  'cbdfb1a5-0ae0-4c1b-a1c2-3b1ee3442e77': {
+                    id: 'cbdfb1a5-0ae0-4c1b-a1c2-3b1ee3442e77',
+                    matched: true,
+                    mismatches: [
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        missingEndpoints: []
       });
     });
   });

--- a/test/unit/WSDLRemoteResolver.test.js
+++ b/test/unit/WSDLRemoteResolver.test.js
@@ -4,7 +4,8 @@ const expect = require('chai').expect,
     calculateDownloadPathAndParentBaseURL,
     resolveRemoteRefsNoMerge,
     getRemoteReferencesArray,
-    resolveRemoteRefsMultiFile
+    resolveRemoteRefsMultiFile,
+    MISSING_REMOTE_FILE_IDENTIFIER
   } = require('../../lib/utils/WSDLRemoteResolver'),
   remoteRefs11 = 'test/data/separatedFiles/remoteRefs',
   remoteRefsIncludeTag = 'test/data/separatedFiles/includeTag',
@@ -258,6 +259,24 @@ describe('resolveRemoteRefsNoMerge method', async function () {
     expect(res).to.not.be.undefined;
     expect(res[0]).to.deep.equal({
       content: 'invalid content',
+      path: 'remoteStockquote.wsdl'
+    });
+  });
+
+  it('Should not fail when file is missing in the url', async function () {
+    const data = fs.readFileSync(remoteRefs11 + '/remoteStockquoteservice.wsdl', 'utf8'),
+      customFetch = () => {
+        return Promise.resolve({
+          text: () => { return Promise.resolve(''); },
+          status: 404
+        });
+      },
+      res = await resolveRemoteRefsNoMerge({ data }, new XMLParser(),
+        { resolveRemoteRefs: true, remoteRefsResolver: customFetch });
+    expect(res).to.not.be.undefined;
+    expect(res[0]).to.deep.equal({
+      content: MISSING_REMOTE_FILE_IDENTIFIER + 'https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/' +
+      'development/test/data/separatedFiles/remoteRefs/remoteStockquote.wsdl',
       path: 'remoteStockquote.wsdl'
     });
   });

--- a/test/unit/WSDLRemoteResolver.test.js
+++ b/test/unit/WSDLRemoteResolver.test.js
@@ -1,7 +1,8 @@
 const expect = require('chai').expect,
   {
     resolveRemoteRefs,
-    calculateDowloadPathAndParentBaseURL
+    calculateDownloadPathAndParentBaseURL,
+    resolveRemoteRefsNoMerge
   } = require('../../lib/utils/WSDLRemoteResolver'),
   remoteRefs11 = 'test/data/separatedFiles/remoteRefs',
   remoteRefsIncludeTag = 'test/data/separatedFiles/includeTag',
@@ -140,10 +141,10 @@ describe('WSDLRemoteResolver resolveRemoteRefs', function () {
 });
 
 
-describe('WSDLRemoteResolver calculateDowloadPathAndParentBaseURL', function () {
+describe('WSDLRemoteResolver calculateDownloadPathAndParentBaseURL', function () {
 
   it('Should return same path when is a valid xsd absolute path and parent should be the base of the url', function () {
-    const { parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(
+    const { parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(
       'https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/xsd0.xsd', '', ''
     );
     expect(parentBaseURL).to.equal('https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/');
@@ -151,7 +152,7 @@ describe('WSDLRemoteResolver calculateDowloadPathAndParentBaseURL', function () 
   });
 
   it('Should return same path when is a valid xsd absolute path parent and process are set', function () {
-    const { parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(
+    const { parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(
       'https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/xsd0.xsd',
       'https://raw.com/', 'https://raw.war.com/'
     );
@@ -161,7 +162,7 @@ describe('WSDLRemoteResolver calculateDowloadPathAndParentBaseURL', function () 
 
   it('Should return same path when is a valid xsd absolute path and parent' +
   ' should be the base of the url even with processURL', function () {
-    const { parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(
+    const { parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(
       'https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/xsd0.xsd', '',
       'https://raw.githubusercontent.com/otherBasePath'
     );
@@ -170,7 +171,7 @@ describe('WSDLRemoteResolver calculateDowloadPathAndParentBaseURL', function () 
   });
 
   it('Should return resolved absolute path when send parent path and relative in the file', function () {
-    const { parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(
+    const { parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(
       'xsd0.xsd', 'https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/',
       'https://raw.githubusercontent.com/otherBasePath'
     );
@@ -179,7 +180,7 @@ describe('WSDLRemoteResolver calculateDowloadPathAndParentBaseURL', function () 
   });
 
   it('Should return absolute path when there is no parent path and relative in the file take processURL', function () {
-    const { parentBaseURL, downloadPath } = calculateDowloadPathAndParentBaseURL(
+    const { parentBaseURL, downloadPath } = calculateDownloadPathAndParentBaseURL(
       'xsd0.xsd', '',
       'https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/'
     );
@@ -187,4 +188,12 @@ describe('WSDLRemoteResolver calculateDowloadPathAndParentBaseURL', function () 
     expect(downloadPath).to.equal('https://raw.githubusercontent.com/postmanlabs/wsdl-to-postman/xsd0.xsd');
   });
 
+});
+
+describe('getHost method', async function () {
+  it('Should return the resolved references example 2', async function () {
+    const data = fs.readFileSync(remoteRefsServiceFinderQuery + '/ServiceFinderQuery.wsdl', 'utf8');
+    let res = await resolveRemoteRefsNoMerge({ data }, new XMLParser(), { resolveRemoteRefs: true });
+    expect(res).to.not.be.undefined;
+  });
 });

--- a/test/unit/WSDLRemoteResolver.test.js
+++ b/test/unit/WSDLRemoteResolver.test.js
@@ -127,7 +127,7 @@ describe('WSDLRemoteResolver resolveRemoteRefs', function () {
 
   it('Should propagate errors', function (done) {
     resolveRemoteRefs('', new XMLParser(), optionFromOptions, (resolvedFile) => {
-      expect(resolvedFile.err.message).to.equal('Cannot get prefix from undefined or null object');
+      expect(resolvedFile.err.message).to.equal('There was not WSDL file in folder.');
       done();
     });
   });
@@ -242,6 +242,24 @@ describe('resolveRemoteRefsNoMerge method', async function () {
     expect(res[1].path).to.equal('xsd1.xsd');
     expect(res[2].path).to.equal('xsd2.xsd');
     expect(res[3].path).to.equal('xsd3.xsd');
+  });
+
+  it('Should not fail when downloaded file is an invalid content', async function () {
+    const data = fs.readFileSync(remoteRefs11 + '/remoteStockquoteservice.wsdl', 'utf8'),
+      customFetch = () => {
+        let content = 'invalid content';
+        return Promise.resolve({
+          text: () => { return Promise.resolve(content); },
+          status: 200
+        });
+      },
+      res = await resolveRemoteRefsNoMerge({ data }, new XMLParser(),
+        { resolveRemoteRefs: true, remoteRefsResolver: customFetch });
+    expect(res).to.not.be.undefined;
+    expect(res[0]).to.deep.equal({
+      content: 'invalid content',
+      path: 'remoteStockquote.wsdl'
+    });
   });
 });
 


### PR DESCRIPTION
## Description

- Create a new download remote references function that is asyn, does not throw errors when documents are not valid WSDL, and does not merge the downloaded files
- Add the download remote references functionality in the validate transactions API.

This function will be used in bundle API.

Uses the current download remote references code base.
Publish options for supporting the injection of the fetching function.



## How to test this ticket

npm run test

## Sample Input and Output (remove if not needed)

Review the expected results in tests

### Checklist:

- [X] Checked all the config values
- [X] Added relevant unit tests for my code
- [ ] Did not add relevant unit test for my code, by created {{ticket#}} to
      handle in the future
