### PR TITLE
Fix html encoded uri

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -143,11 +143,12 @@ class WsdlInformationService11 {
    * @param {object} servicePort the service port element tag information
    * @param {object} bindingOperation the binding operation element tag information
    * @param {object} bindingTagInfo the binding information for the binding
+   * @param {function} decodeFunction a function to decode the url
    * @param {object} mimeContentInput input information binding details
    * @param {object} elementInput the schema input of the service
    * @returns {string} the service url
    */
-  getServiceURL(servicePort, bindingOperation, bindingTagInfo, mimeContentInput,
+  getServiceURL(servicePort, bindingOperation, bindingTagInfo, decodeFunction, mimeContentInput,
     elementInput) {
     if (!servicePort) {
       return '';
@@ -167,7 +168,8 @@ class WsdlInformationService11 {
         parametersURL = helper.convertInputToURLParams(elementInput);
       url += '?' + parametersURL;
     }
-    return url;
+
+    return decodeFunction(url);
   }
 
   /**

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -179,15 +179,17 @@ class WsdlInformationService20 {
    * @param {object} serviceEndpoint the service endpoint element tag information
    * @param {object} bindingOperation the binding operation element tag information
    * @param {object} bindingTagInfo the binding information for the binding
+   * @param {function} decodeFunction a function to decode the url
    * @returns {string} the service url
    */
-  getServiceURL(serviceEndpoint, bindingOperation, bindingTagInfo) {
+  getServiceURL(serviceEndpoint, bindingOperation, bindingTagInfo, decodeFunction) {
     if (!serviceEndpoint) {
       return '';
     }
     let serviceLocation = this.getLocationFromBindingOperation(bindingOperation, bindingTagInfo);
     serviceLocation = serviceLocation ? serviceLocation : '';
-    return getAttributeByName(serviceEndpoint, ADDRESS_TAG) + serviceLocation;
+
+    return decodeFunction(getAttributeByName(serviceEndpoint, ADDRESS_TAG) + serviceLocation);
   }
 
   /**

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -20,7 +20,10 @@ const
   } = require('./WsdlParserCommon'),
   {
     getLastSegmentURL
-  } = require('../lib/utils/textUtils');
+  } = require('../lib/utils/textUtils'),
+  {
+    decodeFromXML
+  } = require('./utils/urlUtils');
 
 class WsdlParser {
 
@@ -240,7 +243,7 @@ class WsdlParser {
         wsdlOperation.mimeContentOutput = this.informationService.getMimeContentInfo(bindingOperation,
           principalPrefix, this.informationService.OutputTagName);
         wsdlOperation.url = this.informationService.getServiceURL(servicePort, bindingOperation, bindingTagInfo,
-          wsdlOperation.mimeContentInput, wsdlOperation.input[0]);
+          decodeFromXML, wsdlOperation.mimeContentInput, wsdlOperation.input[0]);
 
         wsdlOperations.push(wsdlOperation);
       });

--- a/lib/utils/urlUtils.js
+++ b/lib/utils/urlUtils.js
@@ -41,7 +41,31 @@ function getAllButProtocolAndHost(url) {
   return rest;
 }
 
+/**
+ * Decodes the url from an xml compliant string uri
+ * @param {string} url the url
+ * @returns {string} the decoded url
+ */
+function decodeFromXML(url) {
+  if (url === undefined || url === null || url === '') {
+    return '';
+  }
+  let substitutionChars = [
+    { oldRep: '&amp;', newRep: '&' },
+    { oldRep: '&lt;', newRep: '<' },
+    { oldRep: '&gt;', newRep: '>' },
+    { oldRep: '&apos;', newRep: '\'' },
+    { oldRep: '&quot;', newRep: '"' }
+  ];
+  substitutionChars.forEach((substitutionChar) => {
+    url = url.replaceAll(substitutionChar.oldRep, substitutionChar.newRep);
+  });
+  return url;
+
+}
+
 module.exports = {
   getProtocolAndHost,
-  getAllButProtocolAndHost
+  getAllButProtocolAndHost,
+  decodeFromXML
 };

--- a/lib/utils/urlUtils.js
+++ b/lib/utils/urlUtils.js
@@ -50,16 +50,18 @@ function decodeFromXML(url) {
   if (url === undefined || url === null || url === '') {
     return '';
   }
-  let substitutionChars = [
-    { oldRep: '&amp;', newRep: '&' },
-    { oldRep: '&lt;', newRep: '<' },
-    { oldRep: '&gt;', newRep: '>' },
-    { oldRep: '&apos;', newRep: '\'' },
-    { oldRep: '&quot;', newRep: '"' }
-  ];
-  substitutionChars.forEach((substitutionChar) => {
-    url = url.replaceAll(substitutionChar.oldRep, substitutionChar.newRep);
-  });
+
+  const regexAmpersand = new RegExp('&amp;', 'g'),
+    regexLessThan = new RegExp('&lt;', 'g'),
+    regexGreaterThan = new RegExp('&gt;', 'g'),
+    regexApostrophe = new RegExp('&apos;', 'g'),
+    regexQuote = new RegExp('&quot;', 'g');
+  url = url.replace(regexAmpersand, '&')
+    .replace(regexLessThan, '<')
+    .replace(regexGreaterThan, '>')
+    .replace(regexApostrophe, '\'')
+    .replace(regexQuote, '"');
+
   return url;
 
 }

--- a/test/data/validWSDLs11/addressURIEspecialChars.wsdl
+++ b/test/data/validWSDLs11/addressURIEspecialChars.wsdl
@@ -1,0 +1,201 @@
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/"
+    xmlns:tns="http://tempuri.org/"
+    xmlns:s="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
+    <wsdl:types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+            <s:element name="Add">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="AddResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="AddResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Subtract">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="SubtractResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="SubtractResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Multiply">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="MultiplyResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="MultiplyResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Divide">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="intA" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="intB" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="DivideResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="DivideResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+        </s:schema>
+    </wsdl:types>
+    <wsdl:message name="AddSoapIn">
+        <wsdl:part name="parameters" element="tns:Add" />
+    </wsdl:message>
+    <wsdl:message name="AddSoapOut">
+        <wsdl:part name="parameters" element="tns:AddResponse" />
+    </wsdl:message>
+    <wsdl:message name="SubtractSoapIn">
+        <wsdl:part name="parameters" element="tns:Subtract" />
+    </wsdl:message>
+    <wsdl:message name="SubtractSoapOut">
+        <wsdl:part name="parameters" element="tns:SubtractResponse" />
+    </wsdl:message>
+    <wsdl:message name="MultiplySoapIn">
+        <wsdl:part name="parameters" element="tns:Multiply" />
+    </wsdl:message>
+    <wsdl:message name="MultiplySoapOut">
+        <wsdl:part name="parameters" element="tns:MultiplyResponse" />
+    </wsdl:message>
+    <wsdl:message name="DivideSoapIn">
+        <wsdl:part name="parameters" element="tns:Divide" />
+    </wsdl:message>
+    <wsdl:message name="DivideSoapOut">
+        <wsdl:part name="parameters" element="tns:DivideResponse" />
+    </wsdl:message>
+    <wsdl:portType name="CalculatorSoap">
+        <wsdl:operation name="Add">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Adds two integers. This is a test WebService. ©DNE Online</wsdl:documentation>
+            <wsdl:input message="tns:AddSoapIn" />
+            <wsdl:output message="tns:AddSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <wsdl:input message="tns:SubtractSoapIn" />
+            <wsdl:output message="tns:SubtractSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <wsdl:input message="tns:MultiplySoapIn" />
+            <wsdl:output message="tns:MultiplySoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <wsdl:input message="tns:DivideSoapIn" />
+            <wsdl:output message="tns:DivideSoapOut" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="CalculatorSoap" type="tns:CalculatorSoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Add">
+            <soap:operation soapAction="http://tempuri.org/Add" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <soap:operation soapAction="http://tempuri.org/Subtract" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <soap:operation soapAction="http://tempuri.org/Multiply" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <soap:operation soapAction="http://tempuri.org/Divide" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="CalculatorSoap12" type="tns:CalculatorSoap">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Add">
+            <soap12:operation soapAction="http://tempuri.org/Add" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Subtract">
+            <soap12:operation soapAction="http://tempuri.org/Subtract" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Multiply">
+            <soap12:operation soapAction="http://tempuri.org/Multiply" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Divide">
+            <soap12:operation soapAction="http://tempuri.org/Divide" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Calculator">
+        <wsdl:port name="CalculatorSoap" binding="tns:CalculatorSoap">
+            <soap:address location="http://acme.org/SOAPAdapter/MessageServlet?senderParty=&amp;senderService=TIBCO&amp;receiverParty=&amp;receiverService=&amp;interface=IsuMrAcmeHistory&amp;interfaceNamespace=http%3A%2F%2Facme.org%2Finterfaces%2Facme%2Fisu%2Fmr%2Facme%2Fhistory%2Fv1"
+            xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/data/validWSDLs20/addressURIEspecialChars.wsdl
+++ b/test/data/validWSDLs20/addressURIEspecialChars.wsdl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description xmlns="http://www.w3.org/ns/wsdl" 
+             xmlns:tns="http://www.tmsws.com/wsdl20sample" 
+             xmlns:whttp="http://schemas.xmlsoap.org/wsdl/http/"
+             xmlns:wsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+             targetNamespace="http://www.tmsws.com/wsdl20sample">
+
+<documentation>
+    This is a sample WSDL 2.0 document. 
+</documentation>
+
+<!-- Abstract type -->
+   <types>
+      <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns="http://www.tmsws.com/wsdl20sample"
+                targetNamespace="http://www.example.com/wsdl20sample">
+                 
+         <xs:element name="request">  </xs:element>
+         <xs:element name="response">  </xs:element>
+      </xs:schema>
+   </types>
+
+<!-- Abstract interfaces -->
+   <interface name="Interface1">
+      <fault name="Error1" element="tns:response"/>
+      <operation name="Get" pattern="http://www.w3.org/ns/wsdl/in-out">
+         <input messageLabel="In" element="tns:request"/>
+         <output messageLabel="Out" element="tns:response"/>
+      </operation>
+   </interface>
+   
+<!-- Concrete Binding with SOAP-->
+   <binding name="SoapBinding" interface="tns:Interface1" 
+            type="http://www.w3.org/ns/wsdl/soap" 
+            wsoap:protocol="http://www.w3.org/2003/05/soap/bindings/HTTP/"
+            wsoap:mepDefault="http://www.w3.org/2003/05/soap/mep/request-response">
+      <operation ref="tns:Get" />
+   </binding>
+
+<!-- Web Service offering endpoints for both bindings-->
+   <service name="Service1" interface="tns:Interface1">
+      <endpoint name="SoapEndpoint" 
+                binding="tns:SoapBinding" 
+                address="http://acme.org/SOAPAdapter/MessageServlet?senderParty=&amp;senderService=TIBCO&amp;receiverParty=&amp;receiverService=&amp;interface=IsuMrAcmeHistory&amp;interfaceNamespace=http%3A%2F%2Facme.org%2Finterfaces%2Facme%2Fisu%2Fmr%2Facme%2Fhistory%2Fv1"
+                />
+   </service>
+</description>

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -173,6 +173,30 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
       });
     });
   });
+
+  it('[Github #11329] - Should convert and decoded an html encoded uri', function() {
+    let fileContent = fs.readFileSync(validWSDLs + '/addressURIEspecialChars.wsdl', 'utf8');
+    const schemaPack = new SchemaPack({
+      data: fileContent,
+      type: 'string'
+    }, {});
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output).to.be.an('array');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].type).to.equal('collection');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].data.item).to.be.an('array');
+      expect(result.output[0].data.item[0].item[0].request.url.query[0].key).to.equal('senderParty');
+      expect(result.output[0].data.item[0].item[0].request.url.query[1].key).to.equal('senderService');
+      expect(result.output[0].data.item[0].item[0].request.url.query[2].key).to.equal('receiverParty');
+      expect(result.output[0].data.item[0].item[0].request.url.query[3].key).to.equal('receiverService');
+      expect(result.output[0].data.item[0].item[0].request.url.query[4].key).to.equal('interface');
+      expect(result.output[0].data.item[0].item[0].request.url.query[5].key).to.equal('interfaceNamespace');
+    });
+  });
 });
 
 describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
@@ -277,6 +301,29 @@ describe('SchemaPack convert unit test WSDL 2.0', function () {
         expect(result.output[0].data).to.be.an('object');
         expect(result.output[0].type).to.equal('collection');
       });
+    });
+  });
+  it('[Github #11329] - Should convert and decoded an html encoded uri', function() {
+    let fileContent = fs.readFileSync(validWSDLs20 + '/addressURIEspecialChars.wsdl', 'utf8');
+    const schemaPack = new SchemaPack({
+      data: fileContent,
+      type: 'string'
+    }, {});
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output).to.be.an('array');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].type).to.equal('collection');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].data.item).to.be.an('array');
+      expect(result.output[0].data.item[0].request.url.query[0].key).to.equal('senderParty');
+      expect(result.output[0].data.item[0].request.url.query[1].key).to.equal('senderService');
+      expect(result.output[0].data.item[0].request.url.query[2].key).to.equal('receiverParty');
+      expect(result.output[0].data.item[0].request.url.query[3].key).to.equal('receiverService');
+      expect(result.output[0].data.item[0].request.url.query[4].key).to.equal('interface');
+      expect(result.output[0].data.item[0].request.url.query[5].key).to.equal('interfaceNamespace');
     });
   });
 });

--- a/test/unit/urlUtils.test.js
+++ b/test/unit/urlUtils.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { getProtocolAndHost, getAllButProtocolAndHost } = require('../../lib/utils/urlUtils');
+const { getProtocolAndHost, getAllButProtocolAndHost, decodeFromXML } = require('../../lib/utils/urlUtils');
 
 describe('getProtocolAndHost method', function() {
   it('should return the correct host and protocol from a url', function() {
@@ -57,5 +57,30 @@ describe('getAllButProtocolAndHost method', function() {
       urlToCheck = getAllButProtocolAndHost(url);
     expect(urlToCheck).to.be.equal('Services/Geocode/WebService/GeocoderService_V04_01.asmx/' +
     'GeocodeAddressParsed');
+  });
+});
+
+
+describe('decodeFromXML method', function () {
+  it('should return http://localhost:3000/projects?param=value&param1=&param2=TIBCO\'">< for entry ' +
+    'http://localhost:3000/projects?param=value&amp;param1=&amp;param2=TIBCO&apos;&quot;&gt;&lt;', function () {
+    const result = decodeFromXML('http://localhost:3000/projects?' +
+    'param=value&amp;param1=&amp;param2=TIBCO&apos;&quot;&gt;&lt;');
+    expect(result).to.equal('http://localhost:3000/projects?param=value&param1=&param2=TIBCO\'"><');
+  });
+
+  it('should return empty string when input is undefined', function () {
+    const result = decodeFromXML();
+    expect(result).to.equal('');
+  });
+
+  it('should return empty string when input is null', function () {
+    const result = decodeFromXML(null);
+    expect(result).to.equal('');
+  });
+
+  it('should return empty string when input is empty string', function () {
+    const result = decodeFromXML('');
+    expect(result).to.equal('');
   });
 });


### PR DESCRIPTION
Fix html encoded uri

## Description

Fixes https://github.com/postmanlabs/postman-app-support/issues/11329
Currently we are not decoding the html uri, so the encodec characters:  &amp; &lt; &gt; &apos;  &quot; are left in the uri
Those characters should be replaced by:  & < > '  " 

Ref:
https://docs.oracle.com/cd/A97335_02/apps.102/bc4j/developing_bc_projects/obcCustomXml.htm

https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML


## How to test this ticket

npm run test

## Solution
We are replacing the characters once we extract the url and generate the query parameters.

note ![CDATA notation is used only for content and nodes in xml not attributes that is why we are doing the replace in all of  the URIs from address.

### Checklist:

- [ ] Checked all the config values
- [x] Added relevant unit tests for my code

