### PR TITLE
Added handling for specifications with no defined portType

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -367,12 +367,12 @@ class WsdlInformationService11 {
       localPortname = getQNameLocal(portTypeName);
       const definitions = getNodeByName(parsedXml, principalPrefix, WSDL_ROOT),
         arrayPortTypes = getArrayFrom(getNodeByName(definitions, principalPrefix, PORT_TYPE_TAG));
-      portTypeFound = arrayPortTypes.find((portType) => {
+      portTypeFound = arrayPortTypes && arrayPortTypes.find((portType) => {
         return getAttributeByName(portType, NAME_TAG) === localPortname;
       });
       operations = getArrayFrom(getNodeByName(portTypeFound, principalPrefix, OPERATION_TAG));
 
-      operationReturn = operations.find((operation) => {
+      operationReturn = operations && operations.find((operation) => {
         return getAttributeByName(operation, NAME_TAG) === operationName;
       }) || {};
 

--- a/lib/utils/XMLParsedUtils.js
+++ b/lib/utils/XMLParsedUtils.js
@@ -8,7 +8,9 @@ const XML_NAMESPACE_SEPARATOR = ':';
  * @returns {object} the parsed object
  */
 function getXMLNodeByName(parentNode, prefix, nodeName) {
-  return parentNode[prefix + nodeName];
+  if (parentNode) {
+    return parentNode[prefix + nodeName];
+  }
 }
 
 /**

--- a/test/data/specialCases/NoServicesPortType.wsdl
+++ b/test/data/specialCases/NoServicesPortType.wsdl
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:tns="http://www.dataaccess.com/webservicesserver/" name="NumberConversion" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+  <types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+      <xs:element name="NumberToWords">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ubiNum" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToWordsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="NumberToWordsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToDollars">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dNum" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToDollarsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="NumberToDollarsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="NumberToWordsSoapRequest">
+    <part name="parameters" element="tns:NumberToWords"/>
+  </message>
+  <message name="NumberToWordsSoapResponse">
+    <part name="parameters" element="tns:NumberToWordsResponse"/>
+  </message>
+  <message name="NumberToDollarsSoapRequest">
+    <part name="parameters" element="tns:NumberToDollars"/>
+  </message>
+  <message name="NumberToDollarsSoapResponse">
+    <part name="parameters" element="tns:NumberToDollarsResponse"/>
+  </message>
+  <binding name="NumberConversionSoapBinding" type="tns:NumberConversionSoapType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="NumberToWords">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="NumberToDollars">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <binding name="NumberConversionSoapBinding12" type="tns:NumberConversionSoapType">
+    <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="NumberToWords">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="NumberToDollars">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="NumberConversion">
+    <documentation>The Number Conversion Web Service, implemented with Visual DataFlex, provides functions that convert numbers into words or dollar amounts.</documentation>
+    <port name="NumberConversionSoap" binding="tns:NumberConversionSoapBinding">
+      <soap:address location="https://www.dataaccess.com/webservicesserver/numberconversion.wso"/>
+    </port>
+    <port name="NumberConversionSoap12" binding="tns:NumberConversionSoapBinding12">
+      <soap12:address location="https://www.dataaccess.com/webservicesserver/numberconversion.wso"/>
+    </port>
+  </service>
+</definitions>

--- a/test/unit/ConversionSpecialCases.test.js
+++ b/test/unit/ConversionSpecialCases.test.js
@@ -294,4 +294,23 @@ describe('SchemaPack convert special cases WSDL 2.0', function() {
     });
   });
 
+  it('Should get an object representing PM Collection from wsdl without services porttypes', function() {
+    let fileContent = fs.readFileSync(validWSDLs + '/NoServicesPortType.wsdl', 'utf8');
+    const schemaPack = new SchemaPack({
+      data: fileContent,
+      type: 'string'
+    }, {});
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output).to.be.an('array');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].type).to.equal('collection');
+      expect(result.output[0].data).to.be.an('object');
+      expect(result.output[0].data.item).to.be.an('array');
+      expect(result.output[0].data.item.length).to.equal(2);
+    });
+  });
+
 });

--- a/test/unit/WsdlInformationService11.test.js
+++ b/test/unit/WsdlInformationService11.test.js
@@ -1689,15 +1689,14 @@ describe('WSDL 1.1 parser getAbstractOperationByName', function () {
     }
   });
 
-  it('should throw an error when parsedxml is an empty object', function () {
+  it('should not throw an error when parsedxml is an empty object', function () {
     try {
       const informationService = new WsdlInformationService11();
       informationService.getAbstractOperationByName('NumberConversionSoapType',
         'NumberToWords', {}, '');
-      assert.fail('we expected an error');
     }
     catch (error) {
-      expect(error.message).to.equal('Cannot get port type from WSDL');
+      assert.fail('we expected this to succeed');
     }
   });
 


### PR DESCRIPTION
## Description

This PR fixes issues where absence of `portType` in a definition was leading to collection conversion failures on both the Postman App as well as standalone module usage.

Ref: Issue on Postman App Support: https://github.com/postmanlabs/postman-app-support/issues/11267

## How to test this ticket

- Use the wsdl file attached in the github issue mentioned above.
- Try converting it into a postman collection using this module. It should succeed.
- Now try importing the collection's json file on Postman, it should succeed too.

### Checklist:

- [x] Checked all the config values
- [x] Added relevant unit tests for my code
