### PR TITLE
Improve performance by removing unnecessary deep copying of objects

### DIFF
--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -681,7 +681,7 @@ class SchemaBuilderXSD {
       wsdlElement.pattern = element.pattern;
       wsdlElement.enum = element.enum;
 
-      this.getChildren(getDeepCopyOfObject(element), wsdlElement, elements);
+      this.getChildren(element, wsdlElement, elements);
       elements.push(wsdlElement);
     });
   }


### PR DESCRIPTION
## Description
Improves performance in converting a WSDL file with many types by removing unnecessary deep copying of objects where it is not required.

## Details
I profiled the code using [0x](https://www.npmjs.com/package/0x). I've posted a screenshot of the flamegraph below.

In the method [SchemaBuilderXSD.processElementsToWSDElements](https://github.com/postmanlabs/wsdl-to-postman/blob/v1.7.0/lib/utils/SchemaBuilderXSD.js#L661), I found that passing a deep copy of `element` to `getChildren` is unnecessary because:

1. `element` is used in the current function just once to pass it to the `getChildren` method.
2. The variable `elementsFromWSDL` being passed to this method is a local variable in the parent function. Its scope expires when the method completes and is not used anywhere except this method.

So, it is okay for `getChildren` to mutate `element` because it is used only in constructing `wsdlElement` and discarded after the parent function completes.

### Before the fix
![35475c4b-59a5-4749-bdbe-3d99aa6a9e97](https://user-images.githubusercontent.com/3478831/218983604-a1f2be51-e0c7-49c6-8437-1f7388eebb77.png)
The conversion took between 120-130s on average, utilised 100% of the CPU, and consumed around 1.4GB of memory at peak.

### After the fix
![2cd6fa39-36ac-473b-a572-481a228419e2](https://user-images.githubusercontent.com/3478831/218983549-28f7b211-ed09-49ac-80c8-b19a3ac559aa.png)
After making this change, the conversion took 55s on average. It still utilised 100% of the CPU but consumed around 1.0GB of memory at peak. That is around a 30% reduction in peak memory and 60% in duration. The flamegraph indicated that `clone` calls were no longer taking time.

## How to test this ticket
- Existing unit tests should pass
- To confirm that the fix did not introduce any regressions, all valid WSDL test files present in test/data were tested using a script, once using the existing flow and then after removing the call to `getDeepCopyOfObject`. The resulting collection objects were then compared (after removing auto-generated ids), and there was no difference.

### Checklist:
- [x] Checked all the config values (no config changes)
- [x] Added relevant unit tests for my code (not needed)
- [x] Did not add relevant unit test for my code because it is not needed