### PR TITLE
Fixed issue where conversion failed with typeeror while resolving non defined variables.

### DIFF
--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -1387,7 +1387,7 @@ class SchemaBuilderXSD {
       isBeenLookedUp = lookedReferences.find((lookedReference) => {
         return lookedReference.element === elementName;
       });
-      if (isBeenLookedUp) {
+      if (isBeenLookedUp && typeof path === 'string') {
         containsPath = path.includes(isBeenLookedUp.path);
       }
     }

--- a/test/unit/SchemaBuilderXSD.test.js
+++ b/test/unit/SchemaBuilderXSD.test.js
@@ -3,6 +3,7 @@ const expect = require('chai').expect,
     SchemaBuilderXSD
   } = require('../../lib/utils/SchemaBuilderXSD'),
   fs = require('fs'),
+  _ = require('lodash'),
   validSchemaFolder = 'test/data/schemaTest',
   {
     XMLParser
@@ -2079,5 +2080,19 @@ describe('replaceTagInSchema', function () {
     const schemaBuilder = new SchemaBuilderXSD(),
       result = schemaBuilder.replaceTagInSchema(fileContent, schemaNamespace, 'all', 'sequence');
     expect(result.includes('<xsd:all>')).to.equal(false);
+  });
+});
+
+describe('SchemaBuilderXSD isLoopReferenceElement', function () {
+  it('should not throw error if certain path is not defined', function () {
+    const builder = new SchemaBuilderXSD();
+    try {
+      const isLoopReferenceElement = builder.isLoopReferenceElement({}, '', ['user'], _.isEqual, 'user', null);
+
+      expect(isLoopReferenceElement).to.be.false;
+    }
+    catch (error) {
+      expect(error).to.be.undefined;
+    }
   });
 });


### PR DESCRIPTION
we are having a function named `isLoopReferenceElement` that’s supposed to identify if an element has a reference to itself to avoid a recursion loop.

This function was always accessing `includes()` function on a property called path. As this path was coming from SDK, for certain cases it could be undefined or null. In such cases, this failed with TypeError rather than correct response which should be false for this function.