### PR TITLE
Fixed issue where circular references were not corectly identified while resolving elements.

### DIFF
--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -1,4 +1,5 @@
-const { ElementResolver } = require('./ElementResolver');
+const { ElementResolver } = require('./ElementResolver'),
+  _ = require('lodash');
 
 const Parser = require('fast-xml-parser').j2xParser,
   parserOptions = {
@@ -1380,20 +1381,18 @@ class SchemaBuilderXSD {
   isLoopReferenceElement(elementProperties, complexTypeName, lookedReferences, comparer,
     elementName, path) {
     let isSelfReference = false,
-      isBeenLookedUp,
-      containsPath = false;
+      isElementTraversed = false;
 
     if (lookedReferences) {
-      isBeenLookedUp = lookedReferences.find((lookedReference) => {
-        return lookedReference.element === elementName;
+      isElementTraversed = _.some(lookedReferences, (ref) => {
+        return ref.element === elementName && (path.includes(ref.path) || path === ref.path);
       });
-      if (isBeenLookedUp && typeof path === 'string') {
-        containsPath = path.includes(isBeenLookedUp.path);
-      }
     }
-    if (containsPath) {
+
+    if (isElementTraversed) {
       return true;
     }
+
     traverseUtility(elementProperties).forEach((property) => {
       if (property) {
         let hasReferenceTypeKey = Object.keys(property)

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -1381,15 +1381,19 @@ class SchemaBuilderXSD {
   isLoopReferenceElement(elementProperties, complexTypeName, lookedReferences, comparer,
     elementName, path) {
     let isSelfReference = false,
-      isElementTraversed = false;
+      isElementTraversedAlready = false;
 
     if (lookedReferences) {
-      isElementTraversed = _.some(lookedReferences, (ref) => {
+      /**
+       * For any already looped element, if path is same or substring of current path
+       * current element would already be have been traversed
+       */
+      isElementTraversedAlready = _.some(lookedReferences, (ref) => {
         return ref.element === elementName && (path.includes(ref.path) || path === ref.path);
       });
     }
 
-    if (isElementTraversed) {
+    if (isElementTraversedAlready) {
       return true;
     }
 

--- a/test/data/validWSDLs11/circularComplexTypeReference.wsdl
+++ b/test/data/validWSDLs11/circularComplexTypeReference.wsdl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:tns="http://www.cleverbuilder.com/BookService/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="BookService"
+                  targetNamespace="http://www.cleverbuilder.com/BookService/">
+  <wsdl:documentation>Definition for a web service called BookService,
+    which can be used to add or retrieve books from a collection.
+  </wsdl:documentation>
+
+  <!--
+      The `types` element defines the data types (XML elements)
+      that are used by the web service.
+   -->
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://www.cleverbuilder.com/BookService/">
+      <xsd:complexType name="setFilterConditionList">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element ref="tns:setFilterCondition" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>   
+      </xsd:complexType>
+      <xsd:group name="setFilterCondition">
+          <xsd:choice>
+              <xsd:element ref="setFilterAnd">
+                  <xsd:annotation>
+                      <xsd:documentation source="rn_added_7.0"/>
+                  </xsd:annotation>
+              </xsd:element>
+              <xsd:element ref="setFilterOr">
+                  <xsd:annotation>
+                      <xsd:documentation source="rn_added_7.0"/>
+                  </xsd:annotation>
+              </xsd:element>
+              <xsd:element ref="setFilterNot">
+                  <xsd:annotation>
+                      <xsd:documentation source="rn_added_7.0"/>
+                  </xsd:annotation>
+              </xsd:element>
+          </xsd:choice>
+      </xsd:group>
+      <xsd:element name="setFilterAnd" type="setFilterConditionList"/>
+      <xsd:element name="setFilterOr" type="setFilterConditionList"/>
+      <xsd:element name="setFilterNot">
+          <xsd:complexType>
+              <xsd:group ref="setFilterCondition"/>
+          </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Book">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Title" type="xsd:string"/>
+            <xsd:element name="Author" type="xsd:string"/>
+            <xsd:element ref="tns:Book" minOccurs="0" maxOccurs="unbounded"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Books">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element ref="tns:Book" minOccurs="0" maxOccurs="unbounded"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="GetBook">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="ID" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="GetBookResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element ref="tns:setFilterAnd" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+
+
+  <!--
+      A wsdl `message` element is used to define a message
+      exchanged between a web service, consisting of zero
+      or more `part`s.
+   -->
+
+  <wsdl:message name="GetBookRequest">
+    <wsdl:part element="tns:GetBook" name="parameters"/>
+  </wsdl:message>
+  <wsdl:message name="GetBookResponse">
+    <wsdl:part element="tns:GetBookResponse" name="parameters"/>
+  </wsdl:message>
+
+  <!--
+      A WSDL `portType` is used to combine multiple `message`s
+      (e.g. input, output) into a single operation.
+
+      Here we define three synchronous (input/output) operations
+      and the `message`s that must be used for each.
+   -->
+  <wsdl:portType name="BookService">
+    <wsdl:operation name="GetBook">
+      <wsdl:input message="tns:GetBookRequest"/>
+      <wsdl:output message="tns:GetBookResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <!--
+      The `binding` element defines exactly how each
+      `operation` will take place over the network.
+      In this case, we are using SOAP.
+   -->
+  <wsdl:binding name="BookServiceSOAP" type="tns:BookService">
+    <soap:binding style="document"
+                  transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="GetBook">
+      <soap:operation
+              soapAction="http://www.cleverbuilder.com/BookService/GetBook"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <!--
+      The `service` element finally says where the service
+      can be accessed from - in other words, its endpoint.
+   -->
+  <wsdl:service name="BookService">
+    <wsdl:port binding="tns:BookServiceSOAP" name="BookServiceSOAP">
+      <soap:address location="http://www.example.org/BookService"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -218,6 +218,36 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
         .to.equal(removeLineBreakTabsSpaces(expectedOutput));
     });
   });
+
+  it('Should convert circular ref and add circular ref element as empty object when' +
+    ' parent node does not contain name', function() {
+    let fileContent = fs.readFileSync(validWSDLs + '/circularComplexTypeReference.wsdl', 'utf8');
+    const schemaPack = new SchemaPack({
+        data: fileContent,
+        type: 'string'
+      }, {}),
+      expectedOutput = `<?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <GetBookResponse xmlns="http://www.cleverbuilder.com/BookService/">
+            <tns:setFilterAnd>
+              <tns:setFilterCondition>
+                <setFilterAnd/>
+              </tns:setFilterCondition>
+            </tns:setFilterAnd>
+          </GetBookResponse>
+        </soap:Body>
+      </soap:Envelope>`;
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output[0].data.item).to.have.lengthOf(1);
+      expect(result.output[0].data.item[0].response).to.have.lengthOf(1);
+      expect(removeLineBreakTabsSpaces(result.output[0].data.item[0].response[0].body))
+        .to.equal(removeLineBreakTabsSpaces(expectedOutput));
+    });
+  });
 });
 
 describe('SchemaPack convert unit test WSDL 1.1 with options', function () {


### PR DESCRIPTION
### Overview
This PR fixes the issue where the conversion process was failing with `RageError: Maximum call stack size exceeded`. See added test file in this PR for more detail on the structure of WSDL and to reproduce it

### RCA
The issue was happening due to an incorrect way of finding out if the element is a looped reference. For this purpose, we are using `isLoopReferenceElement()` method.

This method was finding if current element is already resolved (looped through) once via maintaining resolved references in `lookedReferences` property. And while deciding, then logic was incorrect where it first found the element with same name and then found if the current element `path` contains the found parent element's path.

This logic is incorrect in some cases where `path` which is decided based on parent name was not defined. In such cases this `path` was just empty string. And as this process of finding contained path was split in 2 parts, it meant incorrect element was found in first part which had some `path` defined. But later occurrences having empty string as `path` were not identified as looped reference correctly. 

###  Fix
We'll now be making sure that the logic to identify if current reference is looped reference or not is not split in 2 part. i.e. Both element name and path will;l be compared in same iteration and we'll also allow the case where element `path` and parent `path` are same for determining if the reference is looped or not.