### PR TITLE
Fixed all known TypeErrors being caused due to unsafe access of certain properties.

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -124,9 +124,13 @@ class WsdlInformationService11 {
   * @returns {string} the porttype name
   */
   getAbstractDefinitionName(binding, tnsNamespace) {
-    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX;
+    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX,
+      attribute = getAttributeByName(binding, ATTRIBUTE_TYPE);
 
-    return getAttributeByName(binding, ATTRIBUTE_TYPE).replace(tnsNamespacePrefix, '');
+    if (typeof attribute === 'string') {
+      return attribute.replace(tnsNamespacePrefix, '');
+    }
+    return '';
   }
 
   getOperationxPathInfo(bindingName, operationName, wsdlNamespaceUrl) {
@@ -159,7 +163,7 @@ class WsdlInformationService11 {
         if (key.includes(ADDRESS_TAG)) { return true; }
       }),
       serviceLocation = this.getLocationFromBindingOperation(bindingOperation, bindingTagInfo),
-      address = servicePort[addressKey];
+      address = servicePort[addressKey] || {};
     serviceLocation = serviceLocation ? serviceLocation : '';
     url = getAttributeByName(address, LOCATION_TAG) + serviceLocation;
 
@@ -236,9 +240,13 @@ class WsdlInformationService11 {
           return;
         }
         elementName = excludeSeparatorFromName(elementName);
-        foundElement = elementsFromWSDL.find((element) => {
-          return element.name === elementName;
-        });
+
+        if (Array.isArray(elementsFromWSDL)) {
+          foundElement = elementsFromWSDL.find((element) => {
+            return element.name === elementName;
+          });
+        }
+
         if (foundElement === undefined) {
           elementsArray.push(createErrorElement({}, elementName));
         }
@@ -267,7 +275,7 @@ class WsdlInformationService11 {
       part, elementName,
       messageOnlyName = getQNameLocal(messageName),
       messages = getArrayFrom(getNodeByName(definitions, principalPrefix, MESSAGE_TAG)),
-      foundMessage = messages.find((message) => {
+      foundMessage = Array.isArray(messages) && messages.find((message) => {
         return getAttributeByName(message, ATTRIBUTE_NAME) === messageOnlyName;
       });
 

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -1,4 +1,5 @@
 const
+  _ = require('lodash'),
   {
     getNodeByName,
     getAttributeByName,
@@ -106,9 +107,13 @@ class WsdlInformationService20 {
   * @returns {string} the interface name
   */
   getAbstractDefinitionName(binding, tnsNamespace) {
-    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX;
+    let tnsNamespacePrefix = (tnsNamespace && tnsNamespace.key === 'string') ? tnsNamespace.key + ':' : THIS_NS_PREFIX,
+      attribute = getAttributeByName(binding, INTERFACE_TAG);
 
-    return getAttributeByName(binding, INTERFACE_TAG).replace(tnsNamespacePrefix, '');
+    if (typeof attribute === 'string') {
+      return attribute.replace(tnsNamespacePrefix, '');
+    }
+    return '';
   }
 
   /**
@@ -183,7 +188,7 @@ class WsdlInformationService20 {
    * @returns {string} the service url
    */
   getServiceURL(serviceEndpoint, bindingOperation, bindingTagInfo, decodeFunction) {
-    if (!serviceEndpoint) {
+    if (!_.isObject(serviceEndpoint)) {
       return '';
     }
     let serviceLocation = this.getLocationFromBindingOperation(bindingOperation, bindingTagInfo);
@@ -463,10 +468,14 @@ class WsdlInformationService20 {
       elements = [];
     if (information) {
       elementName = getAttributeByName(information, ATTRIBUTE_ELEMENT);
-      element = elementsFromWSDL.find((element) => {
-        let fixedName = getQNameLocal(elementName);
-        return element.name === fixedName;
-      });
+
+      if (Array.isArray(elementsFromWSDL)) {
+        element = elementsFromWSDL.find((element) => {
+          let fixedName = getQNameLocal(elementName);
+          return element.name === fixedName;
+        });
+      }
+
       if (element === undefined) {
         elements.push(createErrorElement({}, elementName));
       }

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -1,4 +1,5 @@
 const
+  _ = require('lodash'),
   WsdlObject = require('./WSDLObject').WsdlObject,
   Operation = require('./WSDLObject').Operation,
   WsdlError = require('./WsdlError'),
@@ -235,7 +236,7 @@ class WsdlParser {
         wsdlOperation.xpathInfo = this.informationService.getOperationxPathInfo(
           bindingTagInfo.bindingName,
           wsdlOperation.name,
-          wsdlObject.wsdlNamespace.url,
+          _.get(wsdlObject, 'wsdlNamespace.url'),
           wsdlObject.tnsNamespace
         );
         wsdlOperation.mimeContentInput = this.informationService.getMimeContentInfo(bindingOperation,

--- a/lib/utils/SOAPBody.js
+++ b/lib/utils/SOAPBody.js
@@ -136,7 +136,10 @@ class SOAPBody {
     else {
       fixedAttributeName = property;
     }
-    jObj[fixedAttributeName] = value;
+
+    if (jObj && typeof jObj === 'object') {
+      jObj[fixedAttributeName] = value;
+    }
   }
 
 }

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -319,7 +319,7 @@ class SchemaBuilderXSD {
         else {
           realPartTypeorelement = partType;
         }
-        realPartTypeorelement = realPartTypeorelement.split(XML_NAMESPACE_SEPARATOR)[1];
+        realPartTypeorelement = _.split(realPartTypeorelement, XML_NAMESPACE_SEPARATOR)[1];
 
         if (realPartTypeorelement) {
           let foundType = this.findMessageParameterAndType(realPartTypeorelement, elementsInTypes,

--- a/lib/utils/httpUtils.js
+++ b/lib/utils/httpUtils.js
@@ -1,4 +1,5 @@
-const POST_METHOD = 'POST',
+const _ = require('lodash'),
+  POST_METHOD = 'POST',
   GET_METHOD = 'GET';
 
 /**
@@ -14,7 +15,7 @@ function getHttpVerb(stringVerb) {
     'post': POST_METHOD,
     'default': POST_METHOD
   };
-  return (verbs[stringVerb.toLowerCase()] || verbs.default);
+  return (verbs[_.toLower(stringVerb)] || verbs.default);
 }
 
 module.exports = {

--- a/test/data/validWSDLs11/noWSDLNamespace.wsdl
+++ b/test/data/validWSDLs11/noWSDLNamespace.wsdl
@@ -1,0 +1,352 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions
+  xmlns:wd-wsdl="some/url/Human_Resources" 
+  xmlns:wd="some/url" 
+  xmlns:nyw="nywurl/aod" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  xmlns:soapbind="http://schemas.xmlsoap.org/wsdl/soap/" 
+  xmlns:httpbind="http://schemas.xmlsoap.org/wsdl/http/" 
+  xmlns:mimebind="http://schemas.xmlsoap.org/wsdl/mime/"
+  name="Human_Resources" 
+  targetNamespace="some/url/Human_Resources">
+  <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="some/url">
+      <xsd:element name="Business_Site_Find" type="wd:Business_Site_FindType"/>
+      <xsd:element name="Validation_Fault" type="wd:Validation_FaultType"/>
+      <xsd:element name="Processing_Fault" type="wd:Processing_FaultType"/>
+      <xsd:element name="Organization_Reference" type="wd:Organization_ReferenceRootType"/>
+      <xsd:element name="Contingent_Worker_Contract_Info_Get" type="wd:Contingent_Worker_Contract_Info_GetType"/>
+      <xsd:element name="Worker_Profile_Get" type="wd:Worker_Profile_GetType"/>
+      <xsd:element name="Workday_Common_Header" type="wd:Workday_Common_HeaderType"/>
+      <xsd:attribute name="version" type="xsd:string" wd:fixed="v36.2"/>
+      <xsd:simpleType name="RichText">
+        <xsd:restriction base="xsd:string"/>
+      </xsd:simpleType>
+
+      <xsd:simpleType name="RoleReferenceEnumeration">
+        <xsd:restriction base="xsd:string">
+          <xsd:annotation>
+            <xsd:appinfo>
+              <wd:enumeration value="WID"/>
+              <wd:enumeration value="Academic_Affiliate_ID"/>
+              <wd:enumeration value="Academic_Contact_ID"/>
+              <wd:enumeration value="Academic_Person_ID"/>
+              <wd:enumeration value="Applicant_ID"/>
+              <wd:enumeration value="Beneficiary_ID"/>
+              <wd:enumeration value="Business_Entity_Contact_ID"/>
+              <wd:enumeration value="Candidate_ID"/>
+              <wd:enumeration value="Company_Reference_ID"/>
+              <wd:enumeration value="Contingent_Worker_ID"/>
+              <wd:enumeration value="Cost_Center_Reference_ID"/>
+              <wd:enumeration value="Custom_Organization_Reference_ID"/>
+              <wd:enumeration value="Dependent_ID"/>
+              <wd:enumeration value="Emergency_Contact_ID"/>
+              <wd:enumeration value="Employee_ID"/>
+              <wd:enumeration value="Extended_Enterprise_Learner_ID"/>
+              <wd:enumeration value="External_Committee_Member_ID"/>
+              <wd:enumeration value="External_Learning_Instructor_ID"/>
+              <wd:enumeration value="External_Learning_User_ID"/>
+              <wd:enumeration value="Former_Worker_ID"/>
+              <wd:enumeration value="Instructor_ID"/>
+              <wd:enumeration value="Learning_Assessor_ID"/>
+              <wd:enumeration value="Learning_Instructor_ID"/>
+              <wd:enumeration value="LearningUserName"/>
+              <wd:enumeration value="Notification_System_Account_Reference_ID"/>
+              <wd:enumeration value="Organization_Reference_ID"/>
+              <wd:enumeration value="Recruiting_Agency_User_ID"/>
+              <wd:enumeration value="RecruitingUserName"/>
+              <wd:enumeration value="Referee_ID"/>
+              <wd:enumeration value="Region_Reference_ID"/>
+              <wd:enumeration value="Service_Center_Representative_ID"/>
+              <wd:enumeration value="Student_ID"/>
+              <wd:enumeration value="Student_Proxy_ID"/>
+              <wd:enumeration value="Student_Recruiter_ID"/>
+              <wd:enumeration value="StudentUserName"/>
+              <wd:enumeration value="SupplierUserName"/>
+              <wd:enumeration value="System_User_ID"/>
+              <wd:enumeration value="System_User_OpenID"/>
+              <wd:enumeration value="System_User_OpenID_Connect_Internal"/>
+              <wd:enumeration value="System_User_OpenID_Internal"/>
+              <wd:enumeration value="WorkdayUserName"/>
+            </xsd:appinfo>
+          </xsd:annotation>
+        </xsd:restriction>
+      </xsd:simpleType>
+
+      <xsd:complexType name="Instance_IDType">
+        <xsd:simpleContent>
+          <xsd:extension base="xsd:string">
+            <xsd:attribute name="parent_id" type="xsd:string"/>
+            <xsd:attribute name="parent_type" type="xsd:string"/>
+            <xsd:attribute name="type" type="xsd:string"/>
+          </xsd:extension>
+        </xsd:simpleContent>
+      </xsd:complexType>
+      <xsd:complexType name="Business_Site_FindType">
+        <xsd:annotation>
+          <xsd:documentation>Utilize the following criteria options to search for Locations within the Workday system.  The Location references that are returned are those that satisfy ALL criteria included in the request.  Therefore, the result set will become more limited with every criteria that is populated.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:element name="Location_Name" type="xsd:string" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+              <xsd:documentation>If specified, this search criterium will return those references with an exact match.  The search index used to query on this value is not case-sensitive.</xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute ref="wd:version"/>
+      </xsd:complexType>
+      <xsd:complexType name="Validation_FaultType">
+        <xsd:sequence>
+          <xsd:element name="Validation_Error" type="wd:Validation_ErrorType" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="Validation_ErrorType">
+        <xsd:sequence>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+          <xsd:element name="Detail_Message" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+          <xsd:element name="Xpath" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="Processing_FaultType">
+        <xsd:sequence>
+          <xsd:element name="Detail_Message" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="Organization_ReferenceRootType">
+        <xsd:complexContent>
+          <xsd:extension base="wd:Organization_ReferenceType">
+            <xsd:attribute ref="wd:version"/>
+          </xsd:extension>
+        </xsd:complexContent>
+      </xsd:complexType>
+      <xsd:complexType name="Contingent_Worker_Contract_Info_GetType">
+        <xsd:annotation>
+          <xsd:documentation>
+            Utilize the following Reference element (and other optional attributes) to retrieve an instance of Contingent Worker and his/her Contract Information.</xsd:documentation></xsd:annotation><xsd:sequence><xsd:element name="Contingent_Worker_Reference" type="wd:Contingent_Worker_Reference_DataType"/></xsd:sequence><xsd:attribute name="As_Of_Date" type="xsd:date"><xsd:annotation><xsd:documentation>Defines the As Of Date to be used for any application effective dated data within the Workday system.  For "Find" operations, the "As Of Date" determines what data to be used within the search logic.  For "Get" operations, the response element will only include data that is the most effective as of the "As Of Date".</xsd:documentation></xsd:annotation></xsd:attribute><xsd:attribute name="As_Of_Moment" type="xsd:dateTime"><xsd:annotation><xsd:documentation>Defines the latest moment (e.g. datetime) data was entered into the Workday system.  For "Find" operations, the "As Of Moment" determines what data to be used within the search logic.  For "Get" operations, the response element will only include data entered into Workday before the "As Of Moment".
+          </xsd:documentation>
+        </xsd:annotation>
+        </xsd:attribute><xsd:attribute ref="wd:version"/>
+      </xsd:complexType>
+
+      <xsd:complexType name="Organization_ReferenceType">
+        <xsd:annotation>
+          <xsd:documentation>Reference element representing a unique instance of Organization.</xsd:documentation>
+          <xsd:appinfo>
+            <wd:Validation>
+              <xsd:documentation>A valid instance of Organization must exist for the given Integration ID Reference.</xsd:documentation>
+              <wd:Validation_Message>Organization Reference Integration ID does not exist!</wd:Validation_Message>
+            </wd:Validation>
+            <wd:Validation>
+              <xsd:documentation>A valid instance of Organization also infers that the Organization is in an Active status.</xsd:documentation>
+              <wd:Validation_Message>Organization Reference references an Inactive Organization.</wd:Validation_Message>
+            </wd:Validation>
+          </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:element name="Integration_ID_Reference" type="wd:External_Integration_ID_Reference_DataType"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:complexType name="External_Integration_ID_Reference_DataType">
+        <xsd:annotation>
+          <xsd:documentation>Integration ID reference is used as a unique identifier for integratable objects in the Workday system.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:element name="ID" type="wd:IDType"/>
+        </xsd:sequence>
+        <xsd:attribute name="Descriptor" type="xsd:string">
+          <xsd:annotation>
+            <xsd:documentation>Display name inside the Workday system.</xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:complexType>
+      <xsd:complexType name="IDType">
+        <xsd:annotation>
+          <xsd:documentation>External ID that uniquely identifies the integratable object within the context of the integration system identified by the System ID attribute.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+          <xsd:extension base="xsd:string">
+            <xsd:attribute name="System_ID" type="xsd:string">
+              <xsd:annotation>
+                <xsd:documentation>Integration system identifier, part of a two part key (including the text value of the ID element) that uniquely identify integratable object.</xsd:documentation>
+                <xsd:appinfo>
+                  <wd:Validation>
+                    <xsd:documentation>A valid instance of Integration ID must exist for the given System ID.</xsd:documentation>
+                    <wd:Validation_Message>Integration System ID does not exist.</wd:Validation_Message>
+                  </wd:Validation>
+                </xsd:appinfo>
+              </xsd:annotation>
+            </xsd:attribute>
+          </xsd:extension>
+        </xsd:simpleContent>
+      </xsd:complexType>
+      <xsd:complexType name="Worker_Profile_GetType">
+        <xsd:annotation>
+          <xsd:documentation>Utilize the following Reference element (and other optional attributes) to retrieve an instance of Worker and his/her summarized Personal and Employment/Contract information.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:element name="Worker_Reference" type="wd:Worker_ReferenceType"/>
+        </xsd:sequence>
+        <xsd:attribute name="As_Of_Date" type="xsd:date">
+          <xsd:annotation>
+            <xsd:documentation>Defines the As Of Date to be used for any application effective dated data within the Workday system.  For "Find" operations, the "As Of Date" determines what data to be used within the search logic.  For "Get" operations, the response element will only include data that is the most effective as of the "As Of Date".</xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+          <xsd:attribute name="As_Of_Moment" type="xsd:dateTime">
+          <xsd:annotation>
+            <xsd:documentation>Defines the latest moment (e.g. datetime) data was entered into the Workday system.  For "Find" operations, the "As Of Moment" determines what data to be used within the search logic.  For "Get" operations, the response element will only include data entered into Workday before the "As Of Moment".</xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute ref="wd:version"/>
+      </xsd:complexType>
+
+      <xsd:complexType name="Worker_ReferenceType">
+        <xsd:annotation>
+          <xsd:documentation>Reference element representing a unique instance of Worker (e.g. Employee or Contingent Worker).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:choice>
+            <xsd:element name="Employee_Reference" type="wd:Employee_ReferenceType"/>
+            <xsd:element name="Contingent_Worker_Reference" type="wd:Contingent_Worker_Reference_DataType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:complexType>
+
+      <xsd:complexType name="Employee_ReferenceType">
+        <xsd:annotation>
+          <xsd:documentation>Reference element representing a unique instance of Employee.</xsd:documentation>
+          <xsd:appinfo>
+            <wd:Validation>
+              <xsd:documentation>A valid instance of Employee must exist for the given Integration ID Reference.</xsd:documentation>
+              <wd:Validation_Message>Employee Reference Integration ID does not exist!</wd:Validation_Message>
+            </wd:Validation>
+          </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:element name="Integration_ID_Reference" type="wd:External_Integration_ID_Reference_DataType"/>
+        </xsd:sequence>
+      </xsd:complexType>
+
+      <xsd:complexType name="Contingent_Worker_Reference_DataType">
+        <xsd:annotation>
+          <xsd:documentation>Reference element representing a unique instance of Contingent Worker.</xsd:documentation>
+          <xsd:appinfo>
+            <wd:Validation>
+              <xsd:documentation>A valid instance of Contingent Worker must exist for the given Integration ID Reference.</xsd:documentation>
+              <wd:Validation_Message>Contingent Worker Reference Integration ID does not exist!</wd:Validation_Message>
+            </wd:Validation>
+          </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+          <xsd:element name="Integration_ID_Reference" type="wd:External_Integration_ID_Reference_DataType"/>
+        </xsd:sequence>
+      </xsd:complexType>
+
+      <xsd:complexType name="Workday_Common_HeaderType">
+        <xsd:sequence>
+          <xsd:element name="Include_Reference_Descriptors_In_Response" type="xsd:boolean" minOccurs="0" maxOccurs="1"/>
+        </xsd:sequence>
+      </xsd:complexType>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="Business_Site_FindInputMsg"><wsdl:part name="body" element="wd:Business_Site_Find"/></wsdl:message>
+  <wsdl:message name="Business_Site_ReferencesOutputMsg"><wsdl:part name="body" element="wd:Business_Site_Find"/></wsdl:message>
+  <wsdl:message name="Validation_FaultMsg"><wsdl:part name="body" element="wd:Validation_Fault"/></wsdl:message>
+  <wsdl:message name="Processing_FaultMsg"><wsdl:part name="body" element="wd:Processing_Fault"/></wsdl:message>
+  <wsdl:message name="Contingent_Worker_Contract_Info_GetInputMsg"><wsdl:part name="body" element="wd:Contingent_Worker_Contract_Info_Get"/></wsdl:message>
+  <wsdl:message name="Contingent_Worker_Contract_InfoOutputMsg"><wsdl:part name="body" element="wd:Contingent_Worker_Contract_Info_Get"/></wsdl:message>
+  <wsdl:message name="Worker_Profile_GetInputMsg"><wsdl:part name="body" element="wd:Worker_Profile_Get"/></wsdl:message>
+  <wsdl:message name="Worker_ProfileOutputMsg"><wsdl:part name="body" element="wd:Worker_Profile_Get"/></wsdl:message>
+  <wsdl:message name="Workday_Common_HeaderMsg">
+    <wsdl:part name="header" element="wd:Workday_Common_Header"/>
+  </wsdl:message>
+
+  <wsdl:portType name="Human_ResourcesPort">
+    <wsdl:operation name="Find_Business_Site">
+      <wsdl:documentation>DEPRECATED: This w  eb service operation is deprecated. Please use the Get Locations web service operation instead.  
+
+      This operation responds with a set of references to Business Sites that match the criteria specified in the request element.<wd:Deprecated>1</wd:Deprecated>
+      </wsdl:documentation>
+      <wsdl:input name="Find_Business_SiteInput" message="wd-wsdl:Business_Site_FindInputMsg"/>
+      <wsdl:output name="Find_Business_SiteOutput" message="wd-wsdl:Business_Site_ReferencesOutputMsg" />
+      <wsdl:fault name="Validation_Fault" message="wd-wsdl:Validation_FaultMsg"/>
+      <wsdl:fault name="Processing_Fault" message="wd-wsdl:Processing_FaultMsg"/>
+    </wsdl:operation>
+
+    <wsdl:operation name="Get_Contingent_Worker_Contract_Info">
+      <wsdl:documentation>This operation retrieves data related to a Contingent Worker and his/her Contract information.</wsdl:documentation>
+      <wsdl:input name="Get_Contingent_Worker_Contract_InfoInput" message="wd-wsdl:Contingent_Worker_Contract_Info_GetInputMsg"/>
+      <wsdl:output name="Get_Contingent_Worker_Contract_InfoOutput" message="wd-wsdl:Contingent_Worker_Contract_InfoOutputMsg"/>
+    </wsdl:operation>
+
+    <wsdl:operation name="Get_Worker_Profile">
+      <wsdl:documentation>This operation retrieves a subset of data related to a Worker (e.g. Employee and Contingent Worker) and his/her Employment/Contract, Personal and Compensation information.</wsdl:documentation>
+      <wsdl:input name="Get_Worker_ProfileInput" message="wd-wsdl:Worker_Profile_GetInputMsg"/>
+      <wsdl:output name="Get_Worker_ProfileOutput" message="wd-wsdl:Worker_ProfileOutputMsg" />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="Human_ResourcesBinding" type="wd-wsdl:Human_ResourcesPort">
+    <soapbind:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Find_Business_Site">
+      <soapbind:operation style="document" />
+      <wsdl:input name="Find_Business_SiteInput">
+        <soapbind:body use="literal" />
+        <soapbind:header message="wd-wsdl:Workday_Common_HeaderMsg" part="header" use="literal" />
+      </wsdl:input>
+      <wsdl:output name="Find_Business_SiteOutput">
+        <soapbind:body use="literal" />
+      </wsdl:output>
+      <wsdl:fault name="Processing_Fault">
+        <soapbind:fault name="Processing_Fault" use="literal" />
+      </wsdl:fault>
+      <wsdl:fault name="Validation_Fault">
+        <soapbind:fault name="Validation_Fault" use="literal" />
+      </wsdl:fault>
+    </wsdl:operation>
+
+
+    <wsdl:operation name="Get_Contingent_Worker_Contract_Info">
+      <soapbind:operation style="document" />
+      <wsdl:input name="Get_Contingent_Worker_Contract_InfoInput">
+        <soapbind:body use="literal" />
+        <soapbind:header message="wd-wsdl:Workday_Common_HeaderMsg" part="header" use="literal" />
+      </wsdl:input>
+      <wsdl:output name="Get_Contingent_Worker_Contract_InfoOutput">
+        <soapbind:body use="literal" />
+      </wsdl:output>
+      <wsdl:fault name="Processing_Fault">
+        <soapbind:fault name="Processing_Fault" use="literal" />
+      </wsdl:fault>
+      <wsdl:fault name="Validation_Fault">
+        <soapbind:fault name="Validation_Fault" use="literal" />
+      </wsdl:fault>
+    </wsdl:operation>
+
+    <wsdl:operation name="Get_Worker_Profile">
+      <soapbind:operation style="document" />
+      <wsdl:input name="Get_Worker_ProfileInput">
+        <soapbind:body use="literal" />
+        <soapbind:header message="wd-wsdl:Workday_Common_HeaderMsg" part="header" use="literal" />
+      </wsdl:input>
+      <wsdl:output name="Get_Worker_ProfileOutput">
+        <soapbind:body use="literal" />
+      </wsdl:output>
+      <wsdl:fault name="Processing_Fault">
+        <soapbind:fault name="Processing_Fault" use="literal" />
+      </wsdl:fault>
+      <wsdl:fault name="Validation_Fault">
+        <soapbind:fault name="Validation_Fault" use="literal" />
+      </wsdl:fault>
+    </wsdl:operation>
+
+  </wsdl:binding>
+
+  <wsdl:service name="Human_ResourcesService">
+    <wsdl:port name="Human_Resources" binding="wd-wsdl:Human_ResourcesBinding">
+      <soapbind:address location="Human_Resources"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/test/data/validWSDLs20/noWSDLNamespace.wsdl
+++ b/test/data/validWSDLs20/noWSDLNamespace.wsdl
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<wsdl:description xmlns:wsdl="http://www.w3.org/ns/wsdl"
+  xmlns:wsoap= "http://www.w3.org/ns/wsdl/soap"
+  xmlns:hy="http://{{url}}/Service/" targetNamespace="http://{{url}}/Service/">
+  <wsdl:documentation>
+    Hello_WSDL_20_SOAP.wsdl
+    Copyright (c) HerongYang.com, All Rights Reserved.
+  </wsdl:documentation>
+  <wsdl:types>
+    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://{{url}}/Service/">
+      <xsd:element name="Hello" type="xsd:string"/>
+      <xsd:element name="HelloResponse" type="xsd:string"/>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:interface name="helloInterface">
+    <wsdl:operation name="Hello" pattern="http://www.w3.org/ns/wsdl/in-out">
+      <wsdl:input messageLabel="In" element="hy:Hello"/>
+      <wsdl:output messageLabel="Out" element="hy:HelloResponse"/>
+    </wsdl:operation>
+  </wsdl:interface>
+  <wsdl:binding name="helloBinding" interface="hy:helloInterface" type="http://www.w3.org/ns/wsdl/soap" wsoap:protocol="http://www.w3.org/2003/05/soap/bindings/HTTP/">
+    <wsdl:operation ref="hy:Hello" wsoap:mep="http://www.w3.org/2003/05/soap/mep/soap-response"/>
+  </wsdl:binding>
+  <wsdl:service name="helloService" interface="hy:helloInterface">
+    <wsdl:endpoint name="helloEndpoint" binding="hy:helloBinding" address="http://{{url}}/Service/Hello_SOAP_12.php"/>
+  </wsdl:service>
+</wsdl:description>

--- a/test/unit/SOAPBody.test.js
+++ b/test/unit/SOAPBody.test.js
@@ -266,4 +266,16 @@ describe('SOAPBody assignPropertyValue', function () {
     expect(obj).to.be.a('object');
     expect(obj.parent.property).to.equal('value');
   });
+
+  it('should not assign the property "property" with "value" to object when non-object data is provided',
+    function () {
+      const bodyCreator = new SOAPBody(new XMLParser());
+      let obj = {
+        parent: '456'
+      };
+
+      bodyCreator.assignPropertyValue(obj.parent, 'property', 'value');
+      expect(obj).to.be.a('object');
+      expect(obj.parent).to.equal('456');
+    });
 });

--- a/test/unit/WsdlInformationService11.test.js
+++ b/test/unit/WsdlInformationService11.test.js
@@ -1774,3 +1774,19 @@ describe('WSDL 1.1 parser getAbstractOperationByName', function () {
   });
 
 });
+
+describe('WSDL 1.1 parser getAbstractDefinitionName', function () {
+  it('should correctly provide definition name even if attribute is not found', function () {
+    const informationService = new WsdlInformationService11(),
+      abstractDefinitionName = informationService.getAbstractDefinitionName({}, { key: 'tns' });
+    expect(abstractDefinitionName).to.equal('');
+  });
+});
+
+describe('WSDL 1.1 parser getServiceURL', function () {
+  it('should correctly provide service URL even if address is not defined', function () {
+    const informationService = new WsdlInformationService11(),
+      serviceUrl = informationService.getServiceURL({}, {}, {}, (a) => { return a; });
+    expect(serviceUrl).to.be.ok;
+  });
+});

--- a/test/unit/WsdlInformationService20.test.js
+++ b/test/unit/WsdlInformationService20.test.js
@@ -169,6 +169,30 @@ describe('WSDL 2.0 getElementFromInterfaceOperationInOut', function () {
       element = informationService.getElementFromInterfaceOperationInOut({}, null, 'notfound', '');
     expect(element).to.have.length(0);
   });
+
+  it('should get correct elements when no elements are present', function () {
+    const informationService = new WsdlInformationService20(),
+      elements = informationService.getElementFromInterfaceOperationInOut(
+        { elePrefix: { '@_element': 'UserError' } }, null, 'elePrefix', '');
+    expect(elements).to.have.length(1);
+    expect(elements[0].name).to.equal('UserError');
+  });
+});
+
+describe('WSDL 2.0 getAbstractDefinitionName', function () {
+  it('should correctly provide definition name even if attribute is not found', function () {
+    const informationService = new WsdlInformationService20(),
+      abstractDefinitionName = informationService.getAbstractDefinitionName({}, { key: 'tns' });
+    expect(abstractDefinitionName).to.equal('');
+  });
+});
+
+describe('WSDL 2.0 getServiceURL', function () {
+  it('should correctly provide service URL even if serviceEndpoint is not object', function () {
+    const informationService = new WsdlInformationService20(),
+      serviceUrl = informationService.getServiceURL(null);
+    expect(serviceUrl).to.equal('');
+  });
 });
 
 describe('WSDL 2.0 parser getAbstractOperationByName', function () {

--- a/test/unit/httpUtils.test.js
+++ b/test/unit/httpUtils.test.js
@@ -25,4 +25,9 @@ describe('Http Utils getHttpVerb', function() {
     const method = getHttpVerb('pOsT');
     expect(method).to.equal(POST_METHOD);
   });
+
+  it('should get corect verb when called with non-string value', function() {
+    const method = getHttpVerb(null);
+    expect(method).to.equal(POST_METHOD);
+  });
 });

--- a/test/unit/wsdlParser.test.js
+++ b/test/unit/wsdlParser.test.js
@@ -3,6 +3,7 @@ const { WsdlInformationService11 } = require('../../lib/WsdlInformationService11
   expect = require('chai').expect,
   assert = require('chai').assert,
   WsdlObject = require('../../lib/WSDLObject').WsdlObject,
+  validWSDLs10 = 'test/data/validWSDLs11',
   validWSDLs20 = 'test/data/validWSDLs20',
   specialCasesWSDLs_2_0 = 'test/data/specialCases/wsdl2',
   {
@@ -1252,6 +1253,34 @@ provides functions that convert numbers into words or dollar amounts.</documenta
           serviceName: ''
         });
     });
+
+  it('should assign operations to wsdl object without any error if definition does not have wsdl namespace defined' +
+    ' with WsdlInformationService11', function () {
+    const parser = new WsdlParser(new WsdlInformationService11()),
+      fileContent = fs.readFileSync(validWSDLs10 + '/noWSDLNamespace.wsdl', 'utf8');
+    let wsdlObject = new WsdlObject(),
+      xmlParser = new XMLParser(),
+      parsed = xmlParser.parseToObject(fileContent);
+
+    wsdlObject = parser.assignNamespaces(wsdlObject, parsed);
+    wsdlObject = parser.assignOperations(wsdlObject, parsed);
+    expect(wsdlObject.operationsArray).to.be.an('array');
+    expect(wsdlObject.operationsArray.length).to.equal(3);
+  });
+
+  it('should assign operations to wsdl object without any error if definition does not have wsdl namespace defined' +
+    ' with WsdlInformationService20', function () {
+    const parser = new WsdlParser(new WsdlInformationService20()),
+      fileContent = fs.readFileSync(validWSDLs20 + '/noWSDLNamespace.wsdl', 'utf8');
+    let wsdlObject = new WsdlObject(),
+      xmlParser = new XMLParser(),
+      parsed = xmlParser.parseToObject(fileContent);
+
+    wsdlObject = parser.assignNamespaces(wsdlObject, parsed);
+    wsdlObject = parser.assignOperations(wsdlObject, parsed);
+    expect(wsdlObject.operationsArray).to.be.an('array');
+    expect(wsdlObject.operationsArray.length).to.equal(1);
+  });
 });
 
 describe('WSDL 1.1 parser getWsdlObject', function () {


### PR DESCRIPTION
## Overview
This PR fixes all of known WSDL TypeErrors that are known ATM.

## RCA
Most of the fixed issues related to TypeErrors were happening because of unsafe access of certain properties.

## Fix
We'll now be safely accessing such properties and to make sure regression doesn't happen, unit tests for the same are also added.