### PR TITLE
Fixed issue where for multiple binding namespaces conversion was failing.

### DIFF
--- a/lib/WsdlInformationService11.js
+++ b/lib/WsdlInformationService11.js
@@ -1,4 +1,5 @@
 const
+  _ = require('lodash'),
   {
     getHttpVerb,
     POST_METHOD
@@ -496,9 +497,10 @@ class WsdlInformationService11 {
    * @param {NameSpace} soapNamespace the soap namespace information
    * @param {NameSpace} soap12Namespace the sopa 1.2 namespace information
    * @param {NameSpace} httpNamespace the http namespace information
+   * @param {Array} allNameSpaces All namespaces present in wsdl definition
    * @returns {object} a new object with the information
    */
-  getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace, httpNamespace) {
+  getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace, httpNamespace, allNameSpaces) {
     if (!binding || typeof binding !== 'object') {
       throw new WsdlError('Cannot get binding info from undefined or null object');
     }
@@ -510,22 +512,51 @@ class WsdlInformationService11 {
         if (key.includes(BINDING_TAG)) {
           return true;
         }
-      });
+      }),
+      isProtocolSoap12,
+      isProtocolSoap,
+      isProtocolHttp;
+
     if (namespace === undefined) {
       throw new WsdlError('Cannot get binding from WSDL');
     }
+
     const protocolKey = getQNamePrefix(namespace);
     protocolPrefix = getQNamePrefixFilter(namespace);
 
-    if (soap12Namespace && protocolKey === soap12Namespace.key) {
+    /**
+     * There can be multiple namespaces defined with same binding URL.
+     * In such cases detect binding namespaces by going through all namespaces and
+     *  identifying correct one via URL.
+     */
+    isProtocolSoap12 = soap12Namespace && (protocolKey === soap12Namespace.key ||
+      _.some(allNameSpaces, (namespace) => {
+        return soap12Namespace.url === namespace.url && soap12Namespace.key !== namespace.key;
+      }));
+
+    if (!isProtocolSoap12) {
+      isProtocolSoap = soapNamespace && (protocolKey === soapNamespace.key ||
+        _.some(allNameSpaces, (namespace) => {
+          return soapNamespace.url === namespace.url && soapNamespace.key !== namespace.key;
+        }));
+    }
+
+    if (!isProtocolSoap12 && !isProtocolSoap) {
+      isProtocolHttp = httpNamespace && (protocolKey === httpNamespace.key ||
+        _.some(allNameSpaces, (namespace) => {
+          return httpNamespace.url === namespace.url && httpNamespace.key !== namespace.key;
+        }));
+    }
+
+    if (isProtocolSoap12) {
       protocol = SOAP12_PROTOCOL;
       verb = POST_METHOD;
     }
-    else if (soapNamespace && protocolKey === soapNamespace.key) {
+    else if (isProtocolSoap) {
       protocol = SOAP_PROTOCOL;
       verb = POST_METHOD;
     }
-    else if (httpNamespace && protocolKey === httpNamespace.key) {
+    else if (isProtocolHttp) {
       protocol = HTTP_PROTOCOL;
       verb = getHttpVerb(getAttributeByName(binding[namespace], ATTRIBUTE_VERB));
     }

--- a/lib/WsdlInformationService20.js
+++ b/lib/WsdlInformationService20.js
@@ -263,9 +263,10 @@ class WsdlInformationService20 {
    * @param {NameSpace} soapNamespace the documents found namespace
    * @param {NameSpace} soap12Namespace the documentos found namespace
    * @param {NameSpace} httpNamespace the documentos found namespace
+   * @param {Array} allNameSpaces All namespaces present in wsdl definition
    * @returns {object} the protocol information
    */
-  getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace, httpNamespace) {
+  getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace, httpNamespace, allNameSpaces) {
     const type = getAttributeByName(binding, ATTRIBUTE_TYPE);
     let protocol = '',
       verb = '',
@@ -276,8 +277,26 @@ class WsdlInformationService20 {
     if ((soapNamespace && type === SOAP_NS_URL) || (soap12Namespace && type === SOAP_12_NS_URL)) {
       let namespaceKey = soapNamespace ? soapNamespace.key : soap12Namespace.key,
         version = getAttributeByName(binding, namespaceKey + XML_NAMESPACE_SEPARATOR + ATTRIBUTE_VERSION);
+
+      /**
+       * There can be multiple namespaces defined with same binding URL.
+       * In such cases detect binding namespaces by going through all namespaces and
+       *  identifying correct one via URL.
+       */
+      _.forEach(allNameSpaces, (namespace) => {
+        if (_.get(soap12Namespace, 'url', _.get(soapNamespace, 'url')) === namespace.url &&
+          namespaceKey !== namespace.key) {
+          let currVersion = getAttributeByName(binding, namespace.key + XML_NAMESPACE_SEPARATOR + ATTRIBUTE_VERSION);
+
+          if (currVersion) {
+            version = currVersion;
+            namespaceKey = namespace.key;
+            return false;
+          }
+        }
+      });
+
       if (version === '1.2') {
-        protocol = SOAP12_PROTOCOL;
         protocol = SOAP12_PROTOCOL;
         verb = POST_METHOD;
         protocolPrefix = namespaceKey;
@@ -292,13 +311,32 @@ class WsdlInformationService20 {
       protocol = HTTP_PROTOCOL;
       readVerb = getAttributeByName(binding, httpNamespace.key + XML_NAMESPACE_SEPARATOR +
         ATTRIBUTE_METHOD_DEFAULT);
+      protocolPrefix = httpNamespace.key;
+
+      /**
+       * There can be multiple namespaces defined with same binding URL.
+       * In such cases detect binding namespaces by going through all namespaces and
+       *  identifying correct one via URL.
+       */
+      _.forEach(allNameSpaces, (namespace) => {
+        if (_.get(httpNamespace, 'url') === namespace.url && _.get(httpNamespace, 'key') !== namespace.key) {
+          let currReadVerb = getAttributeByName(binding, namespace.key + XML_NAMESPACE_SEPARATOR +
+            ATTRIBUTE_METHOD_DEFAULT);
+
+          if (currReadVerb) {
+            readVerb = currReadVerb;
+            protocolPrefix = namespace.key;
+            return false;
+          }
+        }
+      });
+
       if (!readVerb) {
         verb = undefined;
       }
       else {
         verb = getHttpVerb(readVerb);
       }
-      protocolPrefix = httpNamespace.key;
     }
     else {
       throw new WsdlError('Cannot find protocol in those namespaces');

--- a/lib/WsdlParser.js
+++ b/lib/WsdlParser.js
@@ -155,7 +155,8 @@ class WsdlParser {
         this.informationService.getBindingInfoFromBindingTag(binding,
           newWsdlObject.SOAPNamespace,
           newWsdlObject.SOAP12Namespace,
-          newWsdlObject.HTTPNamespace),
+          newWsdlObject.HTTPNamespace,
+          newWsdlObject.allNameSpaces),
         bindingOperations = getBindingOperation(binding, principalPrefix, newWsdlObject),
 
         portTypeInterfaceName = this.informationService.getAbstractDefinitionName(binding, newWsdlObject.tnsNamespace);

--- a/test/unit/WsdlInformationService11.test.js
+++ b/test/unit/WsdlInformationService11.test.js
@@ -658,6 +658,90 @@ describe('WSDL 1.1 parser getBindingInfoFromBindingTag', function () {
     }
   });
 
+  it('should correctly get info from binding when multiple namespaces with same binding URL are defined', function () {
+    const simpleInput = `<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+    xmlns:tns="http://tempuri.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http" 
+    xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" 
+    xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" 
+    xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" 
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/" name="ISampleService">
+    <wsdl:portType name="ISampleService">
+        <wsdl:operation name="Test">
+            <wsdl:input message="tns:ISampleService_Test_InputMessage" />
+            <wsdl:output message="tns:ISampleService_Test_OutputMessage" />
+        </wsdl:operation>
+        <wsdl:operation name="XmlMethod">
+            <wsdl:input message="tns:ISampleService_XmlMethod_InputMessage" />
+            <wsdl:output message="tns:ISampleService_XmlMethod_OutputMessage" />
+        </wsdl:operation>
+        <wsdl:operation name="TestCustomModel">
+            <wsdl:input message="tns:ISampleService_TestCustomModel_InputMessage" />
+            <wsdl:output message="tns:ISampleService_TestCustomModel_OutputMessage" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="BasicHttpBinding" type="tns:ISampleService">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Test">
+            <soap:operation soapAction="http://tempuri.org/ISampleService/Test" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="XmlMethod">
+            <soap:operation soapAction="http://tempuri.org/ISampleService/XmlMethod" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="TestCustomModel">
+            <soap:operation soapAction="http://tempuri.org/ISampleService/TestCustomModel" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="ISampleService">
+        <wsdl:port name="BasicHttpBinding" binding="tns:BasicHttpBinding">
+            <soap:address location="https://localhost:5001/Service.asmx" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>
+`,
+      informationService = new WsdlInformationService11(),
+      xmlParser = new XMLParser(),
+      soap12Namespace = {
+        key: 'soap12',
+        url: 'http://schemas.xmlsoap.org/wsdl/soap12/',
+        isDefault: 'false'
+      },
+      soapNamespace = {
+        key: 'soap',
+        url: 'http://schemas.xmlsoap.org/wsdl/soap/',
+        isDefault: 'false'
+      };
+    let parsed = xmlParser.parseToObject(simpleInput),
+      binding = getBindings(
+        parsed,
+        informationService.RootTagName
+      )[0],
+      bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace, soap12Namespace);
+    expect(bindingInfo.protocol).to.equal(SOAP_PROTOCOL);
+    expect(bindingInfo.verb).to.equal(POST_METHOD);
+
+  });
+
   it('should throw an error when Cannot get protocol', function () {
     const simpleInput = `<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
     xmlns:tns="http://tempuri.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" 

--- a/test/unit/WsdlInformationService20.test.js
+++ b/test/unit/WsdlInformationService20.test.js
@@ -379,6 +379,117 @@ describe('WSDL 2.0 parser  getBindingInfoFromBindingTag', function () {
       expect(error.message).to.equal('Cannot find protocol in those namespaces');
     }
   });
+
+  it('should correctly get info from binding when multiple namespaces with same binding URL are defined', function () {
+    const simpleInput = `<wsdl2:description xmlns="http://www.w3.org/ns/wsdl/soap"
+    xmlns:wsdl2="http://www.w3.org/ns/wsdl"
+    xmlns:wsoap="http://www.w3.org/ns/wsdl/soap"
+    xmlns:whttp="http://www.w3.org/ns/wsdl/http"
+    xmlns:ns="http://axis2.org"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+    xmlns:wsdlx="http://www.w3.org/ns/wsdl-extensions"
+    xmlns:tns="http://axis2.org"
+    xmlns:wrpc="http://www.w3.org/ns/wsdl/rpc"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:ns1="http://org.apache.axis2/xsd" targetNamespace="http://axis2.org">
+    <wsdl2:documentation> Please Type your service description here </wsdl2:documentation>
+    <wsdl2:types>
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://axis2.org">
+            <xs:element name="hi">
+                <xs:complexType>
+                    <xs:sequence />
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="hiResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="xs:string" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+    </wsdl2:types>
+    <wsdl2:interface name="ServiceInterface">
+        <wsdl2:operation
+            name="hi"
+            style="http://www.w3.org/ns/wsdl/style/rpc http://www.w3.org/ns/wsdl/style/multipart"
+            wrpc:signature="return #return "
+            pattern="http://www.w3.org/ns/wsdl/in-out"
+        >
+            <wsdl2:input element="ns:hi" wsaw:Action="urn:hi" />
+            <wsdl2:output element="ns:hiResponse" wsaw:Action="urn:hiResponse" />
+        </wsdl2:operation>
+    </wsdl2:interface>
+    <wsdl2:binding
+        name="SayHelloSoap11Binding"
+        interface="tns:ServiceInterface"
+        type="http://www.w3.org/ns/wsdl/soap"
+        wsoap:version="1.1"
+    >
+        <wsdl2:operation ref="tns:hi" wsoap:action="urn:hi">
+            <wsdl2:input />
+            <wsdl2:output />
+        </wsdl2:operation>
+    </wsdl2:binding>
+    <wsdl2:binding
+        name="SayHelloSoap12Binding"
+        interface="tns:ServiceInterface"
+        type="http://www.w3.org/ns/wsdl/soap"
+        wsoap:version="1.2"
+    >
+        <wsdl2:operation ref="tns:hi" wsoap:action="urn:hi">
+            <wsdl2:input />
+            <wsdl2:output />
+        </wsdl2:operation>
+    </wsdl2:binding>
+    <wsdl2:binding
+        name="SayHelloHttpBinding"
+        interface="tns:ServiceInterface"
+        whttp:methodDefault="POST"
+        type="http://www.w3.org/ns/wsdl/http"
+    >
+        <wsdl2:operation ref="tns:hi" whttp:location="hi">
+            <wsdl2:input />
+            <wsdl2:output />
+        </wsdl2:operation>
+    </wsdl2:binding>
+    <wsdl2:service name="SayHello" interface="tns:ServiceInterface">
+        <wsdl2:endpoint
+            name="SayHelloHttpEndpoint"
+            binding="tns:SayHelloHttpBinding"
+            address="http://192.168.100.75:8080/Axis2-bottom/services/SayHello.SayHelloHttpEndpoint/"
+        />
+        <wsdl2:endpoint
+            name="SayHelloHttpSoap11Endpoint"
+            binding="tns:SayHelloSoap11Binding"
+            address="http://192.168.100.75:8080/Axis2-bottom/services/SayHello.SayHelloHttpSoap11Endpoint/"
+        />
+        <wsdl2:endpoint
+            name="SayHelloHttpSoap12Endpoint"
+            binding="tns:SayHelloSoap12Binding"
+            address="http://192.168.100.75:8080/Axis2-bottom/services/SayHello.SayHelloHttpSoap12Endpoint/"
+        />
+    </wsdl2:service>
+</wsdl2:description>
+`,
+      informationService = new WsdlInformationService20(),
+      xmlParser = new XMLParser(),
+      soapNamespace = {
+        key: 'soap',
+        url: 'http://schemas.xmlsoap.org/wsdl/soap/',
+        isDefault: 'false'
+      };
+    let parsed = xmlParser.parseToObject(simpleInput),
+      binding = getBindings(
+        parsed,
+        informationService.RootTagName
+      )[0],
+      bindingInfo = informationService.getBindingInfoFromBindingTag(binding, soapNamespace);
+
+    expect(bindingInfo.protocol).to.equal('soap');
+    expect(bindingInfo.verb).to.equal('POST');
+    expect(bindingInfo.bindingName).to.equal('SayHelloSoap11Binding');
+  });
 });
 
 describe('WSDL 2.0 getServiceAndExpossedInfoByBindingName', function () {


### PR DESCRIPTION
## Description

This PR fixes the issue where for certain valid WSDL, conversion was failing with `Error: Cannot find protocol in those namespaces`.

## RCA

Issue was happening due to the way we defined binding namespaces. In WSDL definition, one can use bindings like `soap` and `http`. In some cases, there were namespaces defined with such binding twice. Due to this, it could be the case that depending upon the order of these namespace definitions, binding namespaces were not defined correctly while parsing WSDL object.

Function named `getBindingInfoFromBindingTag` in `WsdlParser.js` was using such bindings to define protocol and namespace keys. While doing so in such cases, it was not able to correctly interpret information and detected no binding defined.

## Fix

We'll now correctly define protocol by going through all namespaces and correctly identifying namespace whose prefix is being used for binding rather than relying on the first mentioned namespace with binding namespace.