### PR TITLE
Releases using GitHub Actions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,15 +1,22 @@
 name: Test
 
 on:
-  [pull_request]
+  push:
+    branches: [develop, master]
+  pull_request:
 
 jobs:
   Unit-Tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 16.x, 18.x]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Get Code
+        uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run test
+      - run: npm test

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,78 @@
+name: Draft new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version you want to release. Must be a valid semver version.
+        required: true
+        type: string
+
+jobs:
+  draft-new-release:
+    if: startsWith(github.event.inputs.version, 'v')
+    name: Draft a new release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@1.1.0
+        with:
+          version: ${{ github.event.inputs.version }}
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+
+      - name: Bump version
+        run: npm version ${{ github.event.inputs.version }} --git-tag-version false
+
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+          git add CHANGELOG.md package.json package-lock.json
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+      
+      - name: Push new branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create pull request for main
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: main
+          title: "Release version ${{ github.event.inputs.version }}"
+          reviewers: ${{ github.actor }}
+          body: |
+            Hi @${{ github.actor }}!
+
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
+
+      - name: Create pull request for development
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: development
+          title: "Release version ${{ github.event.inputs.version }}"
+          reviewers: ${{ github.actor }}
+          body: |
+            Hi @${{ github.actor }}!
+
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -1,0 +1,46 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Publish new release
+    runs-on: ubuntu-latest
+    # only merged pull requests that begin with 'release/' or 'hotfix/' must trigger this job
+    if: github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.head.ref, 'release/') || contains(github.event.pull_request.head.ref, 'hotfix/'))
+    permissions:
+      contents: write
+
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: contains(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from branch name (for hotfix branches)
+        if: contains(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#hotfix/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create Release
+        uses: thomaseizinger/create-release@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,31 @@
 # WSDL to Postman Changelog
 
-#### v1.8.0 (March 30, 2023)
-* Fixed issue where conversion failed with RangeError: Maximum stack size reached when recursive elements were present.
-* Fixed issue where conversion failed with typeeror with path.includes is not a function.
+## [Unreleased]
 
+### Added
+
+-   GitHub Actions for Release management.
+
+### Changed
+
+-   Bumped up minimum Node version to 12.
+-   Unit tests now run on Node versions 12, 16 and 18.
+
+### Fixed
+
+-   Fixed an issue where conversion failed with typeeror while resolving non defined variables.
+-   Fixed an issue where circular references were not correctly identified while resolving elements.
+-   Fixed an issue where for multiple binding namespaces conversion was failing.
+
+## [1.8.0] - 2023-03-30
+
+### Fixed
+
+-   Fixed issue where conversion failed with RangeError: Maximum stack size reached when recursive elements were present.
+-   Fixed issue where conversion failed with typeeror with path.includes is not a function.
+
+## Previous Releases
+Newer releases follow the [Keep a Changelog](https://keepachangelog.com) format.
 #### v1.7.1 (March 02, 2023)
 * Improve performance by removing unnecessary deep copying of objects
 
@@ -31,3 +53,7 @@
 #### v1.1.0 (April 18, 2022)
 * Stable release
 * Removed libxmljs from package.json
+
+[Unreleased]: https://github.com/postmanlabs/wsdl-to-postman/compare/1.8.0...HEAD
+
+[1.8.0]: https://github.com/postmanlabs/wsdl-to-postman/compare/v1.7.1...1.8.0

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nyc": "15.1.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "dependencies": {
     "ajv": "8.1.0",


### PR DESCRIPTION
Automated the Release management process for GitFlow process using steps mentioned in [this blog](https://blog.eizinger.io/12274/using-github-actions-and-gitflow-to-automate-your-release-process).

### Changes
- Unit tests: Now run on NodeJS versions 12, 16 and 18.
- Bumped up minimum NodeJS version to 12.
- For automation to work the `CHANGELOG.md` file has to match the [Keep A Changelog](https://keepachangelog.com) format. 
- `draft-new-release`: This action is triggered manually. It creates a release branch, bumps up versions in `package.json` and `package-lock.json` and automatically inserts the latest tag in `CHANGELOG.md` file. Then creates PRs against `main` and `development` branches. It requires write access to `contents` and `pull_requests` permissions, which has been done at the job level. This action can be triggered only by people with write access to the repository.
- `publish-new-release`: This action is triggered when PR from `release/` or `hotfix/` is merged into `main` branch. It will create a release and tag the commit in master. Additionally we can use this to automatically publish to NPM in the future, but because that action is irreversible, I've avoided it now and we can consider it in the future if required.

With the new changelog format, we now maintain an `Unreleased` section that will keep the list of all changes that are not yet released. The automation will insert the correct tag and create the links when drafting a new release. One advantage with this process is that we can keep adding to the `CHANGELOG.md` file in the PR to `development`.