### PR TITLE
Fixed issue where conversion was failing with type error.

### DIFF
--- a/lib/WsdlParserCommon.js
+++ b/lib/WsdlParserCommon.js
@@ -224,9 +224,9 @@ function getNamespaceByKey(parsedXml, key, wsdlRoot) {
  */
 function getTnsNamespace(parsedXml, defaultTnsKey, targetNamespace, allNameSpaces, wsdlRoot) {
   let tnsNamespace = getNamespaceByKey(parsedXml, defaultTnsKey, wsdlRoot);
-  if (!tnsNamespace.url) {
+  if (!_.get(tnsNamespace, 'url')) {
     tnsNamespace = allNameSpaces.find((ns) => {
-      return ns.url === targetNamespace.url && ns.key !== targetNamespace.key;
+      return ns.url === _.get(targetNamespace, 'url') && ns.key !== _.get(targetNamespace, 'key');
     });
   }
   return tnsNamespace;
@@ -394,7 +394,7 @@ function getSchemaNamespace(parsedXml, wsdlRoot, tnsNamespace) {
     localSchemaNamespaces;
   globalSchemaNamespace = getNamespaceByURL(parsedXml, SCHEMA_NS_URL, wsdlRoot);
   if (globalSchemaNamespace) {
-    globalSchemaNamespace.tnsDefinitionURL = tnsNamespace.url;
+    globalSchemaNamespace.tnsDefinitionURL = _.get(tnsNamespace, 'url');
   }
   localSchemaNamespaces = getSchemaNamespacesFromTypesDefinitions(parsedXml, wsdlRoot, principalPrefix,
     globalSchemaNamespace);


### PR DESCRIPTION
## Overview

This PR fixes the TypeError issue that was happening in case when no target namespace is defined.

## Fix

We'll be using lodash `_.get()` function to safely access this url. We've also made sure that not having this `url` doesn't affect further code as it's used for comparision further.