### PR TITLE
Fixed issue where max stack size was reached while generating collection from certain WSDL definition.

### DIFF
--- a/lib/utils/orderSchemasByDependency.js
+++ b/lib/utils/orderSchemasByDependency.js
@@ -126,7 +126,7 @@ function processSchema(schemaAndInformation, independent, attributePlaceHolder, 
         namespacesFromWSDL = getNotCommonNamespaces(allNameSpaces, importedName),
         isNotProcessedSchema = true,
         toProcess = schemasToOrderInformation.find((schema) => {
-          return schema.targetNamespace === importedName;
+          return typeof importedName !== 'undefined' && schema.targetNamespace === importedName;
         });
       schemaAndInformation.dependencies.add(
         getXMLAttributeByName(importElement, attributePlaceHolder, 'namespace'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "nyc": "15.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/test/data/schemaTest/noNamespaceImports.wsdl
+++ b/test/data/schemaTest/noNamespaceImports.wsdl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<wsdl:definitions
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+	<wsdl:types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+			<xsd:import
+				schemaLocation="Hello-request.xsd" />
+			<xsd:import
+				schemaLocation="Hello-response.xsd" />
+		</xsd:schema>
+
+	</wsdl:types>
+
+	<wsdl:message name="HelloQuoteRequest">
+		<wsdl:part name="request" element="HelloQuoteRequest" />
+	</wsdl:message>
+
+	<wsdl:message name="HelloQuoteResponse">
+		<wsdl:part name="response" element="HelloQuoteResponse" />
+	</wsdl:message>
+
+	<wsdl:portType name="HelloPayoutService">
+		<wsdl:operation name="submitHelloQuote">
+			<wsdl:input message="HelloQuoteRequest"
+				name="HelloQuoteRequest" />
+			<wsdl:output message="HelloQuoteResponse"
+				name="HelloQuoteResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+	<wsdl:binding name="HelloPayoutServiceSoapBinding"
+		type="HelloPayoutService">
+		<soap:binding style="document"
+			transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="submitHelloQuote">
+			<soap:operation soapAction="" />
+			<wsdl:input name="HelloQuoteRequest">
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output name="HelloQuoteResponse">
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+
+	<wsdl:service name="PayoutHelloQuoteService">
+		<wsdl:port binding="HelloPayoutServiceSoapBinding"
+			name="HelloPayout">
+			<soap:address location="https://hello-pay.com/payout" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
## Overview

This PR fixes issue where if WSDL definition had schema imports/includes without no namespace then conversion was failing with error `RangeError: Maximum call stack size exceeded`.

## RCA

Issue was happening due to improper checking of import elements. We were always expecting import element's namespace but in case not present `toProcess` gets resolved correctly with any namespace without namespace defined as there's no check for `importedName` to be defined.

## Fix

We'll also start checking that import element name should not be `undefined` while evaluating `toProcess`.