### PR TITLE
Added support for element and attribute prefixes for qualified schema types and elements.

### DIFF
--- a/lib/TransactionValidator.js
+++ b/lib/TransactionValidator.js
@@ -239,12 +239,12 @@ class TransactionValidator {
         let parsedXmlMessage = xmlParser.parseToObject(response.body),
           info = this.getItemRequestProcessedInfo(response, parsedXmlMessage, operationFromWSDL),
           operationOutput = operationFromWSDL.output.find((currentOutput) => {
-            return currentOutput.name === info.name;
+            return currentOutput.name === info.name || `${currentOutput.nsPrefix}:${currentOutput.name}` === info.name;
           });
 
         if (!operationOutput) {
           operationOutput = operationFromWSDL.fault.find((currentFault) => {
-            return currentFault.name === info.name;
+            return currentFault.name === info.name || `${currentFault.nsPrefix}:${currentFault.name}` === info.name;
           });
         }
         bodyMismatches = this.validateBody(response.body, wsdlObject, operationFromWSDL, true,

--- a/lib/utils/SOAPBody.js
+++ b/lib/utils/SOAPBody.js
@@ -71,19 +71,21 @@ class SOAPBody {
   processChildren(currentMessageParameter, messageJSObject, visitedElements, messageParametersQueue,
     createdJavascriptObjectQueue) {
     for (let childrenIndex = 0; childrenIndex < currentMessageParameter.children.length; childrenIndex++) {
-      let elementChild = currentMessageParameter.children[childrenIndex];
+      let elementChild = currentMessageParameter.children[childrenIndex],
+        elementChildName = this.generatePrefixedElementName(elementChild);
+
       if (elementChild.isComplex) {
-        this.assignPropertyValue(messageJSObject, elementChild.name, {});
+        this.assignPropertyValue(messageJSObject, elementChildName, {});
       }
       else if (elementChild.type === ERROR_ELEMENT_IDENTIFIER) {
-        this.assignPropertyValue(messageJSObject, elementChild.name, 'The element or type could not be found');
+        this.assignPropertyValue(messageJSObject, elementChildName, 'The element or type could not be found');
       }
       else {
-        this.assignPropertyValue(messageJSObject, elementChild.name, getValueExample(elementChild));
+        this.assignPropertyValue(messageJSObject, elementChildName, getValueExample(elementChild));
       }
       if (!visitedElements.has(elementChild)) {
         messageParametersQueue.push(elementChild);
-        createdJavascriptObjectQueue.push(messageJSObject[elementChild.name]);
+        createdJavascriptObjectQueue.push(messageJSObject[elementChildName]);
         visitedElements.add(elementChild);
       }
     }
@@ -98,23 +100,27 @@ class SOAPBody {
    * @returns {object} createdJSOBjectReference updated
    */
   processMessageParent(messageParent, messageJSObject, createdJSOBjectReference, visitedElements) {
+    const messageParentName = this.generatePrefixedElementName(messageParent),
+      tnsKey = `${this.parserAttributePlaceHolder}xmlns` +
+        (messageParent.attributeFormDefault && messageParent.nsPrefix ? `:${messageParent.nsPrefix}` : '');
+
     if (messageParent.isComplex) {
-      messageJSObject[messageParent.name] = {};
-      createdJSOBjectReference = messageJSObject[messageParent.name];
+      messageJSObject[messageParentName] = {};
+      createdJSOBjectReference = messageJSObject[messageParentName];
       if (messageParent.namespace) {
-        messageJSObject[messageParent.name][`${this.parserAttributePlaceHolder}xmlns`] = messageParent.namespace;
+        messageJSObject[messageParentName][tnsKey] = messageParent.namespace;
       }
     }
     else if (messageParent.type === ERROR_ELEMENT_IDENTIFIER) {
       messageJSObject[messageParent.name] = 'The element or type could not be found';
     }
     else if (messageParent.namespace && messageParent.namespace !== '') {
-      messageJSObject[messageParent.name] = {};
-      messageJSObject[messageParent.name]['#text'] = getValueExample(messageParent);
-      messageJSObject[messageParent.name][`${this.parserAttributePlaceHolder}xmlns`] = messageParent.namespace;
+      messageJSObject[messageParentName] = {};
+      messageJSObject[messageParentName]['#text'] = getValueExample(messageParent);
+      messageJSObject[messageParentName][tnsKey] = messageParent.namespace;
     }
     else {
-      messageJSObject[messageParent.name] = getValueExample(messageParent);
+      messageJSObject[messageParentName] = getValueExample(messageParent);
     }
 
     visitedElements.add(messageParent);
@@ -140,6 +146,37 @@ class SOAPBody {
     if (jObj && typeof jObj === 'object') {
       jObj[fixedAttributeName] = value;
     }
+  }
+
+  /**
+   * Generates element name with prefix based on `attributeFormDefault` and `elementFormDefault` attributes
+   * for the provided element.
+   * `attributeFormDefault` and `elementFormDefault` are inherited from the parent schema of corresponding element
+   *
+   * @param {object} element WSDL element from which the name is to be generated
+   * @returns {string} Generated element name with prefix
+   */
+  generatePrefixedElementName (element) {
+    let elementName = element.name,
+      prefixedElementName = elementName;
+
+    if (typeof elementName !== 'string') {
+      return '';
+    }
+
+    if (elementName.startsWith(element.nsPrefix + ':') || elementName.startsWith('@' + element.nsPrefix + ':') ||
+      !element.nsPrefix) {
+      return elementName;
+    }
+
+    if (elementName.startsWith('@') && element.attributeFormDefault) {
+      prefixedElementName = '@' + element.nsPrefix + ':' + elementName.slice(1);
+    }
+    else if (!elementName.startsWith('@') && element.elementFormDefault) {
+      prefixedElementName = element.nsPrefix + ':' + elementName;
+    }
+
+    return prefixedElementName;
   }
 
 }

--- a/lib/utils/SOAPBody.js
+++ b/lib/utils/SOAPBody.js
@@ -2,6 +2,7 @@ const
   {
     getValueExample
   } = require('./knownTypes'),
+  { generatePrefixedElementName } = require('./WSDLElementUtils'),
   {
     ELEMENT_NOT_FOUND
   } = require('../constants/messageConstants'),
@@ -72,7 +73,7 @@ class SOAPBody {
     createdJavascriptObjectQueue) {
     for (let childrenIndex = 0; childrenIndex < currentMessageParameter.children.length; childrenIndex++) {
       let elementChild = currentMessageParameter.children[childrenIndex],
-        elementChildName = this.generatePrefixedElementName(elementChild);
+        elementChildName = generatePrefixedElementName(elementChild);
 
       if (elementChild.isComplex) {
         this.assignPropertyValue(messageJSObject, elementChildName, {});
@@ -100,7 +101,7 @@ class SOAPBody {
    * @returns {object} createdJSOBjectReference updated
    */
   processMessageParent(messageParent, messageJSObject, createdJSOBjectReference, visitedElements) {
-    const messageParentName = this.generatePrefixedElementName(messageParent),
+    const messageParentName = generatePrefixedElementName(messageParent),
       tnsKey = `${this.parserAttributePlaceHolder}xmlns` +
         (messageParent.attributeFormDefault && messageParent.nsPrefix ? `:${messageParent.nsPrefix}` : '');
 
@@ -146,37 +147,6 @@ class SOAPBody {
     if (jObj && typeof jObj === 'object') {
       jObj[fixedAttributeName] = value;
     }
-  }
-
-  /**
-   * Generates element name with prefix based on `attributeFormDefault` and `elementFormDefault` attributes
-   * for the provided element.
-   * `attributeFormDefault` and `elementFormDefault` are inherited from the parent schema of corresponding element
-   *
-   * @param {object} element WSDL element from which the name is to be generated
-   * @returns {string} Generated element name with prefix
-   */
-  generatePrefixedElementName (element) {
-    let elementName = element.name,
-      prefixedElementName = elementName;
-
-    if (typeof elementName !== 'string') {
-      return '';
-    }
-
-    if (elementName.startsWith(element.nsPrefix + ':') || elementName.startsWith('@' + element.nsPrefix + ':') ||
-      !element.nsPrefix) {
-      return elementName;
-    }
-
-    if (elementName.startsWith('@') && element.attributeFormDefault) {
-      prefixedElementName = '@' + element.nsPrefix + ':' + elementName.slice(1);
-    }
-    else if (!elementName.startsWith('@') && element.elementFormDefault) {
-      prefixedElementName = element.nsPrefix + ':' + elementName;
-    }
-
-    return prefixedElementName;
   }
 
 }

--- a/lib/utils/SchemaBuilderXSD.js
+++ b/lib/utils/SchemaBuilderXSD.js
@@ -61,6 +61,7 @@ const Parser = require('fast-xml-parser').j2xParser,
     newTagName: 'sequence'
   }],
   DEFINITIONS_FILTER = '#/definitions/',
+  PARSER_ATTRIBUTE_NAME_PLACE_HOLDER = '@_',
   {
     createErrorElement
   } = require('./WSDLElementUtils'),
@@ -564,7 +565,14 @@ class SchemaBuilderXSD {
       globalAttributes = jsonSchema.globalAttributes ?
         Object.keys(jsonSchema.globalAttributes) :
         [],
-      scTag = schemaTagInformation.foundSchemaTag;
+      scTag = schemaTagInformation.foundSchemaTag,
+      schemaAttributes = {
+        attributeFormDefault: _.toLower(_.get(scTag, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER +
+          'attributeFormDefault')) === 'qualified',
+        elementFormDefault: _.toLower(_.get(scTag, PARSER_ATTRIBUTE_NAME_PLACE_HOLDER +
+          'elementFormDefault')) === 'qualified',
+        nsPrefix: this.getNamespacePrefix(schemaTagInformation.tnsNamespace, targetNamespace)
+      };
 
     // set current tnsNamespace under this
     this.tnsNamespace = schemaTagInformation.tnsNamespace;
@@ -611,11 +619,12 @@ class SchemaBuilderXSD {
 
     if (jsonSchemaSimpleTypesFromCurrentTag && jsonSchemaSimpleTypesFromCurrentTag.length > 0) {
       this.processComplexOrSimpleTypesToElement(jsonSchemaSimpleTypesFromCurrentTag, targetNamespace,
-        simpleTypeElements);
+        simpleTypeElements, schemaAttributes);
     }
 
     if (jsonSchemaGroupsFromCurrentTag && jsonSchemaGroupsFromCurrentTag.length > 0) {
-      this.processComplexOrSimpleTypesToElement(jsonSchemaGroupsFromCurrentTag, targetNamespace, groupElements);
+      this.processComplexOrSimpleTypesToElement(jsonSchemaGroupsFromCurrentTag, targetNamespace, groupElements,
+        schemaAttributes);
     }
 
     previousPlusCurrentSimple = jsonSchemaSimpleTypesFromCurrentTag.concat(jsonSchemaSimpleTypesProcessed);
@@ -625,7 +634,7 @@ class SchemaBuilderXSD {
     if (jsonSchemaGlobalAttributesFromCurrentTag && jsonSchemaGlobalAttributesFromCurrentTag.length > 0) {
       this.processComplexOrSimpleTypesToElement(jsonSchemaGlobalAttributesFromCurrentTag,
         jsonSchemaClxTypesProcessed,
-        jsonSchemaSimpleTypesProcessed, targetNamespace, globalAttributesElements);
+        jsonSchemaSimpleTypesProcessed, targetNamespace, globalAttributesElements, schemaAttributes);
     }
 
     previousPlusCurrentSimple = previousPlusCurrentSimple.concat(jsonSchemaGlobalAttributesFromCurrentTag);
@@ -633,14 +642,14 @@ class SchemaBuilderXSD {
 
     if (jsonSchemaComplexTypesFromCurrentTag && jsonSchemaComplexTypesFromCurrentTag.length > 0) {
       this.processComplexOrSimpleTypesToElement(jsonSchemaComplexTypesFromCurrentTag,
-        targetNamespace, complexTypeElements);
+        targetNamespace, complexTypeElements, schemaAttributes);
     }
 
     previousPlusCurrentComplex = jsonSchemaComplexTypesFromCurrentTag.concat(jsonSchemaClxTypesProcessed);
 
     if (jsonSchemaElementsFromCurrentTag && jsonSchemaElementsFromCurrentTag.length > 0) {
       this.processElementsToWSDElements(jsonSchemaElementsFromCurrentTag, previousPlusCurrentComplex,
-        previousPlusCurrentSimple, targetNamespace, elements);
+        previousPlusCurrentSimple, targetNamespace, elements, schemaAttributes);
     }
     return {
       elements,
@@ -659,9 +668,11 @@ class SchemaBuilderXSD {
    * @param {object} simpleTypes the list of processed simple types
    * @param {object} targetNamespace the found namespace in wsdl
    * @param {string} elements the elements to fill in
+   * @param {object} schemaAttributes schema attributes corresponding to current elements
    * @returns {undefined} returns nothing
    */
-  processElementsToWSDElements(elementsFromWSDL, complexTypes, simpleTypes, targetNamespace, elements) {
+  processElementsToWSDElements(elementsFromWSDL, complexTypes, simpleTypes, targetNamespace, elements,
+    schemaAttributes = {}) {
     let sorted = sortElementsAccordingToDependencies(elementsFromWSDL);
     sorted.forEach((element) => {
       let wsdlElement = new Element(),
@@ -683,10 +694,33 @@ class SchemaBuilderXSD {
       wsdlElement.contentEncoding = element.contentEncoding;
       wsdlElement.pattern = element.pattern;
       wsdlElement.enum = element.enum;
+      wsdlElement.attributeFormDefault = schemaAttributes.attributeFormDefault;
+      wsdlElement.elementFormDefault = schemaAttributes.elementFormDefault;
+      wsdlElement.nsPrefix = schemaAttributes.nsPrefix;
 
       this.getChildren(element, wsdlElement, elements, targetNamespace);
       elements.push(wsdlElement);
     });
+  }
+
+  /**
+   * Provides mathcing namespace prefix for given URL
+   *
+   * @param {Array} namespaces - Namespaces defined for current schema
+   * @param {String} namespaceUrl - Namespace URL
+   * @returns {String} Namespace prefix matching with current namespace URL
+   */
+  getNamespacePrefix (namespaces, namespaceUrl) {
+    let nsPrefix = '';
+
+    _.forEach(namespaces, (ns) => {
+      if (_.get(ns, 'url') === namespaceUrl) {
+        (_.has(ns, 'key') && typeof ns.key === 'string') && (nsPrefix = ns.key);
+        return true;
+      }
+    });
+
+    return nsPrefix;
   }
 
   /**
@@ -704,9 +738,10 @@ class SchemaBuilderXSD {
    * @param {Array} origin the elements from the schema to traverse
    * @param {object} targetNamespace the found namespace in wsdl
    * @param {string} typeElements the elements to fill in
+   * @param {object} schemaAttributes schema attributes corresponding to current elements
    * @returns {undefined} returns nothing
    */
-  processComplexOrSimpleTypesToElement(origin, targetNamespace, typeElements) {
+  processComplexOrSimpleTypesToElement(origin, targetNamespace, typeElements, schemaAttributes = {}) {
     let sorted = sortElementsAccordingToDependencies(origin);
     sorted.forEach((element) => {
       let wsdlElement = new Element();
@@ -724,6 +759,9 @@ class SchemaBuilderXSD {
       wsdlElement.minLength = element.minLength;
       wsdlElement.pattern = element.pattern;
       wsdlElement.enum = element.enum;
+      wsdlElement.attributeFormDefault = schemaAttributes.attributeFormDefault;
+      wsdlElement.elementFormDefault = schemaAttributes.elementFormDefault;
+      wsdlElement.nsPrefix = schemaAttributes.nsPrefix;
 
       this.getChildren(element, wsdlElement, typeElements, targetNamespace);
       typeElements.push(wsdlElement);
@@ -936,7 +974,7 @@ class SchemaBuilderXSD {
               hasRef = properties[key] ? properties[key].$ref : undefined;
               type = oneOfOrAnyOf ? properties[key][oneOfOrAnyOf][0].type : properties[key].type;
               if (this.isScalarType(type, hasRef)) {
-                let element = this.getChildScalarType(key, properties, property, targetNamespace);
+                let element = this.getChildScalarType(key, properties, property, targetNamespace, wsdlElement);
                 children.push(element);
                 wsdlElement.children = children;
               }
@@ -988,9 +1026,10 @@ class SchemaBuilderXSD {
    * @param {object} properties object properties of the json schema
    * @param {object} property if the element has a named reference
    * @param {string} targetNamespace the target namespace of the element
+   * @param {object} parentWsdlElement parent wsdl element
    * @returns {WsdlElement} the created element
    */
-  getChildScalarType(key, properties, property, targetNamespace) {
+  getChildScalarType(key, properties, property, targetNamespace, parentWsdlElement) {
     let element = new Element(),
       propertiesObject = this.getTypeFromScalarType(properties[key]);
     element.name = key;
@@ -1007,6 +1046,11 @@ class SchemaBuilderXSD {
     element.minOccurs = this.getMinOccursOfElement(property, key);
     element.maxOccurs = this.getMaxOccursOfElement(property, key);
     element.namespace = targetNamespace;
+
+    // inherit schema attributes from parent wsdl element
+    element.attributeFormDefault = parentWsdlElement.attributeFormDefault;
+    element.elementFormDefault = parentWsdlElement.elementFormDefault;
+    element.nsPrefix = parentWsdlElement.nsPrefix;
 
     return element;
   }
@@ -1028,9 +1072,10 @@ class SchemaBuilderXSD {
    * @param {object} property if the element has a named reference
    * @param {Array} preprocessed preprocessed elements to look for
    * @param {string} targetNamespace the target namespace of the element
+   * @param {object} parentWsdlElement parent wsdl element
    * @returns {WsdlElement} the created element
    */
-  getChildElement(key, properties, property, preprocessed, targetNamespace) {
+  getChildElement(key, properties, property, preprocessed, targetNamespace, parentWsdlElement) {
     let element = new Element();
     element.name = key;
     element.type = properties[key].complexName;
@@ -1040,6 +1085,12 @@ class SchemaBuilderXSD {
     element.namespace = targetNamespace;
     element.children = [];
     element.isElement = true;
+
+    // inherit schema attributes from parent wsdl element
+    element.attributeFormDefault = parentWsdlElement.attributeFormDefault;
+    element.elementFormDefault = parentWsdlElement.elementFormDefault;
+    element.nsPrefix = parentWsdlElement.nsPrefix;
+
     if (preprocessed.children) {
       element.children = preprocessed.children.concat([]);
     }
@@ -1071,6 +1122,12 @@ class SchemaBuilderXSD {
         element.isComplex = true;
         element.minOccurs = this.getMinOccursOfElement(property, key);
         element.maxOccurs = this.getMaxOccursOfElement(property, key);
+
+        // inherit schema attributes from parent wsdl element
+        element.attributeFormDefault = wsdlElement.attributeFormDefault;
+        element.elementFormDefault = wsdlElement.elementFormDefault;
+        element.nsPrefix = wsdlElement.nsPrefix;
+
         wsdlElement.children.push(element);
         if (property.properties[key].properties) {
           this.getChildren(property.properties[key], element, processedElements,
@@ -1080,7 +1137,7 @@ class SchemaBuilderXSD {
       }
       else if (preprocessed.isElement) {
         element = this.getChildElement(key, properties, property, preprocessed,
-          targetNamespace);
+          targetNamespace, wsdlElement);
         wsdlElement.children.push(element);
         property.properties[key] = {};
       }

--- a/lib/utils/WSDLElementUtils.js
+++ b/lib/utils/WSDLElementUtils.js
@@ -39,8 +39,40 @@ function createEmptyElement(name) {
   return element;
 }
 
+/**
+ * Generates element name with prefix based on `attributeFormDefault` and `elementFormDefault` attributes
+ * for the provided element.
+ * `attributeFormDefault` and `elementFormDefault` are inherited from the parent schema of corresponding element
+ *
+ * @param {object} element WSDL element from which the name is to be generated
+ * @returns {string} Generated element name with prefix
+ */
+function generatePrefixedElementName (element) {
+  let elementName = element.name,
+    prefixedElementName = elementName;
+
+  if (typeof elementName !== 'string') {
+    return '';
+  }
+
+  if (elementName.startsWith(element.nsPrefix + ':') || elementName.startsWith('@' + element.nsPrefix + ':') ||
+    !element.nsPrefix) {
+    return elementName;
+  }
+
+  if (elementName.startsWith('@') && element.attributeFormDefault) {
+    prefixedElementName = '@' + element.nsPrefix + ':' + elementName.slice(1);
+  }
+  else if (!elementName.startsWith('@') && element.elementFormDefault) {
+    prefixedElementName = element.nsPrefix + ':' + elementName;
+  }
+
+  return prefixedElementName;
+}
+
 
 module.exports = {
   createErrorElement,
-  createEmptyElement
+  createEmptyElement,
+  generatePrefixedElementName
 };

--- a/lib/utils/messageWithSchemaValidation.js
+++ b/lib/utils/messageWithSchemaValidation.js
@@ -7,6 +7,7 @@ const { SOAPMessageHelper } = require('./SOAPMessageHelper'),
   { removeDoubleQuotes } = require('./../utils/textUtils'),
   { mergeSchemas } = require('./../utils/schemaMerger'),
   { XMLXSDValidator } = require('./../xsdValidation/XMLXSDValidator'),
+  { generatePrefixedElementName } = require('./WSDLElementUtils'),
   {
     HTTP_PROTOCOL
   } = require('./../constants/processConstants'),
@@ -79,14 +80,16 @@ function unwrapAndCleanBody(message, tagName) {
  * @returns {string} Unwrapped body message without attributes
  */
 function getBodyMessage(nodeElement, protocol, cleanBody = true) {
-  const soapMessageHelper = new SOAPMessageHelper();
+  const soapMessageHelper = new SOAPMessageHelper(),
+    elementName = generatePrefixedElementName(nodeElement);
+
   bodyMessage = soapMessageHelper.convertInputToMessage(nodeElement, [], protocol,
     new XMLParser());
   if (cleanBody) {
-    cleanBodyMessage = nodeElement ? unwrapAndCleanBody(bodyMessage, nodeElement.name) : '';
+    cleanBodyMessage = nodeElement ? unwrapAndCleanBody(bodyMessage, elementName) : '';
   }
   else {
-    cleanBodyMessage = nodeElement ? getMessagePayload(bodyMessage, nodeElement.name) : '';
+    cleanBodyMessage = nodeElement ? getMessagePayload(bodyMessage, elementName) : '';
   }
   return cleanBodyMessage;
 }

--- a/test/data/auth/SAMLToken/SAMLV11Token.wsdl
+++ b/test/data/auth/SAMLToken/SAMLV11Token.wsdl
@@ -18,7 +18,7 @@
         </sp:SupportingTokens>
     </wsp:Policy>
     <types>
-        <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+        <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
             <xs:element name="NumberToWords">
                 <xs:complexType>
                     <xs:sequence>

--- a/test/data/auth/SAMLToken/SenderVouchersOverSSL.wsdl
+++ b/test/data/auth/SAMLToken/SenderVouchersOverSSL.wsdl
@@ -43,7 +43,7 @@
 
     </wsp:Policy>
 <types>
-<xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+<xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
 <xs:element name="NumberToWords">
     <xs:complexType>
         <xs:sequence>

--- a/test/data/auth/usernameToken/NoPassword.wsdl
+++ b/test/data/auth/usernameToken/NoPassword.wsdl
@@ -17,7 +17,7 @@
     </sp:SupportingTokens>
 </wsp:Policy>
 <types>
-    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+    <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
         <xs:element name="NumberToWords">
             <xs:complexType>
                 <xs:sequence>

--- a/test/data/auth/usernameToken/NoSecurityBinding.wsdl
+++ b/test/data/auth/usernameToken/NoSecurityBinding.wsdl
@@ -13,7 +13,7 @@
     </sp:SupportingTokens>
   </wsp:Policy>
   <types>
-    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+    <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
       <xs:element name="NumberToWords">
         <xs:complexType>
           <xs:sequence>

--- a/test/data/auth/usernameToken/TimeStampNoncePwdHash.wsdl
+++ b/test/data/auth/usernameToken/TimeStampNoncePwdHash.wsdl
@@ -17,7 +17,7 @@
     </sp:SupportingTokens>
 </wsp:Policy>
 <types>
-    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+    <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
         <xs:element name="NumberToWords">
             <xs:complexType>
                 <xs:sequence>

--- a/test/data/auth/usernameToken/UsernameToken.wsdl
+++ b/test/data/auth/usernameToken/UsernameToken.wsdl
@@ -13,7 +13,7 @@
         </sp:SupportingTokens>
     </wsp:Policy>
     <types>
-        <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+        <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
             <xs:element name="NumberToWords">
                 <xs:complexType>
                     <xs:sequence>

--- a/test/data/validWSDLs11/2namespaceSameURL.wsdl
+++ b/test/data/validWSDLs11/2namespaceSameURL.wsdl
@@ -4,7 +4,7 @@
   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
   xmlns:tns="http://spring.io/guides/gs-producing-web-service" targetNamespace="http://spring.io/guides/gs-producing-web-service">
   <wsdl:types>
-    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://spring.io/guides/gs-producing-web-service">
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="unqualified" targetNamespace="http://spring.io/guides/gs-producing-web-service">
 
       <xs:element name="getCountryRequest">
         <xs:complexType>

--- a/test/data/validWSDLs11/2schemasValid.wsdl
+++ b/test/data/validWSDLs11/2schemasValid.wsdl
@@ -4,7 +4,7 @@
   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
   targetNamespace="http://account.marketplace.services.adyen.com">
   <wsdl:types>
-    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified" 
+    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="unqualified" 
       targetNamespace="http://account.marketplace.services.adyen.com">
       <xsd:import namespace="http://common.services.adyen.com" />
       <xsd:element name="AccountHolderDetails">
@@ -15,7 +15,7 @@
         	</xsd:complexType>
    	 </xsd:element>
     </xsd:schema>
-    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://common.services.adyen.com">
+    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="unqualified" targetNamespace="http://common.services.adyen.com">
       <xsd:complexType name="Address">
         <xsd:sequence>
           <xsd:element minOccurs="0" name="city" nillable="true" type="xsd:string" />

--- a/test/data/validWSDLs11/CalculatorChoice.wsdl
+++ b/test/data/validWSDLs11/CalculatorChoice.wsdl
@@ -8,7 +8,7 @@
     xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:element name="Add">
                 <s:complexType>
                     <s:choice>

--- a/test/data/validWSDLs11/ChoiceInProperties.wsdl
+++ b/test/data/validWSDLs11/ChoiceInProperties.wsdl
@@ -13,7 +13,7 @@
     The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.
   </wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
  
       <xsd:element name="Employee_Personal_Info_Get" type="wd:Employee_Personal_InfoType" /> 
       <xsd:element name="Employee_Personal_Info" type="wd:Employee_Personal_InfoType" />

--- a/test/data/validWSDLs11/InnerBindingNOPrefix.wsdl
+++ b/test/data/validWSDLs11/InnerBindingNOPrefix.wsdl
@@ -2,7 +2,7 @@
     xmlns="http://schemas.xmlsoap.org/wsdl/"
     xmlns:tns="urn:microsoft-dynamics-schemas/page/service">
     <types>
-        <xsd:schema elementFormDefault="qualified" targetNamespace="urn:microsoft-dynamics-schemas/page/service"
+        <xsd:schema elementFormDefault="unqualified" targetNamespace="urn:microsoft-dynamics-schemas/page/service"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
             <xsd:simpleType name="EnumerationValue">
                 <xsd:restriction base="xsd:string">

--- a/test/data/validWSDLs11/TexasGeocoderService_V04_01.wsdl
+++ b/test/data/validWSDLs11/TexasGeocoderService_V04_01.wsdl
@@ -8,7 +8,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="https://geoservices.tamu.edu/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="https://geoservices.tamu.edu/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="https://geoservices.tamu.edu/">
             <s:element name="GeocodeAddressParsed">
                 <s:complexType>
                     <s:sequence>

--- a/test/data/validWSDLs11/addressURIEspecialChars.wsdl
+++ b/test/data/validWSDLs11/addressURIEspecialChars.wsdl
@@ -8,7 +8,7 @@
     xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:element name="Add">
                 <s:complexType>
                     <s:sequence>

--- a/test/data/validWSDLs11/attributeIssue.wsdl
+++ b/test/data/validWSDLs11/attributeIssue.wsdl
@@ -8,7 +8,7 @@
     xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:attribute name="version" type="s:string" tns:fixed="v36.2" />
             <s:element name="Add" type="tns:AddEle" />
             <s:element name="AddResponse">

--- a/test/data/validWSDLs11/base64Encoding.wsdl
+++ b/test/data/validWSDLs11/base64Encoding.wsdl
@@ -13,7 +13,7 @@
     The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.
   </wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
     <xsd:element name="Contingent_Worker_Contract_Info" type="wd:Contingent_Worker_Contract_InfoType" />
 
     <xsd:complexType name="Contingent_Worker_Contract_InfoType">

--- a/test/data/validWSDLs11/calculator-soap11and12.wsdl
+++ b/test/data/validWSDLs11/calculator-soap11and12.wsdl
@@ -8,7 +8,7 @@
     xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:element name="Add">
                 <s:complexType>
                     <s:sequence>

--- a/test/data/validWSDLs11/complexReferenceBy2elements.wsdl
+++ b/test/data/validWSDLs11/complexReferenceBy2elements.wsdl
@@ -13,7 +13,7 @@
     The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.
   </wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
       <xsd:element name="Put_Location_Request" type="wd:Put_Location_RequestType" />
       <xsd:attribute name="version" type="xsd:string" wd:fixed="v36.2" />
       <xsd:complexType name="Put_Location_RequestType">

--- a/test/data/validWSDLs11/countryInformation.wsdl
+++ b/test/data/validWSDLs11/countryInformation.wsdl
@@ -4,7 +4,7 @@
     xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
     xmlns:tns="http://www.oorsprong.org/websamples.countryinfo" name="CountryInfoService" targetNamespace="http://www.oorsprong.org/websamples.countryinfo">
     <types>
-        <xs:schema elementFormDefault="qualified" targetNamespace="http://www.oorsprong.org/websamples.countryinfo">
+        <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.oorsprong.org/websamples.countryinfo">
             <xs:complexType name="tContinent">
                 <xs:sequence>
                     <xs:element name="sCode" type="xs:string" />

--- a/test/data/validWSDLs11/elementFormDefaultQualified.wsdl
+++ b/test/data/validWSDLs11/elementFormDefaultQualified.wsdl
@@ -1,0 +1,358 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:wd-wsdl="urn:com.workday/bsvc/Human_Resources" xmlns:wd="urn:com.workday/bsvc"
+    xmlns:nyw="urn:com.netyourwork/aod" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:soapbind="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:httpbind="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:mimebind="http://schemas.xmlsoap.org/wsdl/mime/" name="Human_Resources"
+    targetNamespace="urn:com.workday/bsvc/Human_Resources">
+    <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday
+        Human Capital Management Business Services data, including Employee, Contingent Worker and
+        Organization information. This Web Service can be used for integration with enterprise
+        systems including corporate directories, data analysis tools, email or other provisioning
+        sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
+    <wsdl:types>
+        <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="urn:com.workday/bsvc">
+            <xsd:element name="Workday_Common_Header" type="wd:Workday_Common_HeaderType" />
+            <xsd:element name="Put_Disability_Request" type="wd:Put_Disability_RequestType" />
+            <xsd:element name="Put_Disability_Response" type="wd:Put_Disability_ResponseType" />
+            <xsd:element name="Validation_Fault" type="wd:Validation_FaultType" />
+            <xsd:element name="Processing_Fault" type="wd:Processing_FaultType" />
+
+            <xsd:complexType name="Put_Disability_RequestType">
+                <xsd:annotation>
+                    <xsd:documentation>Request element for Put Disability</xsd:documentation>
+                    <xsd:appinfo><wd:Validation>
+                            <wd:Validation_Message>Disability, '[disability]', already exists.</wd:Validation_Message>
+                        </wd:Validation></xsd:appinfo>
+                </xsd:annotation>
+                <xsd:sequence>
+                    <xsd:element name="Disability_Reference" type="wd:DisabilityObjectType"
+                        minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>A unique identifier used to reference an Disability.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Disability_Data" type="wd:Disability_DataType">
+                        <xsd:annotation>
+                            <xsd:documentation>Encapsulating element containing all Disability data.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute name="Add_Only" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:documentation>Add Only Flag. Indicates that the service is an add only,
+                            not an update.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute ref="wd:version" />
+            </xsd:complexType>
+            <xsd:complexType name="Put_Disability_ResponseType">
+                <xsd:annotation>
+                    <xsd:documentation>Response element for the Put Disability operation.</xsd:documentation>
+                </xsd:annotation>
+                <xsd:sequence>
+                    <xsd:element name="Disability_Reference" type="wd:DisabilityObjectType"
+                        minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>A unique identifier used to reference an Disability.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute ref="wd:version" />
+            </xsd:complexType>
+            <xsd:complexType name="DisabilityObjectType">
+                <xsd:annotation wd:Is_Reference_ID="1" />
+                <xsd:sequence>
+                    <xsd:element name="ID" type="wd:DisabilityObjectIDType" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+                <xsd:attribute name="Descriptor" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>Display information used to describe an instance of an
+                            object. This 'optional' information is for outbound descriptive purposes
+                            only and is not processed on inbound Workday Web Services requests.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:complexType>
+            <xsd:complexType name="Disability_DataType">
+                <xsd:annotation>
+                    <xsd:documentation>Encapsulating element containing all Disability data.</xsd:documentation>
+                </xsd:annotation>
+                <xsd:sequence>
+                    <xsd:element name="ID" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>The ID for the Disability (Disability_ID).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>The name of the Disability.</xsd:documentation>
+                            <xsd:appinfo><wd:Validation>
+                                    <wd:Validation_Message>Name is required.</wd:Validation_Message>
+                                </wd:Validation></xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Applicable_Subjects_Reference"
+                        type="wd:Unique_IdentifierObjectType" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Applicable Subjects for the Disability. Only Worker
+                                and Dependent are enabled.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Code" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>The code for the Disability.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>The description for the Disability.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Location_Reference" type="wd:Location_ContextObjectType"
+                        minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>The country the Disability is for.</xsd:documentation>
+                            <xsd:appinfo><wd:Validation>
+                                    <wd:Validation_Message>Location (Country or Country Region) is
+                                required.</wd:Validation_Message>
+                                </wd:Validation></xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Inactive" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>If true, the Disability field is inactive. If false,
+                                the Disability field is active.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DisabilityObjectIDType">
+                <xsd:annotation>
+                    <xsd:documentation>Contains a unique identifier for an instance of an object.</xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleContent>
+                    <xsd:extension base="xsd:string">
+                        <xsd:attribute name="type" type="wd:DisabilityReferenceEnumeration"
+                            use="required">
+                            <xsd:annotation>
+                                <xsd:documentation>The unique identifier type. Each "ID" for an
+                                    instance of an object contains a type and a value. A single
+                                    instance of an object can have multiple "ID" but only a single
+                                    "ID" per "type". Some "types" require a reference to a parent
+                                    instance.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                    </xsd:extension>
+                </xsd:simpleContent>
+            </xsd:complexType>
+            <xsd:simpleType name="DisabilityReferenceEnumeration">
+                <xsd:restriction base="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo><wd:enumeration value="WID" /><wd:enumeration
+                                value="Disability_ID" /></xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="Unique_IdentifierObjectType">
+                <xsd:annotation wd:Is_Reference_ID="1" />
+                <xsd:sequence>
+                    <xsd:element name="ID" type="wd:Unique_IdentifierObjectIDType" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+                <xsd:attribute name="Descriptor" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>Display information used to describe an instance of an
+                            object. This 'optional' information is for outbound descriptive purposes
+                            only and is not processed on inbound Workday Web Services requests.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:complexType>
+            <xsd:complexType name="Unique_IdentifierObjectIDType">
+                <xsd:annotation>
+                    <xsd:documentation>Contains a unique identifier for an instance of an object.</xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleContent>
+                    <xsd:extension base="xsd:string">
+                        <xsd:attribute name="type" type="wd:Unique_IdentifierReferenceEnumeration"
+                            use="required">
+                            <xsd:annotation>
+                                <xsd:documentation>The unique identifier type. Each "ID" for an
+                                    instance of an object contains a type and a value. A single
+                                    instance of an object can have multiple "ID" but only a single
+                                    "ID" per "type". Some "types" require a reference to a parent
+                                    instance.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                    </xsd:extension>
+                </xsd:simpleContent>
+            </xsd:complexType>
+            <xsd:simpleType name="Unique_IdentifierReferenceEnumeration">
+                <xsd:restriction base="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo><wd:enumeration value="IID" /><wd:enumeration value="WID" /></xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="Location_ContextObjectType">
+                <xsd:annotation wd:Is_Reference_ID="1" />
+                <xsd:sequence>
+                    <xsd:element name="ID" type="wd:Location_ContextObjectIDType" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+                <xsd:attribute name="Descriptor" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>Display information used to describe an instance of an
+                            object. This 'optional' information is for outbound descriptive purposes
+                            only and is not processed on inbound Workday Web Services requests.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:complexType>
+            <xsd:complexType name="Location_ContextObjectIDType">
+                <xsd:annotation>
+                    <xsd:documentation>Contains a unique identifier for an instance of an object.</xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleContent>
+                    <xsd:extension base="xsd:string">
+                        <xsd:attribute name="type" type="wd:Location_ContextReferenceEnumeration"
+                            use="required">
+                            <xsd:annotation>
+                                <xsd:documentation>The unique identifier type. Each "ID" for an
+                                    instance of an object contains a type and a value. A single
+                                    instance of an object can have multiple "ID" but only a single
+                                    "ID" per "type". Some "types" require a reference to a parent
+                                    instance.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                        <xsd:attribute name="parent_id" type="xsd:string">
+                            <xsd:annotation>
+                                <xsd:documentation>For types that require a parent reference,
+                                    contains a unique identifier for an instance of a parent object.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                        <xsd:attribute name="parent_type">
+                            <xsd:annotation>
+                                <xsd:documentation>For types that require a parent reference, the
+                                    unique identifier type of a parent object.</xsd:documentation>
+                            </xsd:annotation>
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:string">
+                                    <xsd:annotation>
+                                        <xsd:appinfo><wd:enumeration value="WID" /><wd:enumeration
+                                                value="ISO_3166-1_Alpha-2_Code" /><wd:enumeration
+                                                value="ISO_3166-1_Alpha-3_Code" /><wd:enumeration
+                                                value="ISO_3166-1_Numeric-3_Code" /></xsd:appinfo>
+                                    </xsd:annotation>
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:attribute>
+                    </xsd:extension>
+                </xsd:simpleContent>
+            </xsd:complexType>
+            <xsd:simpleType name="Location_ContextReferenceEnumeration">
+                <xsd:restriction base="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo><wd:enumeration value="WID" /><wd:enumeration
+                                value="Country_Region_ID" /><wd:enumeration
+                                value="Country_Subregion_Code_In_Country" /><wd:enumeration
+                                value="Country_Subregion_Internal_ID" /><wd:enumeration
+                                value="ISO_3166-1_Alpha-2_Code" /><wd:enumeration
+                                value="ISO_3166-1_Alpha-3_Code" /><wd:enumeration
+                                value="ISO_3166-1_Numeric-3_Code" /><wd:enumeration
+                                value="ISO_3166-2_Code" /><wd:enumeration
+                                value="ISO_3166-2_Country-Region_Code" /></xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+            <xsd:complexType name="Validation_FaultType">
+                <xsd:sequence>
+                    <xsd:element name="Validation_Error" type="wd:Validation_ErrorType"
+                        minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="Processing_FaultType">
+                <xsd:sequence>
+                    <xsd:element name="Detail_Message" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="Validation_ErrorType">
+                <xsd:sequence>
+                    <xsd:element name="Message" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Detail_Message" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Xpath" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:attribute name="version" type="xsd:string" wd:fixed="v39.0" />
+        </xsd:schema>
+    </wsdl:types>
+
+
+    <wsdl:message name="Put_Disability_RequestInputMsg">
+        <wsdl:part name="body" element="wd:Put_Disability_Request" />
+    </wsdl:message>
+    <wsdl:message name="Put_Disability_ResponseOutputMsg">
+        <wsdl:part name="body" element="wd:Put_Disability_Response" />
+    </wsdl:message>
+    <wsdl:message name="Validation_FaultMsg">
+        <wsdl:part name="body" element="wd:Validation_Fault" />
+    </wsdl:message>
+    <wsdl:message name="Processing_FaultMsg">
+        <wsdl:part name="body" element="wd:Processing_Fault" />
+    </wsdl:message>
+    <wsdl:message name="Dissolve_Organization_StructureOutputMsg" />
+    <wsdl:message name="Update_Employee_Personal_InfoOutputMsg" />
+    <wsdl:message name="Update_Contingent_Worker_Personal_InfoOutputMsg" />
+    <wsdl:message name="Inactivate_OrganizationOutputMsg" />
+    <wsdl:message name="Update_Employee_ImageOutputMsg" />
+    <wsdl:message name="Update_Workday_AccountOutputMsg" />
+    <wsdl:message name="Add_Workday_AccountOutputMsg" />
+    <wsdl:message name="Add_Update_Company_Tax_IDOutputMsg" />
+    <wsdl:message name="Workday_Common_HeaderMsg">
+        <wsdl:part name="header" element="wd:Workday_Common_Header" />
+    </wsdl:message>
+    <wsdl:portType name="Human_ResourcesPort">
+        <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday
+            Human Capital Management Business Services data, including Employee, Contingent Worker
+            and Organization information. This Web Service can be used for integration with
+            enterprise systems including corporate directories, data analysis tools, email or other
+            provisioning sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
+        <wsdl:operation name="Put_Disability">
+            <wsdl:documentation>This operation adds or updates a Disability.<wd:contextualSecurity>
+                Yes</wd:contextualSecurity></wsdl:documentation>
+            <wsdl:input name="Put_DisabilityInput" message="wd-wsdl:Put_Disability_RequestInputMsg" />
+            <wsdl:output name="Put_DisabilityOutput"
+                message="wd-wsdl:Put_Disability_ResponseOutputMsg" />
+            <wsdl:fault name="Validation_Fault" message="wd-wsdl:Validation_FaultMsg" />
+            <wsdl:fault name="Processing_Fault" message="wd-wsdl:Processing_FaultMsg" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="Human_ResourcesBinding" type="wd-wsdl:Human_ResourcesPort">
+        <soapbind:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Put_Disability">
+            <soapbind:operation style="document" />
+            <wsdl:input name="Put_DisabilityInput">
+                <soapbind:body use="literal" />
+                <soapbind:header message="wd-wsdl:Workday_Common_HeaderMsg" part="header"
+                    use="literal" />
+            </wsdl:input>
+            <wsdl:output name="Put_DisabilityOutput">
+                <soapbind:body use="literal" />
+            </wsdl:output>
+            <wsdl:fault name="Processing_Fault">
+                <soapbind:fault name="Processing_Fault" use="literal" />
+            </wsdl:fault>
+            <wsdl:fault name="Validation_Fault">
+                <soapbind:fault name="Validation_Fault" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Human_ResourcesService">
+        <wsdl:port name="Human_Resources" binding="wd-wsdl:Human_ResourcesBinding">
+            <soapbind:address
+                location="https://wd3-impl-services1.workday.com/ccx/service/bmo/Human_Resources/v39.0" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/data/validWSDLs11/emptyInput.wsdl
+++ b/test/data/validWSDLs11/emptyInput.wsdl
@@ -8,7 +8,7 @@
     xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/" name="ISampleService">
     <wsdl:types>
-        <xsd:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <xsd:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <xsd:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" />
             <xsd:import namespace="http://schemas.datacontract.org/2004/07/System" />
             <xsd:element name="DoSomething">

--- a/test/data/validWSDLs11/emptyMessagesIssue.wsdl
+++ b/test/data/validWSDLs11/emptyMessagesIssue.wsdl
@@ -12,7 +12,7 @@
   targetNamespace="some/url/Human_Resources">
   <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="some/url">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="unqualified" targetNamespace="some/url">
       <xsd:element name="Organization_Structure_Dissolve" type="wd:Organization_Structure_DissolveType"/>
 
       <xsd:complexType name="Organization_Structure_DissolveType">

--- a/test/data/validWSDLs11/hrextract.wsdl
+++ b/test/data/validWSDLs11/hrextract.wsdl
@@ -13,7 +13,7 @@
     The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.
   </wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="unqualified" targetNamespace="urn:com.workday/bsvc">
       <xsd:element name="Put_Location_Request" type="wd:Put_Location_RequestType" />
       <xsd:attribute name="version" type="xsd:string" wd:fixed="v36.2" />
       <xsd:complexType name="Put_Location_RequestType">

--- a/test/data/validWSDLs11/loopRefElements.wsdl
+++ b/test/data/validWSDLs11/loopRefElements.wsdl
@@ -9,7 +9,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:element name="returnLiveDeedsSearchHttpGetIn">
                 <s:complexType>
                     <s:sequence>

--- a/test/data/validWSDLs11/loopRefGroupA-B-A.wsdl
+++ b/test/data/validWSDLs11/loopRefGroupA-B-A.wsdl
@@ -9,7 +9,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:group name="returnLiveDeedsSearchHttpGetInGroup">
                 <s:sequence>
                     <s:element minOccurs="0" maxOccurs="1" name="identifer" type="s:string"/>

--- a/test/data/validWSDLs11/loopRefGroupA-B-C-A.wsdl
+++ b/test/data/validWSDLs11/loopRefGroupA-B-C-A.wsdl
@@ -9,7 +9,7 @@
     xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:group name="A">
                 <s:sequence>
                     <s:element minOccurs="0" maxOccurs="1" name="idGroupA" type="s:string"/>

--- a/test/data/validWSDLs11/loopReferences.wsdl
+++ b/test/data/validWSDLs11/loopReferences.wsdl
@@ -9,7 +9,7 @@
   xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
   xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
   <wsdl:types>
-    <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+    <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
     <s:element name="returnLiveDeedsSearchHttpGetIn">
       <s:complexType>
         <s:sequence>

--- a/test/data/validWSDLs11/multipleSchemaUsed.wsdl
+++ b/test/data/validWSDLs11/multipleSchemaUsed.wsdl
@@ -8,7 +8,7 @@
     xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://tempuri.org/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
             <s:element name="Add">
                 <s:complexType>
                     <s:sequence>

--- a/test/data/validWSDLs11/namespaceIssue.wsdl
+++ b/test/data/validWSDLs11/namespaceIssue.wsdl
@@ -12,7 +12,7 @@
   targetNamespace="some/url/Human_Resources">
   <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="some/url">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="unqualified" targetNamespace="some/url">
       <xsd:element name="Business_Site_Find" type="wd:Business_Site_FindType"/>
       <xsd:element name="Validation_Fault" type="wd:Validation_FaultType"/>
       <xsd:element name="Processing_Fault" type="wd:Processing_FaultType"/>

--- a/test/data/validWSDLs11/noWSDLNamespace.wsdl
+++ b/test/data/validWSDLs11/noWSDLNamespace.wsdl
@@ -11,7 +11,7 @@
   targetNamespace="some/url/Human_Resources">
   <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="some/url">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="qualified" targetNamespace="some/url">
       <xsd:element name="Business_Site_Find" type="wd:Business_Site_FindType"/>
       <xsd:element name="Validation_Fault" type="wd:Validation_FaultType"/>
       <xsd:element name="Processing_Fault" type="wd:Processing_FaultType"/>

--- a/test/data/validWSDLs11/numberConvertion.wsdl
+++ b/test/data/validWSDLs11/numberConvertion.wsdl
@@ -4,7 +4,7 @@
   xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
   xmlns:tns="http://www.dataaccess.com/webservicesserver/" name="NumberConversion" targetNamespace="http://www.dataaccess.com/webservicesserver/">
   <types>
-    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+    <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
       <xs:element name="NumberToWords">
         <xs:complexType>
           <xs:sequence>

--- a/test/data/validWSDLs11/sampleService.wsdl
+++ b/test/data/validWSDLs11/sampleService.wsdl
@@ -9,7 +9,7 @@
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
     targetNamespace="http://tempuri.org/" name="ISampleService">
   <wsdl:types>
-      <xsd:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+      <xsd:schema elementFormDefault="unqualified" targetNamespace="http://tempuri.org/">
           <xsd:import namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays" />
           <xsd:import namespace="http://schemas.datacontract.org/2004/07/System" />
           <xsd:element name="Test">

--- a/test/data/validWSDLs11/temperatureConverter.wsdl
+++ b/test/data/validWSDLs11/temperatureConverter.wsdl
@@ -8,7 +8,7 @@
     xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="https://www.w3schools.com/xml/">
     <wsdl:types>
-        <s:schema elementFormDefault="qualified" targetNamespace="https://www.w3schools.com/xml/">
+        <s:schema elementFormDefault="unqualified" targetNamespace="https://www.w3schools.com/xml/">
             <s:element name="FahrenheitToCelsius">
                 <s:complexType>
                     <s:sequence>

--- a/test/data/validWSDLs11/textCasing.wsdl
+++ b/test/data/validWSDLs11/textCasing.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:tns="http://www.dataaccess.com/webservicesserver/" name="TextCasing" targetNamespace="http://www.dataaccess.com/webservicesserver/">
   <types>
-    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+    <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
       <xs:element name="TitleCaseWordsWithToken">
         <xs:complexType>
           <xs:sequence>

--- a/test/data/validWSDLs11/usernameToken.wsdl
+++ b/test/data/validWSDLs11/usernameToken.wsdl
@@ -13,7 +13,7 @@
         </sp:SupportingTokens>
     </wsp:Policy>
     <types>
-        <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+        <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
             <xs:element name="NumberToWords">
                 <xs:complexType>
                     <xs:sequence>

--- a/test/data/validWSDLs11/usernameTokenSSL.wsdl
+++ b/test/data/validWSDLs11/usernameTokenSSL.wsdl
@@ -28,7 +28,7 @@
         </sp:TransportBinding>
     </wsp:Policy>
     <types>
-        <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+        <xs:schema elementFormDefault="unqualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
             <xs:element name="NumberToWords">
                 <xs:complexType>
                     <xs:sequence>

--- a/test/data/validWSDLs11/wdAttribute.wsdl
+++ b/test/data/validWSDLs11/wdAttribute.wsdl
@@ -12,7 +12,7 @@
   targetNamespace="some/url/Human_Resources">
   <wsdl:documentation>The Human Resources Web Service contains operations that expose Workday Human Capital Management Business Services data, including Employee, Contingent Worker and Organization information. This Web Service can be used for integration with enterprise systems including corporate directories, data analysis tools, email or other provisioning sub-systems, or any other systems needing Worker and/or Organization data.</wsdl:documentation>
   <wsdl:types>
-    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="some/url">
+    <xsd:schema elementFormDefault="unqualified" attributeFormDefault="unqualified" targetNamespace="some/url">
       <xsd:attribute name="version" type="xsd:string" wd:fixed="v36.2" />
       <xsd:element name="Worker_Profile_Get" type="wd:Worker_Profile_GetType"/>
       <xsd:element name="Workday_Common_Header" type="wd:Workday_Common_HeaderType"/>

--- a/test/data/validWSDLs20/Axis2SchemaPositiveInteger.wsdl
+++ b/test/data/validWSDLs20/Axis2SchemaPositiveInteger.wsdl
@@ -10,7 +10,7 @@
     xmlns:ns1="http://org.apache.axis2/xsd" targetNamespace="http://axis2.org">
     <wsdl2:documentation> Please Type your service description here </wsdl2:documentation>
     <wsdl2:types>
-        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://axis2.org">
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="unqualified" targetNamespace="http://axis2.org">
              <xs:element name="hi">
                 <xs:complexType>
                     <xs:sequence>

--- a/test/data/validWSDLs20/Axis2WSD20.wsdl
+++ b/test/data/validWSDLs20/Axis2WSD20.wsdl
@@ -10,7 +10,7 @@
     xmlns:ns1="http://org.apache.axis2/xsd" targetNamespace="http://axis2.org">
     <wsdl2:documentation> Please Type your service description here </wsdl2:documentation>
     <wsdl2:types>
-        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://axis2.org">
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="unqualified" targetNamespace="http://axis2.org">
             <xs:element name="hi">
                 <xs:complexType>
                     <xs:sequence />

--- a/test/data/validWSDLs20/Axis2WSD20WithSecurity.wsdl
+++ b/test/data/validWSDLs20/Axis2WSD20WithSecurity.wsdl
@@ -19,7 +19,7 @@
       </sp:SupportingTokens>
     </wsp:Policy>
     <wsdl2:types>
-        <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://axis2.org">
+        <xs:schema attributeFormDefault="qualified" elementFormDefault="unqualified" targetNamespace="http://axis2.org">
             <xs:element name="hi">
                 <xs:complexType>
                     <xs:sequence />

--- a/test/unit/SOAPBody.test.js
+++ b/test/unit/SOAPBody.test.js
@@ -98,6 +98,101 @@ describe('SOAPBody create', function () {
       .to.equal('string');
   });
 
+  it('Should get a json object with proerties having namespace prefix if elementFormDefault is true', function () {
+    const bodyCreator = new SOAPBody(new XMLParser()),
+      grandChild1 = {
+        children: [],
+        name: 'id',
+        isComplex: false,
+        type: 'integer',
+        maximum: 2147483647,
+        minimum: -2147483648,
+        elementFormDefault: true,
+        attributeFormDefault: true,
+        nsPrefix: 'wssegc1'
+      },
+      grandChild2 = {
+        children: [],
+        name: 'name',
+        isComplex: false,
+        type: 'string',
+        elementFormDefault: false,
+        attributeFormDefault: true,
+        nsPrefix: 'wssegc2'
+      },
+      grandChild3 = {
+        children: [],
+        name: 'email',
+        isComplex: false,
+        type: 'string',
+        elementFormDefault: true,
+        attributeFormDefault: true,
+        nsPrefix: 'wssegc3'
+      },
+      grandChild4Attr = {
+        children: [],
+        name: '@admin',
+        isComplex: false,
+        type: 'string',
+        elementFormDefault: true,
+        attributeFormDefault: true,
+        nsPrefix: 'wd'
+      },
+      grandChild5Attr = {
+        children: [],
+        name: '@reserved',
+        isComplex: false,
+        type: 'string',
+        elementFormDefault: true,
+        attributeFormDefault: false,
+        nsPrefix: 'wd2'
+      },
+      child = {
+        children: [grandChild1, grandChild2, grandChild3, grandChild4Attr, grandChild5Attr],
+        name: 'inputModel',
+        isComplex: true,
+        type: 'MyCustomModel',
+        elementFormDefault: true,
+        attributeFormDefault: true,
+        nsPrefix: 'wssechild'
+      },
+      soapMessageParent = {
+        children: [child],
+        name: 'TestCustomModel',
+        isComplex: true,
+        type: 'complex',
+        namespace: 'http://www.dataaccess.com/webservicesserver/',
+        elementFormDefault: true,
+        attributeFormDefault: true,
+        nsPrefix: 'wsse'
+      },
+      jsonObjectMessage = bodyCreator.create(soapMessageParent);
+    expect(jsonObjectMessage).to.be.an('object');
+    expect(jsonObjectMessage).to.have.own.property('wsse:TestCustomModel');
+    expect(jsonObjectMessage['wsse:TestCustomModel'])
+      .to.have.own.property('wssechild:inputModel');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel'])
+      .to.have.own.property('wssegc1:id');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel'])
+      .to.have.own.property('name');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel'])
+      .to.have.own.property('wssegc3:email');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel'])
+      .to.have.own.property('@_wd:admin');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel'])
+      .to.have.own.property('@_reserved');
+    assert.isAtLeast(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel']['wssegc1:id'], -2147483648);
+    assert.isAtMost(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel']['wssegc1:id'], 2147483647);
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel'].name)
+      .to.equal('string');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel']['wssegc3:email'])
+      .to.equal('string');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel']['@_wd:admin'])
+      .to.equal('string');
+    expect(jsonObjectMessage['wsse:TestCustomModel']['wssechild:inputModel']['@_reserved'])
+      .to.equal('string');
+  });
+
   it('Should get an empty json object when null is sent', function () {
     const bodyCreator = new SOAPBody(new XMLParser()),
       jsonObjectMessage = bodyCreator.create(null);

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -108,10 +108,10 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
       expectedBodyRaw = '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n' +
         '<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n' +
         '  <soap:Body>\n' +
-        '    <tns:Add xmlns=\"http://tempuri.org/\" version=\"v36.2\">\n' +
-        '      <tns:intA>100</tns:intA>\n' +
-        '      <tns:intB>100</tns:intB>\n' +
-        '    </tns:Add>\n' +
+        '    <Add xmlns=\"http://tempuri.org/\" version=\"v36.2\">\n' +
+        '      <intA>100</intA>\n' +
+        '      <intB>100</intB>\n' +
+        '    </Add>\n' +
         '  </soap:Body>\n' +
         '</soap:Envelope>\n';
 

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -108,10 +108,10 @@ describe('SchemaPack convert unit test WSDL 1.1', function () {
       expectedBodyRaw = '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n' +
         '<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n' +
         '  <soap:Body>\n' +
-        '    <Add xmlns=\"http://tempuri.org/\" version=\"v36.2\">\n' +
-        '      <intA>100</intA>\n' +
-        '      <intB>100</intB>\n' +
-        '    </Add>\n' +
+        '    <tns:Add xmlns=\"http://tempuri.org/\" version=\"v36.2\">\n' +
+        '      <tns:intA>100</tns:intA>\n' +
+        '      <tns:intB>100</tns:intB>\n' +
+        '    </tns:Add>\n' +
         '  </soap:Body>\n' +
         '</soap:Envelope>\n';
 

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -333,6 +333,47 @@ describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
 
     });
   });
+
+  it('[Github #11768] - Should convert definition with elementFormDefault and attributeFormDefault ' +
+    'defined with prefix correctly', function() {
+    let fileContent = fs.readFileSync(validWSDLs + '/elementFormDefaultQualified.wsdl', 'utf8');
+    const schemaPack = new SchemaPack({
+        data: fileContent,
+        type: 'string'
+      }, {}),
+      expectedOutput = `<?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <wd:Put_Disability_Request xmlns:wd="urn:com.workday/bsvc" wd:Add_Only="true" wd:version="v39.0">
+            <wd:Disability_Reference wd:Descriptor="string">
+              <wd:ID wd:type="string"/>
+            </wd:Disability_Reference>
+            <wd:Disability_Data>
+              <wd:ID>string</wd:ID>
+              <wd:Name>string</wd:Name>
+              <wd:Applicable_Subjects_Reference wd:Descriptor="string">
+                <wd:ID wd:type="string"/>
+              </wd:Applicable_Subjects_Reference>
+              <wd:Code>string</wd:Code>
+              <wd:Description>string</wd:Description>
+              <wd:Location_Reference wd:Descriptor="string">
+                <wd:ID wd:type="string" wd:parent_id="string" wd:parent_type="string"/>
+              </wd:Location_Reference>
+              <wd:Inactive>true</wd:Inactive>
+            </wd:Disability_Data>
+          </wd:Put_Disability_Request>
+        </soap:Body>
+      </soap:Envelope>`;
+
+    schemaPack.convert((error, result) => {
+      expect(error).to.be.null;
+      expect(result).to.be.an('object');
+      expect(result.output[0].data.item).to.have.lengthOf(1);
+      expect(result.output[0].data.item[0].name).to.eql('Put_Disability');
+      expect(removeLineBreakTabsSpaces(result.output[0].data.item[0].request.body.raw))
+        .to.equal(removeLineBreakTabsSpaces(expectedOutput));
+    });
+  });
 });
 
 describe('SchemaPack convert unit test WSDL 2.0', function () {


### PR DESCRIPTION
## Overview

Fixes https://github.com/postmanlabs/postman-app-support/issues/11768

This PR adds support for WSDL schema elements having attributes `elementFormDefault` and `attributeFormDefault`. These attributes defines the behavior of data to be sent for the corresponding payload. Specifically whether namespace prefix should be used in payload or not.

More on definition of these attributes [here](https://www.w3schools.com/xml/el_schema.asp).

## Solution

This solution comprises of 2 part as mentioned below.

1. Each parsed element from definition will also now add support for 3 properties namely `elementFormDefault`, `attributeFormDefault`, and `nsPrefix`.
2. While generating the corresponding Payload, we'll use properties with prefix values depending upon `elementFormDefault` and `attributeFormDefault`.

## Tests

As many of definitions were using `elementFormDefault=qualified` without correct context on it, we've made change to this to  `elementFormDefault=unqualified` to fix existing tests. Tests specific to this feature is added separately rather than fixing all hardcoded bodies.