### PR TITLE
Upgraded libxmljs2 module to v0.32.0 to support arm64 binaries.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "clone": "2.1.2",
         "commander": "8.2.0",
         "fast-xml-parser": "3.21.1",
-        "libxmljs2": "0.30.1",
+        "libxmljs2": "0.32.0",
         "node-fetch": "2.6.5",
         "path-browserify": "1.0.1",
         "postman-collection": "3.6.9",
@@ -2439,17 +2439,17 @@
       }
     },
     "node_modules/libxmljs2": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.30.1.tgz",
-      "integrity": "sha512-Upgf6LnbDZV8oYrG2cONazKjnUPV2v8TbAKP951flkCsyyrEuMYBe8IgYtrcm5bXFOmQnKsbFeZwMwVvVNZLpg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
       "hasInstallScript": true,
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.9",
+        "@mapbox/node-pre-gyp": "^1.0.10",
         "bindings": "~1.5.0",
-        "nan": "~2.15.0"
+        "nan": "~2.17.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/liquid-json": {
@@ -2761,9 +2761,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/nanoid": {
       "version": "3.1.12",
@@ -6253,13 +6253,13 @@
       }
     },
     "libxmljs2": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.30.1.tgz",
-      "integrity": "sha512-Upgf6LnbDZV8oYrG2cONazKjnUPV2v8TbAKP951flkCsyyrEuMYBe8IgYtrcm5bXFOmQnKsbFeZwMwVvVNZLpg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.32.0.tgz",
+      "integrity": "sha512-DuvKfSQZeUzw0A4UWZXfcBpr3VqlcJY1b3aw99PxTiX3T5t1rEO4gSpobNrP9S74LIhyDKaAs/lphuErV+n+7w==",
       "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.9",
+        "@mapbox/node-pre-gyp": "^1.0.10",
         "bindings": "~1.5.0",
-        "nan": "~2.15.0"
+        "nan": "~2.17.0"
       }
     },
     "liquid-json": {
@@ -6488,9 +6488,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "nanoid": {
       "version": "3.1.12",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "clone": "2.1.2",
     "commander": "8.2.0",
     "fast-xml-parser": "3.21.1",
-    "libxmljs2": "0.30.1",
+    "libxmljs2": "0.32.0",
     "node-fetch": "2.6.5",
     "path-browserify": "1.0.1",
     "postman-collection": "3.6.9",


### PR DESCRIPTION
## Overview

This PR upgrades `libxmljs2` library to v0.32.0 to support arm64 binaries as well at build times.