### PR TITLE
Update direct access to constructor prototype props to class props.

### DIFF
--- a/lib/security/schemas/inputs/tokens/SAMLTokenInput.js
+++ b/lib/security/schemas/inputs/tokens/SAMLTokenInput.js
@@ -1,5 +1,6 @@
 class SAMLTokenInput {
   constructor() {
+    this.constructor_name = 'SAMLTokenInput';
     this.includeToken = '';
     this.issuerInfo = '';
     this.claims = '';

--- a/lib/security/schemas/inputs/tokens/UsernameTokenInput.js
+++ b/lib/security/schemas/inputs/tokens/UsernameTokenInput.js
@@ -1,5 +1,6 @@
 class UsernameTokenInput {
   constructor() {
+    this.constructor_name = 'UsernameTokenInput';
     this.includeToken = '';
     this.issuerInfo = '';
     this.claims = '';

--- a/lib/security/schemas/inputs/transport/TransportBindingInput.js
+++ b/lib/security/schemas/inputs/transport/TransportBindingInput.js
@@ -1,5 +1,6 @@
 class TransportBindingInput {
   constructor() {
+    this.constructor_name = 'TransportBindingInput';
     this.transportToken = '';
     this.algorithmSuite = '';
     this.layout = '';

--- a/lib/utils/SOAPHeader.js
+++ b/lib/utils/SOAPHeader.js
@@ -158,7 +158,7 @@ class SOAPHeader {
       'TransportBindingInput': this.processSSLTransport,
       'SAMLTokenInput': this.processSAMLToken
     };
-    return handlers[element.constructor.name];
+    return handlers[element.constructor_name];
   }
 
   /**


### PR DESCRIPTION
## Description

This PR updates direct consumption of constructor prototype properties. We're now defining class level props of the constructor name instead of direct constructor prototype prop.

Above change is done to make sure that module bundle modification doesn't affect functionality of this module.