### PR TITLE
Fixed an issue where mergeAndValidate() threw error for files not in UTF-8 encoding.

### DIFF
--- a/lib/XMLParser.js
+++ b/lib/XMLParser.js
@@ -73,7 +73,14 @@ class XMLParser {
     if (!xmlDocumentContent) {
       return '';
     }
-    return fastXMLParser.parse(fixComments(xmlDocumentContent), optionsForFastXMLParser);
+
+    try {
+      return fastXMLParser.parse(fixComments(xmlDocumentContent), optionsForFastXMLParser);
+    }
+    catch (_e) {
+      // ignore errors while parsing data
+      return '';
+    }
   }
 
   /**

--- a/test/unit/XMLParser.test.js
+++ b/test/unit/XMLParser.test.js
@@ -204,3 +204,40 @@ describe('XMLparser parseObjectToXML', function () {
   });
 
 });
+
+describe('XMLParser safeParseToObject', function () {
+  const xmlParser = new XMLParser({});
+
+  it('should return an empty string when input is an empty file', function () {
+    let parsed = xmlParser.safeParseToObject('');
+    expect(parsed).to.equal('');
+  });
+
+  it('should return an empty string when input is null', function () {
+    let parsed = xmlParser.safeParseToObject(null);
+    expect(parsed).to.equal('');
+  });
+
+  it('should return an empty string when input is undefined', function () {
+    let parsed = xmlParser.safeParseToObject(undefined);
+    expect(parsed).to.equal('');
+  });
+
+  it('should return an object when input is valid XML', function () {
+    const validXML = `<note>
+                        <to>User</to>
+                        <from>Library</from>
+                        <heading>Reminder</heading>
+                        <body>Hello</body>
+                      </note>`;
+    let parsed = xmlParser.safeParseToObject(validXML);
+    expect(parsed).to.be.an('object');
+    expect(parsed).to.have.own.property('note');
+  });
+
+  it('should return an empty string when fast-zml-parser fails to parse data', function () {
+    const invalidXML = '€¯!¢s1≤TO¿˛•LH¥Ò‘⁄∞E»ËòÅ¶Tìæv◊';
+    let parsed = xmlParser.safeParseToObject(invalidXML);
+    expect(parsed).to.equal('');
+  });
+});


### PR DESCRIPTION
## Description

This PR fixes an issue where mergeAndValidate() API throw error for any files in input that contains data not in UTF-8 encoding. Since, for folder import, files can be in such format often time the conversion ended in error.

Issue was with the `fast-xml-parser` module. It throws error while parsing files that are not in UTF-8 format. With this PR, we'll ignore such errors and simply report content of such file as empty string for safeParseToObject() function.

We've also added corresponding tests to make sure intended functionality works as expected.