### PR TITLE
Feature/trust 1965 soap wsdl import fix

### DIFF
--- a/lib/utils/SOAPBody.js
+++ b/lib/utils/SOAPBody.js
@@ -107,8 +107,9 @@ class SOAPBody {
    */
   processMessageParent(messageParent, messageJSObject, createdJSOBjectReference, visitedElements) {
     const messageParentName = generatePrefixedElementName(messageParent),
+      needsNsDeclaration = messageParent.nsPrefix && messageParentName.startsWith(messageParent.nsPrefix + ':'),
       tnsKey = `${this.parserAttributePlaceHolder}xmlns` +
-        (messageParent.nsPrefix ? `:${messageParent.nsPrefix}` : '');
+        (needsNsDeclaration ? `:${messageParent.nsPrefix}` : '');
 
     if (messageParent.isComplex) {
       messageJSObject[messageParentName] = {};

--- a/lib/utils/SOAPBody.js
+++ b/lib/utils/SOAPBody.js
@@ -108,7 +108,7 @@ class SOAPBody {
   processMessageParent(messageParent, messageJSObject, createdJSOBjectReference, visitedElements) {
     const messageParentName = generatePrefixedElementName(messageParent),
       tnsKey = `${this.parserAttributePlaceHolder}xmlns` +
-        (messageParent.attributeFormDefault && messageParent.nsPrefix ? `:${messageParent.nsPrefix}` : '');
+        (messageParent.nsPrefix ? `:${messageParent.nsPrefix}` : '');
 
     if (messageParent.isComplex) {
       messageJSObject[messageParentName] = {};

--- a/test/unit/SchemaPack.test.js
+++ b/test/unit/SchemaPack.test.js
@@ -389,13 +389,13 @@ describe('SchemaPack convert unit test WSDL 1.1 with options', function () {
       expectedOutput = `<?xml version=\"1.0\" encoding=\"utf-8\"?>
       <soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">
         <soap:Header>
-          <tns:AuthHeader xmlns=\"http://localhost/App.asmx\" CultureName=\"string\">
+          <tns:AuthHeader xmlns:tns=\"http://localhost/App.asmx\" CultureName=\"string\">
             <tns:UserName>string</tns:UserName>
             <tns:Password>string</tns:Password>
           </tns:AuthHeader>
         </soap:Header>
         <soap:Body>
-          <tns:ChangePassword xmlns=\"http://localhost/App.asmx\">
+          <tns:ChangePassword xmlns:tns=\"http://localhost/App.asmx\">
             <tns:userName>string</tns:userName>
             <tns:password>string</tns:password>
             <tns:oldPassword>string</tns:oldPassword>


### PR DESCRIPTION
## Description

The PR contains the changes for the fix related to the issue mentioned in this CUE ticket: https://postmanlabs.atlassian.net/browse/CUE-6040

Basically we were creating the elements with tns: prefix but did not define the attribute correctly. Hence the request was giving 500.

We basically had the condition to add the tns prefix only if the attributeFormDefault property was true which shouldn't be the case always.

In the new logic, instead of relying on the attributeFormDefault check, we check if the element name contains the tns: prefix. If yes, in that case the xmlns:tns attribute will be needed. 

Steps to reproduce are mentioned here: https://github.com/postmanlabs/postman-app-support/issues/13300


## How to test this ticket

- Added any relevant
- steps to test this work
- as a bullet point list

## Sample Input and Output (remove if not needed)

Provide sample `curl` request and its relevant `json` and other responses. You
can also include images that prove the functionality.

### Checklist:

- [ ] Checked all the config values
- [ ] Added relevant unit tests for my code
- [ ] Did not add relevant unit test for my code, by created {{ticket#}} to
      handle in the future
